### PR TITLE
Copy file from windows bkp folder, log level fix and interface metric update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.26.20")
+    set(ZITI_SDK_C_BRANCH "0.26.24")
 endif()
 
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)

--- a/programs/ziti-edge-tunnel/include/instance.h
+++ b/programs/ziti-edge-tunnel/include/instance.h
@@ -58,7 +58,7 @@ void delete_identity_from_instance(char* identifier);
 
 void set_ip_info(uint32_t dns_ip, uint32_t tun_ip, int bits);
 
-void set_log_level(char* log_level);
+void set_log_level(int log_level);
 
 void set_service_version();
 

--- a/programs/ziti-edge-tunnel/include/instance.h
+++ b/programs/ziti-edge-tunnel/include/instance.h
@@ -62,7 +62,7 @@ void set_log_level(int log_level);
 
 void set_service_version();
 
-char* get_log_level();
+int get_log_level();
 
 void set_ziti_status(bool enabled, char* identifier);
 

--- a/programs/ziti-edge-tunnel/include/instance.h
+++ b/programs/ziti-edge-tunnel/include/instance.h
@@ -62,7 +62,7 @@ void set_log_level(int log_level);
 
 void set_service_version();
 
-int get_log_level();
+const char* get_log_level();
 
 void set_ziti_status(bool enabled, char* identifier);
 

--- a/programs/ziti-edge-tunnel/include/model/dtos.h
+++ b/programs/ziti-edge-tunnel/include/model/dtos.h
@@ -85,13 +85,21 @@ XX(IsAccessible, bool, none, IsAccessible, __VA_ARGS__) \
 XX(Timeout, int, none, Timeout, __VA_ARGS__)         \
 XX(TimeoutRemaining, int, none, TimeoutRemaining, __VA_ARGS__)
 
+#define LOG_LEVEL(XX, ...) \
+XX(error, __VA_ARGS__) \
+XX(warn, __VA_ARGS__) \
+XX(info, __VA_ARGS__) \
+XX(debug, __VA_ARGS__) \
+XX(verbose, __VA_ARGS__) \
+XX(trace, __VA_ARGS__)
+
 #define TUNNEL_STATUS(XX, ...) \
 XX(Active, bool, none, Active, __VA_ARGS__) \
 XX(Duration, int, none, Duration, __VA_ARGS__) \
 XX(StartTime, timestamp, none, StartTime, __VA_ARGS__) \
 XX(Identities, tunnel_identity, array, Identities, __VA_ARGS__) \
 XX(IpInfo, ip_info, ptr, IpInfo, __VA_ARGS__) \
-XX(LogLevel, string, none, LogLevel, __VA_ARGS__) \
+XX(LogLevel, log_level, none, LogLevel, __VA_ARGS__) \
 XX(ServiceVersion, service_version, ptr, ServiceVersion, __VA_ARGS__) \
 XX(TunIpv4, string, none, TunIpv4, __VA_ARGS__) \
 XX(TunIpv4Mask, int, none, TunIpv4Mask, __VA_ARGS__) \
@@ -134,6 +142,7 @@ DECLARE_MODEL(tunnel_service, TUNNEL_SERVICE)
 DECLARE_MODEL(tunnel_identity, TUNNEL_IDENTITY)
 DECLARE_MODEL(ip_info, IP_INFO)
 DECLARE_MODEL(service_version, SERVICE_VERSION)
+DECLARE_ENUM(log_level, LOG_LEVEL)
 DECLARE_MODEL(tunnel_status, TUNNEL_STATUS)
 
 #ifdef __cplusplus

--- a/programs/ziti-edge-tunnel/include/model/dtos.h
+++ b/programs/ziti-edge-tunnel/include/model/dtos.h
@@ -99,7 +99,7 @@ XX(Duration, int, none, Duration, __VA_ARGS__) \
 XX(StartTime, timestamp, none, StartTime, __VA_ARGS__) \
 XX(Identities, tunnel_identity, array, Identities, __VA_ARGS__) \
 XX(IpInfo, ip_info, ptr, IpInfo, __VA_ARGS__) \
-XX(LogLevel, log_level, none, LogLevel, __VA_ARGS__) \
+XX(LogLevel, string, none, LogLevel, __VA_ARGS__) \
 XX(ServiceVersion, service_version, ptr, ServiceVersion, __VA_ARGS__) \
 XX(TunIpv4, string, none, TunIpv4, __VA_ARGS__) \
 XX(TunPrefixLength, int, none, TunIpv4Mask, __VA_ARGS__) \

--- a/programs/ziti-edge-tunnel/include/model/events.h
+++ b/programs/ziti-edge-tunnel/include/model/events.h
@@ -87,17 +87,8 @@ XX(normal, __VA_ARGS__) \
 XX(connected, __VA_ARGS__) \
 XX(disconnected, __VA_ARGS__)
 
-#define LOG_LEVEL(XX, ...) \
-XX(error, __VA_ARGS__) \
-XX(warn, __VA_ARGS__) \
-XX(info, __VA_ARGS__) \
-XX(debug, __VA_ARGS__) \
-XX(verbose, __VA_ARGS__) \
-XX(trace, __VA_ARGS__)
-
 DECLARE_ENUM(event_severity, EVENT_SEVERITY)
 DECLARE_ENUM(event, EVENT_ACTIONS)
-DECLARE_ENUM(log_level, LOG_LEVEL)
 DECLARE_MODEL(status_event, STATUS_EVENT)
 DECLARE_MODEL(action_event, ACTION_EVENT)
 DECLARE_MODEL(tunnel_status_event, TUNNEL_STATUS_EVENT)

--- a/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
+++ b/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
@@ -32,5 +32,6 @@ void remove_all_nrpt_rules();
 bool is_nrpt_policies_effective(char* tns_ip);
 model_map *get_connection_specific_domains();
 void remove_and_add_nrpt_rules(uv_async_t *ar);
+void update_interface_metric(uv_loop_t *ziti_loop, char* tun_name, int metric);
 
 #endif //ZITI_TUNNEL_SDK_C_WINDOWS_SCRIPTS_H

--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -584,15 +584,26 @@ void set_ip_info(uint32_t dns_ip, uint32_t tun_ip, int bits) {
 
 }
 
-void set_log_level(int log_level) {
-    tnl_status.LogLevel = log_level;
+void set_log_level(char* log_level) {
+    if (tnl_status.LogLevel) {
+        free(tnl_status.LogLevel);
+    }
+    size_t len = strlen(log_level) + 1;
+    tnl_status.LogLevel = calloc(len, sizeof(char));
+    char log_lvl[len];
+    int i = 0;
+    while (*log_level != '\0') {
+        log_lvl[i++] = (char) tolower(*log_level++);
+    }
+    log_lvl[i] = '\0';
+    snprintf(tnl_status.LogLevel, len, "%s", log_lvl);
 }
 
-int get_log_level() {
+const char* get_log_level() {
     if (tnl_status.LogLevel) {
         return tnl_status.LogLevel;
     } else {
-        return log_level_Unknown;
+        return NULL;
     }
 }
 

--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -491,11 +491,13 @@ void initialize_tunnel_status() {
     uv_gettimeofday(&now);
     tnl_status.StartTime.tv_sec = now.tv_sec;
     tnl_status.StartTime.tv_usec = now.tv_usec;
-
+    if (tnl_status.LogLevel == log_level_Unknown) {
+        tnl_status.LogLevel = log_level_info;
+    }
 }
 
 bool load_tunnel_status(char* config_data) {
-    if (parse_tunnel_status(&tnl_status, config_data, strlen(config_data)) != 0) {
+    if (parse_tunnel_status(&tnl_status, config_data, strlen(config_data)) < 0) {
         free(config_data);
         ZITI_LOG(ERROR, "Could not read tunnel status from config data");
         return false;
@@ -578,16 +580,15 @@ void set_ip_info(uint32_t dns_ip, uint32_t tun_ip, int bits) {
 
 }
 
-void set_log_level(char* log_level) {
-    if (tnl_status.LogLevel) free(tnl_status.LogLevel);
-    tnl_status.LogLevel = strdup(log_level);
+void set_log_level(int log_level) {
+    tnl_status.LogLevel = log_level;
 }
 
-char* get_log_level() {
+int get_log_level() {
     if (tnl_status.LogLevel) {
         return tnl_status.LogLevel;
     } else {
-        return NULL;
+        return log_level_Unknown;
     }
 }
 

--- a/programs/ziti-edge-tunnel/netif_driver/windows/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/windows/tun.c
@@ -467,3 +467,7 @@ int set_dns(netif_handle tun, uint32_t dns_ip) {
     }
     return rc;
 }
+
+char* get_tun_name(netif_handle tun) {
+    return tun->name;
+}

--- a/programs/ziti-edge-tunnel/netif_driver/windows/tun.h
+++ b/programs/ziti-edge-tunnel/netif_driver/windows/tun.h
@@ -27,4 +27,6 @@ extern netif_driver tun_open(struct uv_loop_s *loop, uint32_t tun_ip, uint32_t d
 
 extern int set_dns(netif_handle tun, uint32_t dns_ip);
 
+extern char* get_tun_name(netif_handle tun);
+
 #endif //ZITI_TUNNEL_SDK_C_TUN_H

--- a/programs/ziti-edge-tunnel/windows-scripts.c
+++ b/programs/ziti-edge-tunnel/windows-scripts.c
@@ -357,3 +357,25 @@ model_map *get_connection_specific_domains() {
         return conn_sp_domains;
     }
 }
+
+void update_interface_metric(uv_loop_t *ziti_loop, char* tun_name, int metric) {
+    char* script = calloc(MAX_POWERSHELL_SCRIPT_LEN, sizeof(char));
+    size_t buf_len = sprintf(script, "$i=Get-NetIPInterface | Where -FilterScript {$_.InterfaceAlias -Eq \"%ls\"}\n", tun_name);
+    size_t copied = buf_len;
+    buf_len = sprintf(script + copied, "Set-NetIPInterface -InterfaceIndex $i.ifIndex -InterfaceMetric %d", metric);
+    copied += buf_len;
+
+    ZITI_LOG(TRACE, "Updating Interface metric using script. total script size: %d", copied);
+
+    char cmd[MAX_POWERSHELL_COMMAND_LEN];
+    snprintf(cmd, sizeof(cmd),"powershell -Command \"%s\"", script);
+
+    ZITI_LOG(DEBUG, "Executing Update Interface metric script :");
+    ZITI_LOG(DEBUG, "%s", cmd);
+    char* args[] = {"powershell", "-Command", script, NULL};
+    bool result = exec_process(ziti_loop, args[0], args);
+    if (!result) {
+        ZITI_LOG(WARN, "Update Interface metric script: %d(err=%d)", result, GetLastError());
+    }
+    free(script);
+}

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -58,7 +58,7 @@ typedef char * (*to_json_fn)(const void * msg, int flags, size_t *len);
 static void send_events_message(const void *message, to_json_fn to_json_f, bool displayEvent);
 static void send_tunnel_command(tunnel_command *tnl_cmd, void *ctx);
 #if _WIN32
-static void move_config_from_backup(uv_loop_t *loop);
+static void move_config_from_previous_windows_backup(uv_loop_t *loop);
 #endif
 
 struct cfg_instance_s {
@@ -339,11 +339,13 @@ static bool process_tunnel_commands(const tunnel_command *tnl_cmd, command_cb cb
                 break;
             }
             log_level lvl = log_level_value_of(tunnel_set_log_level_cmd.loglevel);
+            // int lvl = get_debug_level(tunnel_set_log_level_cmd.loglevel); // can be used only after c-sdk PR is merged
 
-            if (lvl != log_level_Unknown) {
+            if (lvl != -1) {
                 if (ziti_log_level() != lvl) {
-                    set_log_level(tunnel_set_log_level_cmd.loglevel);
+                    set_log_level(lvl);
                     ziti_log_set_level(lvl);
+                    ziti_tunnel_set_log_level(lvl);
                     ZITI_LOG(INFO, "Log level is set to %s", tunnel_set_log_level_cmd.loglevel);
                 } else {
                     ZITI_LOG(INFO, "Log level is already set to %s", tunnel_set_log_level_cmd.loglevel);
@@ -1414,8 +1416,6 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
     }
 
     free(tunneler);
-    uv_close((uv_handle_t *) &cmd_server, (uv_close_cb) free);
-    uv_close((uv_handle_t *) &event_server, (uv_close_cb) free);
 #if _WIN32
     close_log();
 #endif
@@ -1597,7 +1597,7 @@ static void run(int argc, char *argv[]) {
     } else {
         ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, NULL);
     }
-    move_config_from_backup(ziti_loop);
+    move_config_from_previous_windows_backup(ziti_loop);
     ZITI_LOG(INFO,"Loading identity files from %s", config_dir);
 #else
     ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, NULL);
@@ -2561,14 +2561,12 @@ void scm_service_stop() {
     }
 }
 
-static void move_config_from_backup(uv_loop_t *loop) {
-    char **backup_folders = calloc(3, sizeof(char*));
-    char **bkp_temp = backup_folders;
-    *bkp_temp = "Windows.~BT\\Windows\\System32\\config\\systemprofile\\AppData\\Roaming\\NetFoundry";
-    bkp_temp++;
-    *bkp_temp = "Windows.old\\Windows\\System32\\config\\systemprofile\\AppData\\Roaming\\NetFoundry";
-    bkp_temp++;
-    *bkp_temp = '\0';
+static void move_config_from_previous_windows_backup(uv_loop_t *loop) {
+    char *backup_folders[] = {
+        "Windows.~BT\\Windows\\System32\\config\\systemprofile\\AppData\\Roaming\\NetFoundry",
+        "Windows.old\\Windows\\System32\\config\\systemprofile\\AppData\\Roaming\\NetFoundry",
+        NULL
+    };
 
     char* system_drive = getenv("SystemDrive");
 
@@ -2596,9 +2594,9 @@ static void move_config_from_backup(uv_loop_t *loop) {
         while (uv_fs_scandir_next(&fs, &file) == 0) {
             if (file.type == UV_DIRENT_FILE) {
                 char old_file[FILENAME_MAX];
-                sprintf(old_file, "%s\\%s", config_dir_bkp, file.name);
+                snprintf(old_file, FILENAME_MAX, "%s\\%s", config_dir_bkp, file.name);
                 char new_file[FILENAME_MAX];
-                sprintf(new_file, "%s\\%s", config_dir, file.name);
+                snprintf(new_file, FILENAME_MAX, "%s\\%s", config_dir, file.name);
                 uv_fs_t fs_cpy;
                 rc = uv_fs_copyfile(loop, &fs_cpy, old_file, new_file, 0, NULL);
                 if (rc == 0) {
@@ -2615,7 +2613,6 @@ static void move_config_from_backup(uv_loop_t *loop) {
         config_dir_bkp = NULL;
         uv_fs_req_cleanup(&fs);
     }
-    free(backup_folders);
 }
 #endif
 

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -338,23 +338,17 @@ static bool process_tunnel_commands(const tunnel_command *tnl_cmd, command_cb cb
                 result.success = false;
                 break;
             }
-            log_level lvl = log_level_value_of(tunnel_set_log_level_cmd.loglevel);
-            // int lvl = get_debug_level(tunnel_set_log_level_cmd.loglevel); // can be used only after c-sdk PR is merged
 
-            if (lvl != -1) {
-                if (ziti_log_level() != lvl) {
-                    set_log_level(lvl);
-                    ziti_log_set_level(lvl);
-                    ziti_tunnel_set_log_level(lvl);
-                    ZITI_LOG(INFO, "Log level is set to %s", tunnel_set_log_level_cmd.loglevel);
-                } else {
-                    ZITI_LOG(INFO, "Log level is already set to %s", tunnel_set_log_level_cmd.loglevel);
-                }
-                result.success = true;
+            if (stricmp(ziti_log_level_label(), tunnel_set_log_level_cmd.loglevel) != 0) {
+                ziti_log_set_level_by_label(tunnel_set_log_level_cmd.loglevel);
+                ziti_tunnel_set_log_level(ziti_log_level());
+                set_log_level(tunnel_set_log_level_cmd.loglevel);
+                ZITI_LOG(INFO, "Log level is set to %s", tunnel_set_log_level_cmd.loglevel);
             } else {
-                result.error = "invalid loglevel";
-                result.success = false;
+                ZITI_LOG(INFO, "Log level is already set to %s", tunnel_set_log_level_cmd.loglevel);
             }
+            result.success = true;
+
             break;
         }
         case TunnelCommand_UpdateTunIpv4: {
@@ -1107,7 +1101,7 @@ static void on_event(const base_event *ev) {
             ziti_service **zs;
 #if _WIN32
             model_map *hostnamesToAdd = calloc(1, sizeof(model_map));
-            model_map *hostnamesToRemove = calloc(1, sizeof(model_map));;
+            model_map *hostnamesToRemove = calloc(1, sizeof(model_map));
 #endif
             if (svc_ev->removed_services != NULL) {
                 int svc_array_length = 0;
@@ -1573,19 +1567,12 @@ static void run(int argc, char *argv[]) {
     // set ip info into instance
     set_ip_info(dns_ip, tun_ip, bits);
 
-    // set log level from instance/config, if NULL is returned, the default log level will be used
-    int log_lvl_val = ZITI_LOG_DEFAULT_LEVEL;
-    int log_lvl = get_log_level();
-    if (log_lvl != log_lvl_val) {
-        log_lvl_val = log_lvl;
-    }
-
     // set the service version in instance
     set_service_version();
 
 #if _WIN32
     if (init) {
-        ziti_log_init(ziti_loop, log_lvl_val, ziti_log_writer);
+        ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, ziti_log_writer);
         struct tm *start_time = get_log_start_time();
         char time_val[32];
         strftime(time_val, sizeof(time_val), "%a %b %d %Y, %X %p", start_time);
@@ -1603,8 +1590,13 @@ static void run(int argc, char *argv[]) {
     ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, NULL);
 #endif
 
-    set_log_level(ziti_log_level());
+    // set log level from instance/config, if NULL is returned, the default log level will be used
+    char* log_lvl = get_log_level();
+    if (log_lvl != NULL) {
+        ziti_log_set_level_by_label(log_lvl);
+    }
     ziti_tunnel_set_log_level(ziti_log_level());
+    set_log_level(ziti_log_level_label());
     ziti_tunnel_set_logger(ziti_logger);
 
     if (ziti_loop == NULL) {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -339,10 +339,10 @@ static bool process_tunnel_commands(const tunnel_command *tnl_cmd, command_cb cb
                 break;
             }
 
-            if (stricmp(ziti_log_level_label(), tunnel_set_log_level_cmd.loglevel) != 0) {
+            if (strcasecmp(ziti_log_level_label(), tunnel_set_log_level_cmd.loglevel) != 0) {
                 ziti_log_set_level_by_label(tunnel_set_log_level_cmd.loglevel);
                 ziti_tunnel_set_log_level(ziti_log_level());
-                set_log_level(tunnel_set_log_level_cmd.loglevel);
+                set_log_level(ziti_log_level_label());
                 ZITI_LOG(INFO, "Log level is set to %s", tunnel_set_log_level_cmd.loglevel);
             } else {
                 ZITI_LOG(INFO, "Log level is already set to %s", tunnel_set_log_level_cmd.loglevel);


### PR DESCRIPTION
This PR contains the below functionalities.

1. During windows upgrade, the identity files will be backed up to a backup folder. The backup files will be in the windows.old or windows.~bt path. So WDE will search for the identities files in those paths and if it find any identities, those files will be moved to the config/identity path.
2. fixes for the set and get log level. Changed it from char* to int value.
3. Update the interface metric to 255 when nrpt is effective/dns flag is off. Update the interface metric to 5 when nrpt is not effective/dns flag is on.