### PR TITLE
update logger function to match updated ziti_log signature

### DIFF
--- a/lib/ziti-tunnel-cbs/CMakeLists.txt
+++ b/lib/ziti-tunnel-cbs/CMakeLists.txt
@@ -14,6 +14,10 @@ add_library(ziti-tunnel-cbs-c STATIC
         dns_host.c
         dns_host.h)
 
+target_compile_definitions(ziti-tunnel-cbs-c
+        PRIVATE ZITI_LOG_MODULE="tunnel-cbs"
+        )
+
 target_include_directories(ziti-tunnel-cbs-c
         PUBLIC include
         )

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
@@ -32,6 +32,8 @@
 #define HOST_NAME_MAX 254
 #endif
 
+#define ZITI_LOG_MODULE "tunnel-cbs"
+
 // temporary list to pass info between parse and run
 // static LIST_HEAD(instance_list, ziti_instance_s) instance_init_list;
 

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
@@ -32,8 +32,6 @@
 #define HOST_NAME_MAX 254
 #endif
 
-#define ZITI_LOG_MODULE "tunnel-cbs"
-
 // temporary list to pass info between parse and run
 // static LIST_HEAD(instance_list, ziti_instance_s) instance_init_list;
 

--- a/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
+++ b/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
@@ -51,7 +51,7 @@ typedef struct hosted_io_ctx_s *hosted_io_context;
 typedef struct hosted_service_ctx_s host_ctx_t;
 typedef struct io_ctx_s io_ctx_t;
 
-typedef void (*tunnel_logger_f)(int level, const char *file, unsigned int line, const char *func, const char *fmt, ...);
+typedef void (*tunnel_logger_f)(int level, const char *module, const char *file, unsigned int line, const char *func, const char *fmt, ...);
 
 typedef enum {
     CLIENT_CFG_V1,    // ziti-tunnel-client.v1

--- a/lib/ziti-tunnel/ziti_tunnel_priv.h
+++ b/lib/ziti-tunnel/ziti_tunnel_priv.h
@@ -36,11 +36,11 @@ enum {
 };
 
 #define TNL_LOG(level, fmt, ...) do { \
-if (tunnel_logger && level <= tunnel_log_level) { tunnel_logger(level, __FILE__, __LINE__, __func__, fmt, ##__VA_ARGS__); }\
+if (tunnel_logger && level <= tunnel_log_level) { tunnel_logger(level, "tunnel-sdk", __FILE__, __LINE__, __func__, fmt, ##__VA_ARGS__); }\
 } while(0)
 
 extern int tunnel_log_level;
-typedef void (*tunnel_logger_f)(int level, const char *file, unsigned int line, const char *func, const char *fmt, ...);
+typedef void (*tunnel_logger_f)(int level, const char *module, const char *file, unsigned int line, const char *func, const char *fmt, ...);
 extern tunnel_logger_f tunnel_logger;
 
 struct intercept_ctx_s {

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -40,6 +40,7 @@ target_include_directories(ziti-edge-tunnel
 target_compile_definitions(ziti-edge-tunnel
         PRIVATE GIT_VERSION=${GIT_VERSION}
         PRIVATE ZITI_LOG_PREFIX=${PROJECT_NAME}
+        PRIVATE ZITI_LOG_MODULE="ziti-edge-tunnel"
         )
 
 target_link_libraries(ziti-edge-tunnel


### PR DESCRIPTION
TNL_LOG was crashing on Windows, fyi.