### PR TITLE
only free write_ctx in on_ziti_write

### DIFF
--- a/lib/tunnel_tcp.c
+++ b/lib/tunnel_tcp.c
@@ -138,7 +138,6 @@ static err_t on_tcp_client_data(void *io_ctx, struct tcp_pcb *pcb, struct pbuf *
     ssize_t s = zwrite(io->ziti_io, wr_ctx, p->payload, len);
     if (s < 0) {
         ZITI_LOG(ERROR, "ziti_write failed: service=%s, client=%s, ret=%ld", io->tnlr_io->service_name, io->tnlr_io->client, s);
-        free(wr_ctx);
         free(io);
         tcp_arg(pcb, NULL);
         pbuf_free(p);

--- a/lib/tunnel_udp.c
+++ b/lib/tunnel_udp.c
@@ -39,7 +39,7 @@ static void to_ziti(struct io_ctx_s *io, struct pbuf *p) {
         wr_ctx->ack = tunneler_udp_ack;
         ssize_t s = zwrite(io->ziti_io, wr_ctx, recv_data->payload, recv_data->len);
         if (s < 0) {
-            free(wr_ctx);
+            ZITI_LOG(ERROR, "ziti_write failed: service=%s, client=%s, ret=%ld", io->tnlr_io->service_name, io->tnlr_io->client, s);
             pbuf_free(recv_data);
         }
         recv_data = recv_data->next;

--- a/lib/ziti_tunnel.c
+++ b/lib/ziti_tunnel.c
@@ -63,7 +63,6 @@ tunneler_context ziti_tunneler_init(tunneler_sdk_options *opts, uv_loop_t *loop)
 /** called by tunneler application when data has been successfully written to ziti */
 void ziti_tunneler_ack(struct write_ctx_s *write_ctx) {
     write_ctx->ack(write_ctx);
-    free(write_ctx);
 }
 
 void free_tunneler_io_context(tunneler_io_context *tnlr_io_ctx) {

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -145,7 +145,10 @@ void * ziti_sdk_c_dial(const intercept_ctx_t *intercept_ctx, struct io_ctx_s *io
 
 /** called by ziti SDK when data transfer initiated by ziti_write completes */
 static void on_ziti_write(ziti_connection ziti_conn, ssize_t len, void *ctx) {
-    ziti_tunneler_ack(ctx);
+    if (len > 0) {
+        ziti_tunneler_ack(ctx);
+    }
+    free(ctx);
 }
 
 /** called from tunneler SDK when intercepted client sends data */


### PR DESCRIPTION
ziti_write calls the write callback in all cases (even on early error), so free the write context in the callback and nowhere else.