### PR TITLE
Fix crashes

### DIFF
--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -34,7 +34,10 @@ limitations under the License.
 static void ziti_conn_close_cb(ziti_connection zc) {
     ZITI_LOG(TRACE, "ziti_conn[%p] is closed", zc);
     struct hosted_io_ctx_s *io_ctx = ziti_conn_data(zc);
-    if (io_ctx) free(io_ctx);
+    if (io_ctx) {
+        free(io_ctx);
+        ziti_conn_set_data(zc, NULL);
+    }
 }
 
 /** called by ziti SDK when a ziti client write (to a hosted tcp server) is completed */
@@ -596,7 +599,6 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
     done:
     if (err) {
         ziti_close(clt, ziti_conn_close_cb);
-        safe_free(io_ctx);
     }
     if (clt_ctx->app_data != NULL) {
         free_tunneler_app_data(&app_data_model);

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -120,6 +120,7 @@ static size_t get_app_data_json(char *buf, size_t bufsz, tunneler_io_context io,
     static const char *PROTO_KEY = "intercepted_protocol";
     static const char *IP_KEY = "intercepted_ip";
     static const char *PORT_KEY = "intercepted_port";
+    static const char *SOURCE_IP_KEY = "source_ip";
 
     tunneler_app_data app_data_model;
     memset(&app_data_model, 0, sizeof(app_data_model));
@@ -169,7 +170,7 @@ static size_t get_app_data_json(char *buf, size_t bufsz, tunneler_io_context io,
             }
         }
         string_replace(resolved_source_ip, sizeof(resolved_source_ip), "$intercepted_port", model_map_get(&app_data_model.data, "intercepted_port"));
-        model_map_set(&app_data_model.data, "source_ip", resolved_source_ip);
+        model_map_set(&app_data_model.data, SOURCE_IP_KEY, resolved_source_ip);
     }
 
     size_t json_len;
@@ -182,6 +183,7 @@ static size_t get_app_data_json(char *buf, size_t bufsz, tunneler_io_context io,
     model_map_remove(&app_data_model.data, PROTO_KEY);
     model_map_remove(&app_data_model.data, IP_KEY);
     model_map_remove(&app_data_model.data, PORT_KEY);
+    model_map_remove(&app_data_model.data, SOURCE_IP_KEY);
 
     free_tunneler_app_data(&app_data_model);
     return json_len;


### PR DESCRIPTION
One crash happens on intercepting tunneler when source_ip is set in intercept.v1 config

The other happens on hosting tunneler when `on_hosted_client_connect` fails for any reason.