### PR TITLE
initiate session close with hosted_server_close

### DIFF
--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -598,7 +598,7 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
 
     done:
     if (err) {
-        ziti_close(clt, ziti_conn_close_cb);
+        hosted_server_close(io_ctx);
     }
     if (clt_ctx->app_data != NULL) {
         free_tunneler_app_data(&app_data_model);


### PR DESCRIPTION
This fixes the crash that I was seeing when uv_tcp_bind failed to set sourceIp. The close needs to be initiated with hosted_server_close so that the io_ctx (which holds the uv handle) isn't free'd prematurely.