### PR TITLE
Kill active connections

### DIFF
--- a/include/ziti/ziti_tunnel.h
+++ b/include/ziti/ziti_tunnel.h
@@ -69,7 +69,7 @@ typedef struct hosted_service_ctx_s {
  * called when a client connection is intercepted.
  * implementations are expected to dial the service and return
  * context that will be passed to ziti_read/ziti_write */
-typedef void * (*ziti_sdk_dial_cb)(const intercept_ctx_t *intercept_ctx, tunneler_io_context tnlr_io_ctx);
+typedef void * (*ziti_sdk_dial_cb)(const intercept_ctx_t *intercept_ctx, struct io_ctx_s *io);
 typedef int (*ziti_sdk_close_cb)(void *ziti_io_ctx);
 typedef ssize_t (*ziti_sdk_write_cb)(const void *ziti_io_ctx, void *write_ctx, const void *data, size_t len);
 typedef void (*ziti_sdk_host_v1_cb)(void *ziti_ctx, uv_loop_t *loop, const char *service_name, const char *proto, const char *hostname, int port);

--- a/include/ziti/ziti_tunnel.h
+++ b/include/ziti/ziti_tunnel.h
@@ -25,6 +25,7 @@ limitations under the License.
 
 #include <stdbool.h>
 #include "uv.h"
+#include "uv_mbed/queue.h"
 #include "ziti/netif_driver.h"
 
 #ifdef __cplusplus
@@ -43,9 +44,16 @@ typedef struct intercept_ctx_s {
 } intercept_ctx_t;
 
 struct io_ctx_s {
-    tunneler_io_context * tnlr_io_ctx_p; // use pointer to allow tsdk and zsdk callbacks to see when context is nulled.
-    void *                ziti_io_ctx; // context specific to ziti SDK being used by the app.
+    tunneler_io_context   tnlr_io;
+    void *                ziti_io; // context specific to ziti SDK being used by the app.
+    const void *          ziti_ctx;
 };
+
+struct io_ctx_list_entry_s {
+    struct io_ctx_s *io;
+    SLIST_ENTRY(io_ctx_list_entry_s) entries;
+};
+SLIST_HEAD(io_ctx_list_s, io_ctx_list_entry_s);
 
 typedef struct hosted_service_ctx_s {
     char *       service_name;
@@ -90,7 +98,7 @@ extern int ziti_tunneler_host_v1(tunneler_context tnlr_ctx, const void *ziti_ctx
 
 extern void ziti_tunneler_stop_intercepting(tunneler_context tnlr_ctx, const char *service_id);
 
-extern void ziti_tunneler_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io_ctx, bool ok);
+extern void ziti_tunneler_dial_completed(struct io_ctx_s *io_context, bool ok);
 
 extern ssize_t ziti_tunneler_write(tunneler_io_context *tnlr_io_ctx, const void *data, size_t len);
 

--- a/include/ziti/ziti_tunnel_cbs.h
+++ b/include/ziti/ziti_tunnel_cbs.h
@@ -36,7 +36,7 @@ ssize_t ziti_sdk_c_write(const void *ziti_io_ctx, void *write_ctx, const void *d
  * return 0 if TX should still be open, 1 if both sides are closed */
 int ziti_sdk_c_close(void *io_ctx);
 
-void ziti_sdk_c_host_v1(ziti_context ziti_ctx, uv_loop_t *loop, const char *service_id, const char *proto, const char *hostname, int port);
+void ziti_sdk_c_host_v1(void *ziti_ctx, uv_loop_t *loop, const char *service_id, const char *proto, const char *hostname, int port);
 
 #ifdef __cplusplus
 }

--- a/include/ziti/ziti_tunnel_cbs.h
+++ b/include/ziti/ziti_tunnel_cbs.h
@@ -11,7 +11,6 @@ extern "C" {
 /** context passed through the tunneler SDK for network i/o */
 typedef struct ziti_io_ctx_s {
     ziti_connection      ziti_conn;
-    tunneler_io_context  tnlr_io_ctx;
     bool ziti_eof;
     bool tnlr_eof;
 } ziti_io_context;
@@ -28,7 +27,7 @@ struct hosted_io_ctx_s {
 };
 
 /** called by tunneler SDK after a client connection is intercepted */
-void *ziti_sdk_c_dial(const intercept_ctx_t *intercept_ctx, tunneler_io_context tnlr_io_ctx);
+void *ziti_sdk_c_dial(const intercept_ctx_t *intercept_ctx, struct io_ctx_s *io);
 
 /** called from tunneler SDK when intercepted client sends data */
 ssize_t ziti_sdk_c_write(const void *ziti_io_ctx, void *write_ctx, const void *data, size_t len);

--- a/lib/tunnel_tcp.c
+++ b/lib/tunnel_tcp.c
@@ -381,6 +381,7 @@ u8_t recv_tcp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_
         ZITI_LOG(ERROR, "failed to allocate tunneler io context");
         goto done;
     }
+    io->ziti_ctx = intercept_ctx->ziti_ctx;
 
     ZITI_LOG(INFO, "intercepted connection to %s:%d from client %s for service %s (id %s)", ipaddr_ntoa(&dst), dst_p, io->tnlr_io->client,
              intercept_ctx->service_name, intercept_ctx->service_id);

--- a/lib/tunnel_tcp.h
+++ b/lib/tunnel_tcp.h
@@ -9,7 +9,7 @@
 
 extern ssize_t tunneler_tcp_write(struct tcp_pcb *pcb, const void *data, size_t len);
 
-extern void tunneler_tcp_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io_ctx, bool ok);
+extern void tunneler_tcp_dial_completed(struct io_ctx_s *io, bool ok);
 
 extern u8_t recv_tcp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *addr);
 
@@ -18,5 +18,7 @@ extern void tunneler_tcp_ack(struct write_ctx_s *write_ctx);
 extern int tunneler_tcp_close(struct tcp_pcb *pcb);
 
 extern int tunneler_tcp_close_write(struct tcp_pcb *pcb);
+
+extern struct io_ctx_list_s *tunneler_tcp_active(const void *ztx, const char *service_name);
 
 #endif //ZITI_TUNNELER_SDK_TUNNELER_TCP_H

--- a/lib/tunnel_udp.c
+++ b/lib/tunnel_udp.c
@@ -220,6 +220,7 @@ u8_t recv_udp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_
         udp_remove(npcb);
         pbuf_free(p);
         free_tunneler_io_context(&io->tnlr_io);
+        free(io);
         return 1;
     }
 

--- a/lib/tunnel_udp.c
+++ b/lib/tunnel_udp.c
@@ -5,15 +5,22 @@
 #include "intercept.h"
 #include "ziti/ziti_log.h"
 
-static void to_ziti(tunneler_io_context *tnlr_io_ctx_p, void *ziti_io_ctx, struct pbuf *p) {
+static void to_ziti(struct io_ctx_s *io, struct pbuf *p) {
+    if (io == NULL) {
+        ZITI_LOG(ERROR, "null io");
+        return;
+    }
+    if (io->tnlr_io == NULL || io->ziti_io == NULL) {
+        ZITI_LOG(ERROR, "null tnlr or ziti io");
+        return;
+    }
     struct pbuf *recv_data = NULL;
-    tunneler_io_context tnlr_io_ctx = *tnlr_io_ctx_p;
-    if (tnlr_io_ctx->udp.queued != NULL) {
+    if (io->tnlr_io->udp.queued != NULL) {
         if (p != NULL) {
-            pbuf_cat(tnlr_io_ctx->udp.queued, p);
+            pbuf_cat(io->tnlr_io->udp.queued, p);
         }
-        recv_data = tnlr_io_ctx->udp.queued;
-        tnlr_io_ctx->udp.queued = NULL;
+        recv_data = io->tnlr_io->udp.queued;
+        io->tnlr_io->udp.queued = NULL;
     } else {
         recv_data = p;
     }
@@ -25,12 +32,12 @@ static void to_ziti(tunneler_io_context *tnlr_io_ctx_p, void *ziti_io_ctx, struc
 
     do {
         ZITI_LOG(DEBUG, "writing %d bytes to ziti", recv_data->len);
-        ziti_sdk_write_cb zwrite = tnlr_io_ctx->tnlr_ctx->opts.ziti_write;
+        ziti_sdk_write_cb zwrite = io->tnlr_io->tnlr_ctx->opts.ziti_write;
         struct write_ctx_s *wr_ctx = calloc(1, sizeof(struct write_ctx_s));
         wr_ctx->pbuf = recv_data;
-        wr_ctx->udp = tnlr_io_ctx->udp.pcb;
+        wr_ctx->udp = io->tnlr_io->udp.pcb;
         wr_ctx->ack = tunneler_udp_ack;
-        ssize_t s = zwrite(ziti_io_ctx, wr_ctx, recv_data->payload, recv_data->len);
+        ssize_t s = zwrite(io->ziti_io, wr_ctx, recv_data->payload, recv_data->len);
         if (s < 0) {
             free(wr_ctx);
             pbuf_free(recv_data);
@@ -40,8 +47,17 @@ static void to_ziti(tunneler_io_context *tnlr_io_ctx_p, void *ziti_io_ctx, struc
 }
 
 /** called by lwip when a packet arrives from a connected client and the ziti service is not yet connected */
-void on_udp_client_data_enqueue(void *tnlr_io_context, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port) {
-    tunneler_io_context tnlr_io_ctx = tnlr_io_context;
+void on_udp_client_data_enqueue(void *io_context, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port) {
+    if (io_context == NULL) {
+        ZITI_LOG(DEBUG, "null io_context");
+        return;
+    }
+    struct io_ctx_s *io_ctx = io_context;
+    tunneler_io_context tnlr_io_ctx = io_ctx->tnlr_io;
+    if (tnlr_io_ctx == NULL) {
+        ZITI_LOG(INFO, "null tnlr_io_context");
+        return;
+    }
     if (tnlr_io_ctx->udp.queued == NULL) {
         tnlr_io_ctx->udp.queued = p;
     } else {
@@ -58,8 +74,7 @@ void on_udp_client_data(void *io_context, struct udp_pcb *pcb, struct pbuf *p, c
     }
     ZITI_LOG(VERBOSE, "%d bytes from %s:%d", p->len, ipaddr_ntoa(addr), port);
 
-    struct io_ctx_s *io_ctx = (struct io_ctx_s *) io_context;
-    to_ziti(io_ctx->tnlr_io_ctx_p, io_ctx->ziti_io_ctx, p);
+    to_ziti(io_context, p);
 }
 
 void tunneler_udp_ack(struct write_ctx_s *write_ctx) {
@@ -68,7 +83,11 @@ void tunneler_udp_ack(struct write_ctx_s *write_ctx) {
 
 int tunneler_udp_close(struct udp_pcb *pcb) {
     struct io_ctx_s *io_ctx = pcb->recv_arg;
-    tunneler_io_context tnlr_io_ctx = *io_ctx->tnlr_io_ctx_p;
+    tunneler_io_context tnlr_io_ctx = io_ctx->tnlr_io;
+    if (tnlr_io_ctx == NULL) {
+        ZITI_LOG(INFO, "null tnlr_io_ctx");
+        return 0;
+    }
     ZITI_LOG(INFO, "closing %s session", tnlr_io_ctx->service_name);
     if (pcb != NULL) {
         udp_remove(pcb);
@@ -76,19 +95,16 @@ int tunneler_udp_close(struct udp_pcb *pcb) {
     return 0;
 }
 
-void tunneler_udp_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io_ctx, bool ok) {
-    struct io_ctx_s *io_ctx = calloc(1, sizeof(struct io_ctx_s));
-    io_ctx->tnlr_io_ctx_p = tnlr_io_ctx;
-    io_ctx->ziti_io_ctx = ziti_io_ctx;
-    struct udp_pcb *pcb = (*tnlr_io_ctx)->udp.pcb;
+void tunneler_udp_dial_completed(struct io_ctx_s *io, bool ok) {
+    struct udp_pcb *pcb = io->tnlr_io->udp.pcb;
     /* change recv callback to send packets that arrive instead of queuing */
-    udp_recv(pcb, on_udp_client_data, io_ctx);
+    udp_recv(pcb, on_udp_client_data, io);
 
     /* send any data that was queued while waiting for the dial to complete */
     if (ok) {
-        to_ziti(tnlr_io_ctx, ziti_io_ctx, NULL);
+        to_ziti(io, NULL);
     } else {
-        ziti_tunneler_close(tnlr_io_ctx);
+        ziti_tunneler_close(&io->tnlr_io);
     }
 }
 
@@ -192,7 +208,12 @@ u8_t recv_udp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_
         return 1;
     }
 
-    udp_recv(npcb, on_udp_client_data_enqueue, ctx);
+    struct io_ctx_s *io_ctx = calloc(1, sizeof(struct io_ctx_s));
+    io_ctx->tnlr_io = ctx;
+    io_ctx->ziti_io = ziti_io_ctx;
+    io_ctx->ziti_ctx = intercept_ctx->ziti_ctx;
+
+    udp_recv(npcb, on_udp_client_data_enqueue, io_ctx);
     return 0; /* lwip will call on_udp_client_data_enqueue for this packet */
 }
 
@@ -208,4 +229,27 @@ ssize_t tunneler_udp_write(struct udp_pcb *pcb, const void *data, size_t len) {
         return -1;
     }
     return len;
+}
+
+struct io_ctx_list_s *tunneler_udp_active(const void *ztx, const char *service_name) {
+    struct io_ctx_list_s *l = calloc(1, sizeof(struct io_ctx_list_s));
+    SLIST_INIT(l);
+
+    for (struct udp_pcb *pcb = udp_pcbs; pcb != NULL; pcb = pcb->next) {
+        if (pcb->recv == on_udp_client_data) { // recv_arg contains io_context after dial completes.
+            struct io_ctx_s *io = pcb->recv_arg;
+            if (io != NULL) {
+                tunneler_io_context tnlr_io = io->tnlr_io;
+                if (tnlr_io != NULL) {
+                    if (strcmp(tnlr_io->service_name, service_name) == 0 && io->ziti_ctx == ztx) {
+                        struct io_ctx_list_entry_s *n = calloc(1, sizeof(struct io_ctx_list_entry_s));
+                        n->io = io;
+                        SLIST_INSERT_HEAD(l, n, entries);
+                    }
+                }
+            }
+        }
+    }
+
+    return l;
 }

--- a/lib/tunnel_udp.h
+++ b/lib/tunnel_udp.h
@@ -6,9 +6,11 @@
 #include "lwip/raw.h"
 
 extern ssize_t tunneler_udp_write(struct udp_pcb *pcb, const void *data, size_t len);
-extern void tunneler_udp_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io_ctx, bool ok);
+extern void tunneler_udp_dial_completed(struct io_ctx_s *io, bool ok);
 extern u8_t recv_udp(void *tnlr_ctx_arg, struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *addr);
 extern void tunneler_udp_ack(struct write_ctx_s *write_ctx);
 extern int tunneler_udp_close(struct udp_pcb *pcb);
+extern void tunneler_udp_kill_active(const void *ziti_ctx, const void *service_name);
+extern struct io_ctx_list_s *tunneler_udp_active(const void *ztx, const char *service_name);
 
 #endif //ZITI_TUNNELER_SDK_TUNNELER_UDP_H

--- a/lib/ziti_tunnel.c
+++ b/lib/ziti_tunnel.c
@@ -81,19 +81,26 @@ void free_tunneler_io_context(tunneler_io_context *tnlr_io_ctx) {
  * called by tunneler application when a service dial has completed
  * - let the client know that we have a connection (e.g. send SYN/ACK)
  */
-void ziti_tunneler_dial_completed(tunneler_io_context *tnlr_io_ctx, void *ziti_io_ctx, bool ok) {
+void ziti_tunneler_dial_completed(struct io_ctx_s *io, bool ok) {
+    if (io == NULL) {
+        ZITI_LOG(ERROR, "null io");
+        return;
+    }
+    if (io->ziti_io == NULL || io->tnlr_io == NULL) {
+        ZITI_LOG(ERROR, "null ziti_io or tnlr_io");
+    }
     const char *status = ok ? "succeeded" : "failed";
-    ZITI_LOG(INFO, "ziti dial %s: service=%s, client=%s", status, (*tnlr_io_ctx)->service_name, (*tnlr_io_ctx)->client);
+    ZITI_LOG(INFO, "ziti dial %s: service=%s, client=%s", status, io->tnlr_io->service_name, io->tnlr_io->client);
 
-    switch ((*tnlr_io_ctx)->proto) {
+    switch (io->tnlr_io->proto) {
         case tun_tcp:
-            tunneler_tcp_dial_completed(tnlr_io_ctx, ziti_io_ctx, ok);
+            tunneler_tcp_dial_completed(io, ok);
             break;
         case tun_udp:
-            tunneler_udp_dial_completed(tnlr_io_ctx, ziti_io_ctx, ok);
+            tunneler_udp_dial_completed(io, ok);
             break;
         default:
-            ZITI_LOG(ERROR, "unknown proto %d", (*tnlr_io_ctx)->proto);
+            ZITI_LOG(ERROR, "unknown proto %d", io->tnlr_io->proto);
             break;
     }
 }
@@ -134,8 +141,46 @@ int ziti_tunneler_intercept_v1(tunneler_context tnlr_ctx, const void *ziti_ctx, 
     return 0;
 }
 
+static void tunneler_kill_active(const void *ztx, const char *service_name) {
+    struct io_ctx_list_s *l;
+
+    l = tunneler_tcp_active(ztx, service_name);
+    while (!SLIST_EMPTY(l)) {
+        struct io_ctx_list_entry_s *n = SLIST_FIRST(l);
+        ziti_tunneler_close(&n->io->tnlr_io);
+        SLIST_REMOVE_HEAD(l, entries);
+        free(n);
+    }
+
+    // todo be selective about protocols when merging newer config types
+    l = tunneler_udp_active(ztx, service_name);
+}
+
 void ziti_tunneler_stop_intercepting(tunneler_context tnlr_ctx, const char *service_id) {
     ZITI_LOG(DEBUG, "removing intercept for service id %s", service_id);
+    struct intercept_s *intercept, *prev = NULL;
+    const void *ziti_ctx = NULL;
+    const char *service_name = NULL;
+
+    if (tnlr_ctx == NULL) {
+        ZITI_LOG(DEBUG, "null tnlr_ctx");
+        return;
+    }
+
+    // find the service name and ziti_context for this service id
+    for (intercept = tnlr_ctx->intercepts; intercept != NULL; intercept = intercept->next) {
+        if (strcmp(intercept->ctx.service_id, service_id) == 0) {
+            ziti_ctx = intercept->ctx.ziti_ctx;
+            service_name = intercept->ctx.service_name;
+            break;
+        }
+    }
+
+    // kill active connections
+    if (service_name != NULL && ziti_ctx != NULL) {
+        tunneler_kill_active(ziti_ctx, service_name);
+    }
+
     remove_intercept(tnlr_ctx, service_id);
 }
 

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -38,6 +38,7 @@ ssize_t on_ziti_data(ziti_connection conn, uint8_t *data, ssize_t len) {
     ZITI_LOG(TRACE, "got %zd bytes from ziti", len);
     if (io == NULL) {
         ZITI_LOG(WARN, "null io");
+        return UV_ECONNABORTED;
     }
     ziti_io_context *ziti_io_ctx = io->ziti_io;
     if (io->ziti_io == NULL || io->tnlr_io == NULL) {

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -393,7 +393,8 @@ static void hosted_listen_cb(ziti_connection serv, int status) {
 }
 
 /** called by the tunneler sdk when a hosted service becomes available */
-void ziti_sdk_c_host_v1(ziti_context ziti_ctx, uv_loop_t *loop, const char *service_name, const char *proto, const char *hostname, int port) {
+void ziti_sdk_c_host_v1(void *ztx, uv_loop_t *loop, const char *service_name, const char *proto, const char *hostname, int port) {
+    ziti_context ziti_ctx = ztx;
     if (service_name == NULL) {
         ZITI_LOG(ERROR, "null service_name");
         return;

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -316,11 +316,12 @@ static void on_hosted_tcp_server_connect_complete(uv_connect_t *c, int status) {
         ZITI_LOG(ERROR, "connect hosted service %s to %s:%s:%d failed: %s", io_ctx->service->service_name,
                  io_ctx->service->proto, io_ctx->service->hostname, io_ctx->service->port, uv_strerror(status));
         ziti_close(&io_ctx->client);
+        free(c);
         return;
     }
     ZITI_LOG(INFO, "connected to server for client %p: %p", c->handle->data, c);
-    free(c);
     ziti_accept(io_ctx->client, on_hosted_client_connect_complete, on_hosted_client_data);
+    free(c);
 }
 
 /** called by ziti sdk when a ziti endpoint (client) initiates connection to a hosted service */

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -271,7 +271,7 @@ static void on_hosted_udp_server_data(uv_udp_t* handle, ssize_t nread, const uv_
     struct hosted_io_ctx_s *io_ctx = handle->data;
     if (nread > 0) {
         ziti_write(io_ctx->client, buf->base, nread, on_hosted_ziti_write, buf->base);
-    } else if (addr == NULL) {
+    } else if (addr == NULL && nread != 0) {
         if (buf->base != NULL) {
             free(buf->base);
         }

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -285,6 +285,7 @@ static void on_hosted_client_connect_complete(ziti_connection clt, int err) {
     struct hosted_io_ctx_s *io_ctx = ziti_conn_data(clt);
     if (err == ZITI_OK) {
         ZITI_LOG(INFO, "client connected to hosted service %s", io_ctx->service->service_name);
+        uv_read_start((uv_stream_t *) &io_ctx->server.tcp, alloc_buffer, on_hosted_tcp_server_data);
     } else {
         ZITI_LOG(ERROR, "client failed to connect to hosted service %s: %s", io_ctx->service->service_name,
                  ziti_errorstr(err));
@@ -309,7 +310,6 @@ static void on_hosted_tcp_server_connect_complete(uv_connect_t *c, int status) {
         return;
     }
     ZITI_LOG(INFO, "connected to server for client %p: %p", c->handle->data, c);
-    uv_read_start((uv_stream_t *) &io_ctx->server.tcp, alloc_buffer, on_hosted_tcp_server_data);
     ziti_accept(io_ctx->client, on_hosted_client_connect_complete, on_hosted_client_data);
 }
 

--- a/lib/ziti_tunnel_priv.h
+++ b/lib/ziti_tunnel_priv.h
@@ -4,7 +4,7 @@
 #include "lwip/netif.h"
 
 typedef struct tunneler_ctx_s {
-    tunneler_sdk_options opts;
+    tunneler_sdk_options opts; // this must be first - it is accessed opaquely through tunneler_context*
     struct netif netif;
     struct raw_pcb *tcp;
     struct raw_pcb *udp;

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -27,16 +27,6 @@ static ziti_options OPTS = {
         .refresh_interval = 10, /* default refresh */
 };
 
-static tunneler_context my_tnlr_ctx;
-static ziti_context my_ziti_ctx;
-
-static void sigfn(int signo) {
-    if (signo == SIGUSR1) {
-        ziti_tunneler_stop_intercepting(my_tnlr_ctx, "VXFvlJ2GR");
-    }
-    ziti_tunneler_intercept_v1(my_tnlr_ctx, my_ziti_ctx, "VXFvlJ2GR", "lambda-caeli-sshd", "1.1.1.1", 22);
-}
-
 /** callback from ziti SDK when a new service becomes available to our identity */
 void on_service(ziti_context ziti_ctx, ziti_service *service, int status, void *tnlr_ctx) {
     if (status == ZITI_OK) {
@@ -80,7 +70,6 @@ static void on_ziti_init(ziti_context ziti_ctx, int status, void *init_ctx) {
         ZITI_LOG(ERROR, "failed to initialize ziti");
         exit(1);
     }
-    my_ziti_ctx = ziti_ctx;
 }
 
 extern dns_manager *get_dnsmasq_manager(const char* path);
@@ -124,8 +113,6 @@ static int run_tunnel(const char *ip_range, dns_manager *dns) {
         return 1;
     }
 
-    my_tnlr_ctx = tnlr_ctx;
-    signal(SIGUSR1, sigfn);
     if (uv_run(ziti_loop, UV_RUN_DEFAULT) != 0) {
         ZITI_LOG(ERROR, "failed to run event loop");
         exit(1);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -27,6 +27,16 @@ static ziti_options OPTS = {
         .refresh_interval = 10, /* default refresh */
 };
 
+static tunneler_context my_tnlr_ctx;
+static ziti_context my_ziti_ctx;
+
+static void sigfn(int signo) {
+    if (signo == SIGUSR1) {
+        ziti_tunneler_stop_intercepting(my_tnlr_ctx, "VXFvlJ2GR");
+    }
+    ziti_tunneler_intercept_v1(my_tnlr_ctx, my_ziti_ctx, "VXFvlJ2GR", "lambda-caeli-sshd", "1.1.1.1", 22);
+}
+
 /** callback from ziti SDK when a new service becomes available to our identity */
 void on_service(ziti_context ziti_ctx, ziti_service *service, int status, void *tnlr_ctx) {
     if (status == ZITI_OK) {
@@ -70,6 +80,7 @@ static void on_ziti_init(ziti_context ziti_ctx, int status, void *init_ctx) {
         ZITI_LOG(ERROR, "failed to initialize ziti");
         exit(1);
     }
+    my_ziti_ctx = ziti_ctx;
 }
 
 extern dns_manager *get_dnsmasq_manager(const char* path);
@@ -113,6 +124,8 @@ static int run_tunnel(const char *ip_range, dns_manager *dns) {
         return 1;
     }
 
+    my_tnlr_ctx = tnlr_ctx;
+    signal(SIGUSR1, sigfn);
     if (uv_run(ziti_loop, UV_RUN_DEFAULT) != 0) {
         ZITI_LOG(ERROR, "failed to run event loop");
         exit(1);


### PR DESCRIPTION
Look for active connections when `ziti_tunneler_stop_intercepting` is called.

This change also moves the tnlr_io context that gets passed to callbacks into a common structure, so the ziti callbacks and the tsk callbacks are handing the same pointer. I expect this to solve the invalid tnlr_io issues that Dariusz was seeing when running through Valtix. 