### PR TITLE
more robust linux DNS integration

### DIFF
--- a/lib/ziti-tunnel-cbs/include/ziti/ziti_dns.h
+++ b/lib/ziti-tunnel-cbs/include/ziti/ziti_dns.h
@@ -25,6 +25,7 @@ typedef int (*dns_fallback_cb)(const char *name, void *ctx, struct in_addr* addr
 int ziti_dns_setup(tunneler_context tnlr, const char *dns_addr, const char *dns_cidr);
 
 void ziti_dns_set_fallback(struct uv_loop_s *l, dns_fallback_cb fb, void *ctx);
+void ziti_dns_set_miss_code(int code);
 void ziti_dns_set_manager(dns_manager *mgr);
 
 const char *ziti_dns_register_hostname(const char *hostname, void *intercept);

--- a/lib/ziti-tunnel-cbs/include/ziti/ziti_dns.h
+++ b/lib/ziti-tunnel-cbs/include/ziti/ziti_dns.h
@@ -18,6 +18,13 @@
 #define ZITI_TUNNEL_SDK_C_ZITI_DNS_H
 
 #include <ziti/ziti_tunnel.h>
+
+#define DNS_NO_ERROR 0
+#define DNS_NXDOMAIN 3
+#define DNS_NOT_IMPL 4
+#define DNS_REFUSE   5
+#define DNS_NOTZONE  9
+
 typedef struct dns_manager_s dns_manager;
 
 typedef int (*dns_fallback_cb)(const char *name, void *ctx, struct in_addr* addr);
@@ -25,7 +32,6 @@ typedef int (*dns_fallback_cb)(const char *name, void *ctx, struct in_addr* addr
 int ziti_dns_setup(tunneler_context tnlr, const char *dns_addr, const char *dns_cidr);
 
 void ziti_dns_set_fallback(struct uv_loop_s *l, dns_fallback_cb fb, void *ctx);
-void ziti_dns_set_miss_code(int code);
 void ziti_dns_set_manager(dns_manager *mgr);
 
 const char *ziti_dns_register_hostname(const char *hostname, void *intercept);

--- a/lib/ziti-tunnel-cbs/ziti_dns.c
+++ b/lib/ziti-tunnel-cbs/ziti_dns.c
@@ -23,6 +23,13 @@
 #define MAX_DNS_NAME 256
 #define MAX_IP_LENGTH 16
 
+#define DNS_NO_ERROR 0
+#define DNS_NXDOMAIN 3
+#define DNS_NOT_IMPL 4
+#define DNS_REFUSE   5
+#define DNS_NOTZONE  9
+
+
 typedef struct ziti_dns_client_s {
     io_ctx_t *io_ctx;
     LIST_HEAD(reqs, dns_req) active_reqs;
@@ -80,6 +87,7 @@ struct ziti_dns_s {
     tunneler_context tnlr;
 } ziti_dns;
 
+static int dns_miss_code = DNS_NXDOMAIN;
 
 static uint32_t next_ipv4() {
    return  htonl(ziti_dns.ip_pool.base | (ziti_dns.ip_pool.counter++ & ziti_dns.ip_pool.counter_mask));
@@ -117,6 +125,10 @@ int ziti_dns_setup(tunneler_context tnlr, const char *dns_addr, const char *dns_
 
     ziti_tunneler_intercept(tnlr, dns_intercept);
     return 0;
+}
+
+void ziti_dns_set_miss_code(int code) {
+    dns_miss_code = code;
 }
 
 void ziti_dns_set_fallback(uv_loop_t *loop, dns_fallback_cb fb, void *ctx) {
@@ -294,10 +306,6 @@ const char *ziti_dns_register_hostname(const char *hostname, void *intercept) {
 
 static const char DNS_OPT[] = { 0x0, 0x0, 0x29, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
 
-#define DNS_NO_ERROR 0
-#define DNS_NXDOMAIN 3
-#define DNS_NOT_IMPL 4
-
 
 #define DNS_ID(p) (p[0] << 8 | p[1])
 #define DNS_FLAGS(p) (p[2] << 8 | p[3])
@@ -433,7 +441,7 @@ ssize_t on_dns_req(void *ziti_io_ctx, void *write_ctx, const uint8_t *q_packet, 
         req->addr.s_addr = entry->addr.u_addr.ip4.addr;
         req->code = DNS_NO_ERROR;
     } else {
-        req->code = DNS_NXDOMAIN;
+        req->code = dns_miss_code;
     }
 
     DONE:

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -51,6 +51,8 @@
 
 #define RESOLVECTL "resolvectl"
 
+extern void dns_set_miss_status(int code);
+
 static void dns_update_resolvectl(const char* tun, const char* addr);
 static void dns_update_resolvconf(const char* tun, const char* addr);
 static void dns_update_etc_resolv(const char* tun, const char* addr);
@@ -191,10 +193,10 @@ static void dns_update_etc_resolv(const char* tun, const char* addr) {
     int found = run_command("grep -q '^nameserver %s' /etc/resolv.conf", addr);
 
     if (found != 0) {
-        run_command("sed -zi 's/^nameserver/nameserver %s\\nnameserver' /etc/resolv.conf", addr);
+        run_command("sed -z -i 's/nameserver/nameserver %s\\nnameserver' /etc/resolv.conf", addr);
     }
 
-    ziti_dns_set_miss_code(5);
+    dns_set_miss_status(DNS_REFUSE);
 }
 
 static void after_set_dns(uv_work_t *wr, int status) {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -46,6 +46,7 @@
 
 extern dns_manager *get_dnsmasq_manager(const char* path);
 
+static int dns_miss_status = DNS_NXDOMAIN;
 static int dns_fallback(const char *name, void *ctx, struct in_addr* addr);
 
 static void send_message_to_tunnel();
@@ -826,8 +827,12 @@ static int run_opts(int argc, char *argv[]) {
     return optind;
 }
 
+void dns_set_miss_status(int status) {
+    dns_miss_status = status;
+}
+
 static int dns_fallback(const char *name, void *ctx, struct in_addr* addr) {
-    return 3; // NXDOMAIN
+    return dns_miss_status;
 }
 
 static void run(int argc, char *argv[]) {


### PR DESCRIPTION
The following methods are discovered and supported:
* resolvectl
* systemd-resolve
* resolvconf
* /etc/resolv.conf modification as the last resort