### PR TITLE
Support client address variables in intercept.v1:sourceIp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "model-to-json")
+    set(ZITI_SDK_C_BRANCH "0.21.0")
 endif()
 
 execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.20.20")
+    set(ZITI_SDK_C_BRANCH "model-to-json")
 endif()
 
 execute_process(

--- a/include/ziti/ziti_tunnel.h
+++ b/include/ziti/ziti_tunnel.h
@@ -36,6 +36,7 @@ extern "C" {
 typedef struct tunneler_ctx_s *tunneler_context;
 typedef struct tunneler_io_ctx_s *tunneler_io_context;
 const char * get_intercepted_address(const struct tunneler_io_ctx_s * tnlr_io);
+const char * get_client_address(const struct tunneler_io_ctx_s * tnlr_io);
 typedef struct hosted_io_ctx_s *hosted_io_context;
 
 typedef enum {

--- a/include/ziti/ziti_tunnel.h
+++ b/include/ziti/ziti_tunnel.h
@@ -33,6 +33,15 @@ limitations under the License.
 extern "C" {
 #endif
 
+/** keys used in app_data model map */
+extern const char *INTERCEPTED_PROTO_KEY; // "intercepted_protocol"
+extern const char *INTERCEPTED_IP_KEY;    // "intercepted_ip"
+extern const char *INTERCEPTED_PORT_KEY;  // "intercepted_port"
+extern const char *CLIENT_PROTO_KEY;      // "client_protocol"
+extern const char *CLIENT_IP_KEY;         // "client_ip"
+extern const char *CLIENT_PORT_KEY;       // "client_port"
+extern const char *SOURCE_IP_KEY;         // "source_ip"
+
 typedef struct tunneler_ctx_s *tunneler_context;
 typedef struct tunneler_io_ctx_s *tunneler_io_context;
 const char * get_intercepted_address(const struct tunneler_io_ctx_s * tnlr_io);

--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -548,6 +548,7 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
                     goto done;
                 }
             }
+            // todo why exactly does moving this (from before bind) avoid crash?
             io_ctx->server.tcp.data = io_ctx;
             ziti_conn_set_data(clt, io_ctx);
             {
@@ -563,8 +564,6 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
             break;
         case IPPROTO_UDP:
             uv_udp_init(service_ctx->loop, &io_ctx->server.udp);
-            io_ctx->server.udp.data = io_ctx;
-            ziti_conn_set_data(clt, io_ctx);
             if (source_ai != NULL) {
                 uv_err = uv_udp_bind(&io_ctx->server.udp, source_ai->ai_addr, 0);
                 if (uv_err != 0) {
@@ -574,6 +573,8 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
                     goto done;
                 }
             }
+            io_ctx->server.udp.data = io_ctx;
+            ziti_conn_set_data(clt, io_ctx);
             uv_err = uv_udp_connect(&io_ctx->server.udp, dial_ai->ai_addr);
             if (uv_err != 0) {
                 ZITI_LOG(ERROR, "hosted_service[%s], client[%s]: uv_udp_connect failed: %s",

--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -32,11 +32,15 @@ limitations under the License.
 
 
 static void ziti_conn_close_cb(ziti_connection zc) {
-    ZITI_LOG(TRACE, "ziti_conn[%p] is closed", zc);
     struct hosted_io_ctx_s *io_ctx = ziti_conn_data(zc);
     if (io_ctx) {
+        ZITI_LOG(TRACE, "hosted_service[%s] client[%s] ziti_conn[%p] closed",
+                 io_ctx->service->service_name, ziti_conn_source_identity(zc), zc);
+        io_ctx->client = NULL;
         free(io_ctx);
         ziti_conn_set_data(zc, NULL);
+    } else {
+        ZITI_LOG(TRACE, "ziti_conn[%p] is closed", zc);
     }
 }
 
@@ -83,8 +87,12 @@ static void hosted_server_close_cb(uv_handle_t *handle) {
     struct hosted_io_ctx_s *io_ctx = handle->data;
     if (io_ctx->client) {
         ziti_close(io_ctx->client, ziti_conn_close_cb);
+        ZITI_LOG(TRACE, "hosted_service[%s] client[%s] server_conn[%p] closed",
+                 io_ctx->service->service_name, ziti_conn_source_identity(io_ctx->client));
     } else {
+        ZITI_LOG(TRACE, "server_conn[%p] closed", handle);
         free_hosted_io_ctx(handle->data);
+        handle->data = NULL;
     }
 }
 

--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -94,6 +94,9 @@ static void tcp_shutdown_cb(uv_shutdown_t *req, int res) {
 
 #define safe_close(h, cb) if(!uv_is_closing((uv_handle_t*)h)) uv_close((uv_handle_t*)h, cb)
 static void hosted_server_close(struct hosted_io_ctx_s *io_ctx) {
+    if (io_ctx == NULL) {
+        return;
+    }
     switch (io_ctx->server_proto_id) {
         case IPPROTO_TCP:
             safe_close(&io_ctx->server.tcp, hosted_server_close_cb);

--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -502,7 +502,7 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
             source_ip_cp[port_sep-source_ip] = '\0';
             source_ip = source_ip_cp;
         }
-        source_hints.ai_flags = AI_ADDRCONFIG | AI_NUMERICHOST;
+        source_hints.ai_flags = AI_ADDRCONFIG | AI_NUMERICHOST | AI_NUMERICSERV;
         source_hints.ai_protocol = dial_ai_params.hints.ai_protocol;
         source_hints.ai_socktype = dial_ai_params.hints.ai_socktype;
         if ((s = getaddrinfo(source_ip, source_port, &source_hints, &source_ai)) != 0) {
@@ -539,8 +539,6 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
     switch (dial_ai->ai_protocol) {
         case IPPROTO_TCP:
             uv_tcp_init(service_ctx->loop, &io_ctx->server.tcp);
-            io_ctx->server.tcp.data = io_ctx;
-            ziti_conn_set_data(clt, io_ctx);
             if (source_ai != NULL) {
                 uv_err = uv_tcp_bind(&io_ctx->server.tcp, source_ai->ai_addr, 0);
                 if (uv_err != 0) {
@@ -550,6 +548,8 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
                     goto done;
                 }
             }
+            io_ctx->server.tcp.data = io_ctx;
+            ziti_conn_set_data(clt, io_ctx);
             {
                 uv_connect_t *c = malloc(sizeof(uv_connect_t));
                 uv_err = uv_tcp_connect(c, &io_ctx->server.tcp, dial_ai->ai_addr, on_hosted_tcp_server_connect_complete);

--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -88,7 +88,7 @@ static void hosted_server_close_cb(uv_handle_t *handle) {
     if (io_ctx->client) {
         ziti_close(io_ctx->client, ziti_conn_close_cb);
         ZITI_LOG(TRACE, "hosted_service[%s] client[%s] server_conn[%p] closed",
-                 io_ctx->service->service_name, ziti_conn_source_identity(io_ctx->client));
+                 io_ctx->service->service_name, ziti_conn_source_identity(io_ctx->client), handle);
     } else {
         ZITI_LOG(TRACE, "server_conn[%p] closed", handle);
         free_hosted_io_ctx(handle->data);
@@ -556,7 +556,6 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
                     goto done;
                 }
             }
-            // todo why exactly does moving this (from before bind) avoid crash?
             io_ctx->server.tcp.data = io_ctx;
             ziti_conn_set_data(clt, io_ctx);
             {

--- a/lib/ziti_hosting.c
+++ b/lib/ziti_hosting.c
@@ -327,7 +327,7 @@ static bool addrinfo_from_host_cfg_v1(struct addrinfo_params_s *dial_params, con
     const char *dial_protocol_str = NULL;
 
     if (config->dial_intercepted_protocol) {
-        dial_protocol_str = model_map_get(app_data, "intercepted_protocol");
+        dial_protocol_str = model_map_get(app_data, INTERCEPTED_PROTO_KEY);
         if (dial_protocol_str == NULL) {
             snprintf(dial_params->err, sizeof(dial_params->err),
                      "service config specifies 'dialInterceptedProtocol', but client didn't send intercepted protocol");
@@ -344,7 +344,7 @@ static bool addrinfo_from_host_cfg_v1(struct addrinfo_params_s *dial_params, con
     }
 
     if (config->dial_intercepted_address) {
-        dial_params->address = model_map_get(app_data, "intercepted_ip");
+        dial_params->address = model_map_get(app_data, INTERCEPTED_IP_KEY);
         if (dial_params->address == NULL) {
             snprintf(dial_params->err, sizeof(dial_params->err),
                      "service config specifies 'dialInterceptedAddress' but client didn't send intercepted ip");
@@ -355,7 +355,7 @@ static bool addrinfo_from_host_cfg_v1(struct addrinfo_params_s *dial_params, con
     }
 
     if (config->dial_intercepted_port) {
-        dial_params->port = model_map_get(app_data, "intercepted_port");
+        dial_params->port = model_map_get(app_data, INTERCEPTED_PORT_KEY);
         if (dial_params->port == NULL) {
             snprintf(dial_params->err, sizeof(dial_params->err),
                      "service config specifies 'dialInterceptedPort' but client didn't send intercepted port");
@@ -479,9 +479,9 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
                  service_ctx->service_name, client_identity, dial_ai_params.address, dial_ai_params.port);
     }
 
-    const char *iproto = model_map_get(&app_data_model.data, "intercepted_protocol");
-    const char *iip = model_map_get(&app_data_model.data, "intercepted_ip");
-    const char *iport = model_map_get(&app_data_model.data, "intercepted_port");
+    const char *iproto = model_map_get(&app_data_model.data, INTERCEPTED_PROTO_KEY);
+    const char *iip = model_map_get(&app_data_model.data, INTERCEPTED_IP_KEY);
+    const char *iport = model_map_get(&app_data_model.data, INTERCEPTED_PORT_KEY);
     if (iproto != NULL && iip != NULL && iport != NULL) {
         ZITI_LOG(INFO, "hosted_service[%s], client[%s] intercepted_addr[%s:%s:%s]: incoming connection",
                  service_ctx->service_name, client_identity, iproto, iip, iport);
@@ -490,7 +490,7 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
                  service_ctx->service_name, client_identity);
     }
 
-    const char *source_ip = model_map_get(&app_data_model.data, "source_ip");
+    const char *source_ip = model_map_get(&app_data_model.data, SOURCE_IP_KEY);
     if (source_ip != NULL) {
         struct addrinfo source_hints = {0};
         const char *port_sep = strchr(source_ip, ':');

--- a/lib/ziti_tunnel.c
+++ b/lib/ziti_tunnel.c
@@ -36,6 +36,14 @@ limitations under the License.
 
 #include <string.h>
 
+const char *INTERCEPTED_PROTO_KEY = "intercepted_protocol";
+const char *INTERCEPTED_IP_KEY = "intercepted_ip";
+const char *INTERCEPTED_PORT_KEY = "intercepted_port";
+const char *CLIENT_PROTO_KEY = "client_protocol";
+const char *CLIENT_IP_KEY = "client_ip";
+const char *CLIENT_PORT_KEY = "client_port";
+const char *SOURCE_IP_KEY = "source_ip";
+
 struct resolve_req {
     struct pbuf *qp;
     ip_addr_t addr;

--- a/lib/ziti_tunnel.c
+++ b/lib/ziti_tunnel.c
@@ -93,6 +93,13 @@ const char *get_intercepted_address(const struct tunneler_io_ctx_s * tnlr_io) {
     return tnlr_io->intercepted;
 }
 
+const char *get_client_address(const struct tunneler_io_ctx_s * tnlr_io) {
+    if (tnlr_io == NULL) {
+        return NULL;
+    }
+    return tnlr_io->client;
+}
+
 void free_tunneler_io_context(tunneler_io_context *tnlr_io_ctx_p) {
     if (tnlr_io_ctx_p == NULL) {
         return;

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -274,7 +274,7 @@ void * ziti_sdk_c_dial(const intercept_ctx_t *intercept_ctx, struct io_ctx_s *io
     dial_opts.app_data_sz = (size_t) json_len;
     dial_opts.app_data = app_data_json;
 
-    ZITI_LOG(DEBUG, "service[%s] app_data_json[%zd]='%s'", intercept_ctx->service_name, dial_opts.app_data_sz, dial_opts.app_data);
+    ZITI_LOG(DEBUG, "service[%s] app_data_json[%zd]='%.*s'", intercept_ctx->service_name, dial_opts.app_data_sz, (int)dial_opts.app_data_sz, dial_opts.app_data);
     if (ziti_dial_with_options(ziti_io_ctx->ziti_conn, intercept_ctx->service_name, &dial_opts, on_ziti_connect, on_ziti_data) != ZITI_OK) {
         ZITI_LOG(ERROR, "ziti_dial failed");
         free(ziti_io_ctx);

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -272,6 +272,8 @@ void * ziti_sdk_c_dial(const intercept_ctx_t *intercept_ctx, struct io_ctx_s *io
     }
 
     dial_opts.app_data_sz = (size_t) json_len;
+    dial_opts.app_data = app_data_json;
+
     ZITI_LOG(DEBUG, "service[%s] app_data_json[%zd]='%s'", intercept_ctx->service_name, dial_opts.app_data_sz, dial_opts.app_data);
     if (ziti_dial_with_options(ziti_io_ctx->ziti_conn, intercept_ctx->service_name, &dial_opts, on_ziti_connect, on_ziti_data) != ZITI_OK) {
         ZITI_LOG(ERROR, "ziti_dial failed");

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -115,6 +115,7 @@ static char *string_replace(char *source, size_t sourceSize, const char *substri
     return substring_source + strlen(with);
 }
 
+// todo rename or refactor
 static void parse_address2(const char *address, char **proto, char **ip, char **port) {
     if (proto != NULL) *proto = NULL;
     if (ip != NULL) *ip = NULL;
@@ -145,7 +146,7 @@ static size_t get_app_data_json(char *buf, size_t bufsz, tunneler_io_context io,
     static const char *PROTO_KEY = "intercepted_protocol";
     static const char *IP_KEY = "intercepted_ip";
     static const char *PORT_KEY = "intercepted_port";
-    static const char *CLIENT_PROTO_KEY = "client_proto";
+    static const char *CLIENT_PROTO_KEY = "client_protocol"; // todo is this worthwhile? should always match intercepted_protocol
     static const char *CLIENT_IP_KEY = "client_ip";
     static const char *CLIENT_PORT_KEY = "client_port";
     static const char *SOURCE_IP_KEY = "source_ip";

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -191,7 +191,7 @@ static char *get_app_data_json(tunneler_io_context io, ziti_context ziti_ctx, co
         model_map_set(&app_data_model.data, SOURCE_IP_KEY, resolved_source_ip);
     }
 
-    char *app_data_json = tunneler_app_data_to_json(&app_data_model, 0, json_len);
+    char *app_data_json = tunneler_app_data_to_json(&app_data_model, MODEL_JSON_COMPACT, json_len);
     if (app_data_json == NULL) {
         ZITI_LOG(ERROR, "failed to encode app data");
     }

--- a/lib/ziti_tunnel_cbs.c
+++ b/lib/ziti_tunnel_cbs.c
@@ -444,5 +444,5 @@ static void ziti_conn_close_cb(ziti_connection zc) {
     ziti_tunneler_close(io->tnlr_io);
     free(io);
     ziti_conn_set_data(zc, NULL);
-    ZITI_LOG(VERBOSE, "nulled data for ziti_conn[%p]");
+    ZITI_LOG(VERBOSE, "nulled data for ziti_conn[%p]", zc);
 }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -409,16 +409,16 @@ static void enroll_cb(ziti_config *cfg, int status, char *err, void *ctx) {
 
     FILE *f = ctx;
 
-    char output_buf[16000];
     size_t len;
-    json_from_ziti_config(cfg, output_buf, sizeof(output_buf), &len);
+    char *cfg_json = ziti_config_to_json(cfg, 0, &len);
 
-    if (fwrite(output_buf, 1, len, f) != len) {
+    if (fwrite(cfg_json, 1, len, f) != len) {
         ZITI_LOG(ERROR, "failed to write config file");
         fclose(f);
         exit (-1);
     }
 
+    free(cfg_json);
     fflush(f);
     fclose(f);
 }


### PR DESCRIPTION
* add `client_protocol`, `client_ip`, and `client_port` to the map in tunneler_app_data when dialing
* resolve $client_ip, $client_port references in `sourceIp` value.