### PR TITLE
enable TCP KEEPALIVE on tunneler TCP connections

### DIFF
--- a/lib/ziti-tunnel/lwip/lwipopts.h
+++ b/lib/ziti-tunnel/lwip/lwipopts.h
@@ -41,6 +41,11 @@
 
 #define LWIP_SINGLE_NETIF 1               /* avoid some lwip "routing" logic */
 
+#define LWIP_TCP_KEEPALIVE 1
+#define TCP_KEEPIDLE_DEFAULT 30000       /* 30 seconds of idle before starting to send KEEPALIVE packets */
+#define TCP_KEEPINTVL_DEFAULT 10000      /* 10 seconds interval between KEEPALIVE packets */
+#define TCP_KEEPCNT_DEFAULT 3            /* number of missed KEEPALIVE ACKs to consider the client dead */
+
 // APIs
 #define LWIP_RAW 1
 #define LWIP_NETCONN 0

--- a/lib/ziti-tunnel/tunnel_tcp.c
+++ b/lib/ziti-tunnel/tunnel_tcp.c
@@ -253,6 +253,7 @@ void tunneler_tcp_dial_completed(struct io_ctx_s *io, bool ok) {
 
     struct tcp_pcb *pcb = io->tnlr_io->tcp;
     tcp_arg(pcb, io);
+    ip_set_option(pcb, SOF_KEEPALIVE);
     tcp_recv(pcb, on_tcp_client_data);
     tcp_err(pcb, on_tcp_client_err);
 


### PR DESCRIPTION
prevent connection leaks from misbehaving clients