### PR TITLE
Avoid circular lwip pcb list

### DIFF
--- a/lib/tunnel_tcp.c
+++ b/lib/tunnel_tcp.c
@@ -5,27 +5,6 @@
 #include "intercept.h"
 #include "ziti/ziti_log.h"
 
-#if 0
-#include <assert.h>
-#include <lwip/timeouts.h>
-
-static void check_tcp_dups(const char *m, void *n) {
-    struct tcp_pcb * visited[100];
-    int i = 0;
-    memset(visited, 0, sizeof(visited));
-
-    for (struct tcp_pcb *tpcb = tcp_active_pcbs; tpcb != NULL; tpcb = tpcb->next) {
-        for (int j = 0; j < i; j++) {
-            if (visited[j] == tpcb) {
-                ZITI_LOG(ERROR, "dup detected when adding %p", n);
-                assert(false);
-            }
-        }
-        visited[i++] = tpcb;
-    }
-}
-#endif
-
 #if _WIN32
 #define MIN(a,b) ((a)<(b) ? (a) : (b))
 #endif

--- a/lib/ziti_tunnel.c
+++ b/lib/ziti_tunnel.c
@@ -177,9 +177,11 @@ int ziti_tunneler_close(tunneler_io_context *tnlr_io_ctx) {
     switch ((*tnlr_io_ctx)->proto) {
         case tun_tcp:
             tunneler_tcp_close((*tnlr_io_ctx)->tcp);
+            (*tnlr_io_ctx)->tcp = NULL;
             break;
         case tun_udp:
             tunneler_udp_close((*tnlr_io_ctx)->udp.pcb);
+            (*tnlr_io_ctx)->udp.pcb = NULL;
             break;
         default:
             ZITI_LOG(ERROR, "unknown proto %d", (*tnlr_io_ctx)->proto);
@@ -272,7 +274,7 @@ static void run_packet_loop(uv_loop_t *loop, tunneler_context tnlr_ctx) {
     }
 
     uv_timer_init(loop, &tnlr_ctx->lwip_timer_req);
-    uv_timer_start(&tnlr_ctx->lwip_timer_req, check_lwip_timeouts, 0, 100);
+    uv_timer_start(&tnlr_ctx->lwip_timer_req, check_lwip_timeouts, 0, 10);
 }
 
 #define _str(x) #x

--- a/programs/ziti-edge-tunnel/dnsmasq_manager.c
+++ b/programs/ziti-edge-tunnel/dnsmasq_manager.c
@@ -37,6 +37,9 @@ static int apply_address(dns_manager *dns, const char *hostname, const char *ip)
     char entry[512];
     int c = snprintf(entry, sizeof(entry), "%s\t%s", ip, hostname);
     FILE *rec = fopen(fname, "wb");
+    if (rec == NULL) {
+        return 1;
+    }
     fwrite(entry, 1, c, rec);
     fflush(rec);
     fclose(rec);


### PR DESCRIPTION
bandaid to prevent double close