### PR TITLE
update ziti sdk to 0.26.18 for libsodium build fixes (v0.17.x)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.26.15")
+    set(ZITI_SDK_C_BRANCH "0.26.18")
 endif()
 
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)


### PR DESCRIPTION
James ran into the illegal instruction crash when testing 0.17.21. There's a bunch of stuff on `main` since 0.17.21 that I don't think is ready for customers yet so I'm creating a 0.17.x branch.