### PR TITLE
Don't ack client when dial failed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.20.7")
+    set(ZITI_SDK_C_BRANCH "0.20.8")
 endif()
 
 execute_process(

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -21,8 +21,9 @@ static void on_ziti_connect(ziti_connection conn, int status) {
         ziti_close(conn, NULL);
         return;
     }
-    ziti_tunneler_dial_completed(io, status == ZITI_OK);
-    if (status != ZITI_OK) {
+    if (status == ZITI_OK) {
+        ziti_tunneler_dial_completed(io, true);
+    } else {
         ZITI_LOG(ERROR, "ziti dial failed: %s", ziti_errorstr(status));
         ziti_close(conn, ziti_conn_close_cb);
     }


### PR DESCRIPTION
despite taking a bool that indicates whether or not the dial succeeded, ziti_tunnel_dial_completed should only be called when the dial was successful.