### PR TITLE
always close ziti connection first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.20.9")
+    set(ZITI_SDK_C_BRANCH "0.20.10")
 endif()
 
 execute_process(

--- a/lib/ziti_tunnel.c
+++ b/lib/ziti_tunnel.c
@@ -147,7 +147,7 @@ static void tunneler_kill_active(const void *ztx, const char *service_name) {
     l = tunneler_tcp_active(ztx, service_name);
     while (!SLIST_EMPTY(l)) {
         struct io_ctx_list_entry_s *n = SLIST_FIRST(l);
-        ziti_tunneler_close(n->io->tnlr_io);
+        // close the ziti connection, which also closes the underlay
         zclose = n->io->tnlr_io->tnlr_ctx->opts.ziti_close;
         if (zclose) zclose(n->io->ziti_io);
         SLIST_REMOVE_HEAD(l, entries);
@@ -159,7 +159,7 @@ static void tunneler_kill_active(const void *ztx, const char *service_name) {
     l = tunneler_udp_active(ztx, service_name);
     while (!SLIST_EMPTY(l)) {
         struct io_ctx_list_entry_s *n = SLIST_FIRST(l);
-        ziti_tunneler_close(n->io->tnlr_io);
+        // close the ziti connection, which also closes the underlay
         zclose = n->io->tnlr_io->tnlr_ctx->opts.ziti_close;
         if (zclose) zclose(n->io->ziti_io);
         SLIST_REMOVE_HEAD(l, entries);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -61,7 +61,7 @@ void on_service(ziti_context ziti_ctx, ziti_service *service, int status, void *
         }
     } else if (status == ZITI_SERVICE_UNAVAILABLE) {
         ZITI_LOG(INFO, "service unavailable: %s", service->name);
-        ziti_tunneler_stop_intercepting(tnlr_ctx, service->name);
+        ziti_tunneler_stop_intercepting(tnlr_ctx, service->id);
     }
 }
 


### PR DESCRIPTION
The underlay connection gets closed in the ziti_close callback.