### PR TITLE
better handle empty source_ip string

### DIFF
--- a/lib/ziti-tunnel-cbs/ziti_hosting.c
+++ b/lib/ziti-tunnel-cbs/ziti_hosting.c
@@ -494,7 +494,7 @@ static void on_hosted_client_connect(ziti_connection serv, ziti_connection clt, 
     }
 
     const char *source_ip = model_map_get(&app_data_model.data, SOURCE_IP_KEY);
-    if (source_ip != NULL) {
+    if (source_ip != NULL && *source_ip != 0) {
         struct addrinfo source_hints = {0};
         const char *port_sep = strchr(source_ip, ':');
         const char *source_port = NULL;

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
@@ -165,7 +165,7 @@ static ssize_t get_app_data_json(char *buf, size_t bufsz, tunneler_io_context io
         if (_port) model_map_set(&app_data_model.data, CLIENT_PORT_KEY, (char *) _port);
     }
 
-    if (source_ip != NULL) {
+    if (source_ip != NULL && *source_ip != 0) {
         const ziti_identity *zid = ziti_get_identity(ziti_ctx);
         strncpy(resolved_source_ip, source_ip, sizeof(resolved_source_ip));
         string_replace(resolved_source_ip, sizeof(resolved_source_ip), "$tunneler_id.name", zid->name);


### PR DESCRIPTION
hosting side would error out of peer sent empty `source_ip`