### PR TITLE
multiple identity support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.20.15")
+    set(ZITI_SDK_C_BRANCH "0.20.16")
 endif()
 
 execute_process(

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -31,11 +31,23 @@ static model_map instances;
 
 static void on_ziti_event(ziti_context ztx, const ziti_event_t *event);
 
-const char *cfg_types[] = { "ziti-tunneler-client.v1", "intercept.v1", "ziti-tunneler-server.v1", "host.v1", NULL };
+static const char * cfg_types[] = { "ziti-tunneler-client.v1", "intercept.v1", "ziti-tunneler-server.v1", "host.v1", NULL };
 
 static long refresh_interval = 10;
 
+static char *config_dir = NULL;
+
 static tunneler_context tnlr_ctx;
+
+static struct ziti_instance_s *new_ziti_instance(const char *path) {
+    struct ziti_instance_s *inst = calloc(1, sizeof(struct ziti_instance_s));
+    inst->opts.config = realpath(path, NULL);
+    inst->opts.config_types = cfg_types;
+    inst->opts.events = ZitiContextEvent|ZitiServiceEvent;
+    inst->opts.event_cb = on_ziti_event;
+    inst->opts.refresh_interval = refresh_interval; /* default refresh */
+    return inst;
+}
 
 /** callback from ziti SDK when a new service becomes available to our identity */
 static void on_service(ziti_context ziti_ctx, ziti_service *service, int status, void *tnlr_ctx) {
@@ -108,6 +120,40 @@ static void load_ziti_async(uv_async_t *ar) {
     uv_close((uv_handle_t *) ar, (uv_close_cb) free);
 }
 
+static void load_identities(uv_work_t *wr) {
+    if (config_dir != NULL) {
+        uv_fs_t fs;
+        int rc = uv_fs_scandir(wr->loop, &fs, config_dir, 0, NULL);
+        if (rc < 0) {
+            ZITI_LOG(ERROR, "failed to scan dir: %d/%s", rc, uv_strerror(rc));
+        }
+
+        uv_dirent_t file;
+        while (uv_fs_scandir_next(&fs, &file) != UV_EOF) {
+            ZITI_LOG(INFO, "file = %s %d", file.name, file.type);
+
+            if (file.type == UV_DIRENT_FILE) {
+                char path[MAXPATHLEN];
+                snprintf(path, sizeof(path), "%s/%s", config_dir, file.name);
+                struct ziti_instance_s *inst = new_ziti_instance(path);
+                LIST_INSERT_HEAD(&instance_init_list, inst, _next);
+            }
+        }
+    }
+}
+
+static void load_identities_complete(uv_work_t * wr, int status) {
+    while(!LIST_EMPTY(&instance_init_list)) {
+        struct ziti_instance_s *inst = LIST_FIRST(&instance_init_list);
+        LIST_REMOVE(inst, _next);
+
+        uv_async_t *ar = calloc(1, sizeof(uv_async_t));
+        ar->data = inst;
+        uv_async_init(wr->loop, ar, load_ziti_async);
+        uv_async_send(ar);
+    }
+}
+
 static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, const char *ip_range, dns_manager *dns) {
     netif_driver tun;
     char tun_error[64];
@@ -135,15 +181,8 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, const char *ip_rang
     tnlr_ctx = ziti_tunneler_init(&tunneler_opts, ziti_loop);
     ziti_tunneler_set_dns(tnlr_ctx, dns);
 
-    while(!LIST_EMPTY(&instance_init_list)) {
-        struct ziti_instance_s *inst = LIST_FIRST(&instance_init_list);
-        LIST_REMOVE(inst, _next);
-
-        uv_async_t *ar = calloc(1, sizeof(uv_async_t));
-        ar->data = inst;
-        uv_async_init(ziti_loop, ar, load_ziti_async);
-        uv_async_send(ar);
-    }
+    uv_work_t *loader = calloc(1, sizeof(uv_work_t));
+    uv_queue_work(ziti_loop, loader, load_identities, load_identities_complete);
 
     if (uv_run(ziti_loop, UV_RUN_DEFAULT) != 0) {
         ZITI_LOG(ERROR, "failed to run event loop");
@@ -179,6 +218,7 @@ static void usage(int argc, char *argv[]) {
 
 static struct option run_options[] = {
         { "identity", required_argument, NULL, 'i' },
+        { "identity-dir", required_argument, NULL, 'I'},
         { "verbose", required_argument, NULL, 'v'},
         { "refresh", required_argument, NULL, 'r'},
         { "dns-ip-range", required_argument, NULL, 'd'},
@@ -194,19 +234,17 @@ static int run_opts(int argc, char *argv[]) {
     int c, option_index, errors = 0;
     optind = 0;
 
-    while ((c = getopt_long(argc, argv, "i:v:r:d:n:",
+    while ((c = getopt_long(argc, argv, "i:I:v:r:d:n:",
                             run_options, &option_index)) != -1) {
         switch (c) {
             case 'i': {
-                struct ziti_instance_s *inst = calloc(1, sizeof(struct ziti_instance_s));
-                inst->opts.config = strdup(optarg);
-                inst->opts.config_types = cfg_types;
-                inst->opts.events = ZitiContextEvent|ZitiServiceEvent;
-                inst->opts.event_cb = on_ziti_event;
-                inst->opts.refresh_interval = refresh_interval; /* default refresh */
+                struct ziti_instance_s *inst = new_ziti_instance(optarg);
                 LIST_INSERT_HEAD(&instance_init_list, inst, _next);
                 break;
             }
+            case 'I':
+                config_dir = optarg;
+                break;
             case 'v':
                 setenv("ZITI_LOG", optarg, true);
                 break;
@@ -418,6 +456,7 @@ static CommandLine enroll_cmd = make_command("enroll", "enroll Ziti identity",
 static CommandLine run_cmd = make_command("run", "run Ziti tunnel (required superuser access)",
                                           "-i <id.file> [-r N] [-v N] [-d|--dns-ip-range N.N.N.N/n] [-n|--dns <internal|dnsmasq=<dnsmasq hosts dir>>]",
                                           "\t-i|--identity <identity>\trun with provided identity file (required)\n"
+                                          "\t-I|--identity-dir <dir>\tload identities from provided directory\n"
                                           "\t-v|--verbose N\tset log level, higher level -- more verbose (default 3)\n"
                                           "\t-r|--refresh N\tset service polling interval in seconds (default 10)\n"
                                           "\t-d|--dns-ip-range <ip range>\tspecify CIDR block in which service DNS names"


### PR DESCRIPTION
new `ziti-edge-tunnel` options
`-i|--identity` can be repeated multiple times to load multiple identities
`-I|--identity-dir` can be used to load all identities from a directory