### PR TITLE
cleanup handling of pointer when client issues rst

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ int main(int argc, char *argv[]) {
 Once the Ziti Tunneler SDK is initialized with a network device and ziti-sdk
 callbacks, a tunneler application only needs to indiciate which service(s)
 that should be  
+

--- a/include/ziti/ziti_tunnel.h
+++ b/include/ziti/ziti_tunnel.h
@@ -78,6 +78,7 @@ typedef struct tunneler_sdk_options_s {
     netif_driver   netif_driver;
     ziti_sdk_dial_cb    ziti_dial;
     ziti_sdk_close_cb   ziti_close;
+    ziti_sdk_close_cb   ziti_close_write;
     ziti_sdk_write_cb   ziti_write;
     ziti_sdk_host_v1_cb ziti_host_v1;
 } tunneler_sdk_options;

--- a/include/ziti/ziti_tunnel_cbs.h
+++ b/include/ziti/ziti_tunnel_cbs.h
@@ -35,6 +35,7 @@ ssize_t ziti_sdk_c_write(const void *ziti_io_ctx, void *write_ctx, const void *d
 /** called by tunneler SDK after a client connection's RX is closed
  * return 0 if TX should still be open, 1 if both sides are closed */
 int ziti_sdk_c_close(void *io_ctx);
+int ziti_sdk_c_close_write(void *io_ctx);
 
 void ziti_sdk_c_host_v1(void *ziti_ctx, uv_loop_t *loop, const char *service_id, const char *proto, const char *hostname, int port);
 

--- a/lib/tunnel_tcp.c
+++ b/lib/tunnel_tcp.c
@@ -125,13 +125,7 @@ static err_t on_tcp_client_data(void *io_ctx, struct tcp_pcb *pcb, struct pbuf *
     if (err == ERR_OK && p == NULL) {
         ZITI_LOG(INFO, "client sent FIN: client=%s, service=%s", io->tnlr_io->client, io->tnlr_io->service_name);
         LOG_STATE(DEBUG, "FIN received", pcb);
-        if (io->tnlr_io->tnlr_ctx->opts.ziti_close(io->ziti_io)) {
-            tcp_close(pcb);
-            io->ziti_io = NULL;
-            free_tunneler_io_context(&io->tnlr_io);
-            free(io);
-            tcp_arg(pcb, NULL);
-        }
+        io->tnlr_io->tnlr_ctx->opts.ziti_close_write(io->ziti_io);
         return err;
     }
 

--- a/lib/tunnel_tcp.c
+++ b/lib/tunnel_tcp.c
@@ -167,6 +167,9 @@ static void  on_tcp_client_err(void *io_ctx, err_t err) {
         ZITI_LOG(ERROR, "client=%s err=%d, terminating connection", client, err);
         if (io->ziti_io != NULL && io->tnlr_io != NULL) {
             io->tnlr_io->tnlr_ctx->opts.ziti_close(io->ziti_io);
+            io->ziti_io = NULL;
+            free_tunneler_io_context(&io->tnlr_io);
+            free(io);
         }
     }
 }

--- a/lib/ziti_tunnel.c
+++ b/lib/ziti_tunnel.c
@@ -307,7 +307,8 @@ static struct raw_pcb * init_protocol_handler(u8_t proto, raw_recv_fn recv_fn, v
 
 static void run_packet_loop(uv_loop_t *loop, tunneler_context tnlr_ctx) {
     if (tnlr_ctx->opts.ziti_close == NULL || tnlr_ctx->opts.ziti_dial == NULL ||
-        tnlr_ctx->opts.ziti_write == NULL || tnlr_ctx->opts.ziti_host_v1 == NULL) {
+        tnlr_ctx->opts.ziti_write == NULL || tnlr_ctx->opts.ziti_host_v1 == NULL ||
+        tnlr_ctx->opts.ziti_close_write == NULL) {
         ZITI_LOG(ERROR, "ziti_sdk_* callback options cannot be null");
         exit(1);
     }

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -84,7 +84,7 @@ int ziti_sdk_c_close(void *io_ctx) {
     if (ziti_io_ctx->ziti_conn != NULL) {
         ZITI_LOG(DEBUG, "closing ziti_conn tnlr_eof=%d, ziti_eof=%d", ziti_io_ctx->tnlr_eof, ziti_io_ctx->ziti_eof);
         ziti_io_ctx->tnlr_eof = true;
-        ziti_close(&ziti_io_ctx->ziti_conn);
+        ziti_close(ziti_io_ctx->ziti_conn, ziti_conn_close_cb);
         free(ziti_io_ctx);
     }
     return 1;

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -82,6 +82,18 @@ int ziti_sdk_c_close(void *io_ctx) {
     if (ziti_io_ctx->ziti_conn != NULL) {
         ZITI_LOG(DEBUG, "closing ziti_conn tnlr_eof=%d, ziti_eof=%d", ziti_io_ctx->tnlr_eof, ziti_io_ctx->ziti_eof);
         ziti_io_ctx->tnlr_eof = true;
+        ziti_close(&ziti_io_ctx->ziti_conn);
+        free(ziti_io_ctx);
+    }
+    return 1;
+}
+
+/** called by tunneler SDK after a client sends connection is closed */
+int ziti_sdk_c_close_write(void *io_ctx) {
+    ziti_io_context *ziti_io_ctx = io_ctx;
+    if (ziti_io_ctx->ziti_conn != NULL) {
+        ZITI_LOG(DEBUG, "closing ziti_conn tnlr_eof=%d, ziti_eof=%d", ziti_io_ctx->tnlr_eof, ziti_io_ctx->ziti_eof);
+        ziti_io_ctx->tnlr_eof = true;
         if (ziti_io_ctx->ziti_eof) { // both sides are now closed
             ZITI_LOG(DEBUG, "closing ziti_conn tnlr_eof=%d, ziti_eof=%d", ziti_io_ctx->tnlr_eof, ziti_io_ctx->ziti_eof);
             ziti_close(&ziti_io_ctx->ziti_conn);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -99,6 +99,7 @@ static int run_tunnel(const char *ip_range, dns_manager *dns) {
             .netif_driver = tun,
             .ziti_dial = ziti_sdk_c_dial,
             .ziti_close = ziti_sdk_c_close,
+            .ziti_close_write = ziti_sdk_c_close_write,
             .ziti_write = ziti_sdk_c_write,
             .ziti_host_v1 = ziti_sdk_c_host_v1
 


### PR DESCRIPTION
should resolve the issue the Ziti Desktop Edge for Windows sees when accessing a fileshare