### PR TITLE
use app_data_sz instead of requiring NUL-terminated json string for tunneler_app_data

### DIFF
--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -416,16 +416,15 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
     struct hosted_io_ctx_s *io_ctx = NULL;
     bool err = false;
 
-    char *app_data_json = (char *) clt_ctx->app_data;
     tunneler_app_data app_data_model;
     memset(&app_data_model, 0, sizeof(app_data_model));
-    if (app_data_json != NULL) {
-        ZITI_LOG(DEBUG, "hosted_service[%s], client[%s]: received app_data_json='%s'", service_ctx->service_name,
-                 client_identity, app_data_json);
-        if (parse_tunneler_app_data(&app_data_model, app_data_json, strlen(app_data_json)) != 0) {
-            ZITI_LOG(ERROR, "hosted_service[%s], client[%s]: failed to parse app_data_json '%s'",
+    if (clt_ctx->app_data != NULL) {
+        ZITI_LOG(DEBUG, "hosted_service[%s], client[%s]: received app_data_json='%.*s'", service_ctx->service_name,
+                 client_identity, clt_ctx->app_data_sz, clt_ctx->app_data);
+        if (parse_tunneler_app_data(&app_data_model, (char *)clt_ctx->app_data, clt_ctx->app_data_sz) != 0) {
+            ZITI_LOG(ERROR, "hosted_service[%s], client[%s]: failed to parse app_data_json '%.*%s'",
                      service_ctx->service_name,
-                     client_identity, app_data_json);
+                     client_identity, clt_ctx->app_data_sz, clt_ctx->app_data);
             err = true;
             goto done;
         }

--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -598,7 +598,7 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
         ziti_close(clt, ziti_conn_close_cb);
         safe_free(io_ctx);
     }
-    if (app_data_json != NULL) {
+    if (clt_ctx->app_data != NULL) {
         free_tunneler_app_data(&app_data_model);
     }
     if (dial_ai != NULL) {


### PR DESCRIPTION
update hosting code accordingly after #114 - use app_data_sz instead of expecting the json to be NUL-terminated