### PR TITLE
resume sourcing latest container image tag

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,15 +1,14 @@
 version: "3.9"
 
 x-base-service: &base-service
-    image: docker.io/netfoundry/ziti-edge-tunnel:0.17.14-multi # TODO: revert to :latest with 0.17.15 when multi-identity support is merged
-    #image: netfoundry/ziti-edge-tunnel:latest # https://hub.docker.com/repository/docker/netfoundry/ziti-edge-tunnel/tags?page=1&ordering=last_updated
+    image: netfoundry/ziti-edge-tunnel:latest # https://hub.docker.com/repository/docker/netfoundry/ziti-edge-tunnel/tags?page=1&ordering=last_updated
     devices:
     - /dev/net/tun:/dev/net/tun
     volumes:
     - .:/ziti-edge-tunnel
     - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     environment:
-    - NF_REG_NAME            # inherit when run like this: NF_REG_NAME=AcmeIdentity
+    - NF_REG_NAME            # inherit when run like this: NF_REG_NAME=AcmeIdentity docker-compose up ziti-tun
     network_mode: host       # use the Docker host's network, not the Docker bridge
     privileged: true
 


### PR DESCRIPTION
enhance docker entrypoint

preserve Docker Compose examples for dnsmasq as a reference

reconcile entrypoint variants for multi-id and stdin