### PR TITLE
explicitly close ziti when killing connections of removed intercepts

### DIFF
--- a/lib/ziti_tunnel.c
+++ b/lib/ziti_tunnel.c
@@ -142,11 +142,14 @@ int ziti_tunneler_intercept_v1(tunneler_context tnlr_ctx, const void *ziti_ctx, 
 
 static void tunneler_kill_active(const void *ztx, const char *service_name) {
     struct io_ctx_list_s *l;
+    ziti_sdk_close_cb zclose;
 
     l = tunneler_tcp_active(ztx, service_name);
     while (!SLIST_EMPTY(l)) {
         struct io_ctx_list_entry_s *n = SLIST_FIRST(l);
         ziti_tunneler_close(n->io->tnlr_io);
+        zclose = n->io->tnlr_io->tnlr_ctx->opts.ziti_close;
+        if (zclose) zclose(n->io->ziti_io);
         SLIST_REMOVE_HEAD(l, entries);
         free(n);
     }
@@ -157,6 +160,8 @@ static void tunneler_kill_active(const void *ztx, const char *service_name) {
     while (!SLIST_EMPTY(l)) {
         struct io_ctx_list_entry_s *n = SLIST_FIRST(l);
         ziti_tunneler_close(n->io->tnlr_io);
+        zclose = n->io->tnlr_io->tnlr_ctx->opts.ziti_close;
+        if (zclose) zclose(n->io->ziti_io);
         SLIST_REMOVE_HEAD(l, entries);
         free(n);
     }

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -64,7 +64,7 @@ static ssize_t on_ziti_data(ziti_connection conn, uint8_t *data, ssize_t len) {
     return len;
 }
 
-/** called by tunneler SDK after a client connection is closed */
+/** called by tunneler SDK after a client connection is closed. also called from ziti_tunneler_stop_intercepting */
 int ziti_sdk_c_close(void *io_ctx) {
     ziti_io_context *ziti_io_ctx = io_ctx;
     ZITI_LOG(DEBUG, "closing ziti_conn tnlr_eof=%d, ziti_eof=%d", ziti_io_ctx->tnlr_eof, ziti_io_ctx->ziti_eof);


### PR DESCRIPTION
prevent crashes when messages arrive on connections for services that are no longer intercepted. don't rely on the edge router to close the ziti side.