### PR TITLE
fix crashes

### DIFF
--- a/lib/ziti-tunnel-cbs/include/ziti/ziti_tunnel_cbs.h
+++ b/lib/ziti-tunnel-cbs/include/ziti/ziti_tunnel_cbs.h
@@ -138,7 +138,7 @@ XX(code, int, none, code, __VA_ARGS__)
 BASE_EVENT_MODEL(XX, __VA_ARGS__)            \
 XX(status, string, none, status, __VA_ARGS__) \
 XX(added_services, ziti_service, array, added_services, __VA_ARGS__) \
-XX(removed_services, ziti_service, array, added_services, __VA_ARGS__)
+XX(removed_services, ziti_service, array, removed_services, __VA_ARGS__)
 
 #define MFA_EVENT_MODEL(XX, ...)  \
 BASE_EVENT_MODEL(XX, __VA_ARGS__)               \


### PR DESCRIPTION
My tunneler was crashing after pulling https://github.com/openziti/ziti-tunnel-sdk-c/pull/200. This PR gets things back to functional for the services and configs that I'm currently testing with.

I feel like a discussion about the service event model would be worthwhile. Without knowing more about the goals/intent of the service event model, it seems like we could eliminate some code if the events included the intercept_ctx instead of parsing the service configuration again.