### PR TITLE
don't double free pbuf when ziti_sdk_c_write fails.

### DIFF
--- a/lib/tunnel_tcp.c
+++ b/lib/tunnel_tcp.c
@@ -136,7 +136,6 @@ static err_t on_tcp_client_data(void *io_ctx, struct tcp_pcb *pcb, struct pbuf *
     ssize_t s = zwrite(io->ziti_io, wr_ctx, p->payload, len);
     if (s < 0) {
         ZITI_LOG(ERROR, "ziti_write failed: service=%s, client=%s, ret=%ld", io->tnlr_io->service_name, io->tnlr_io->client, s);
-        pbuf_free(p);
         return ERR_ABRT;
     }
     return ERR_OK;

--- a/lib/tunnel_udp.c
+++ b/lib/tunnel_udp.c
@@ -40,7 +40,7 @@ static void to_ziti(struct io_ctx_s *io, struct pbuf *p) {
         ssize_t s = zwrite(io->ziti_io, wr_ctx, recv_data->payload, recv_data->len);
         if (s < 0) {
             ZITI_LOG(ERROR, "ziti_write failed: service=%s, client=%s, ret=%ld", io->tnlr_io->service_name, io->tnlr_io->client, s);
-            pbuf_free(recv_data);
+            break;
         }
         recv_data = recv_data->next;
     } while (recv_data != NULL);


### PR DESCRIPTION
the write callback frees the pbuf and ziti_sdk_c_write calls the callback when ziti_write fails