### PR TITLE
Avoid.concurrency.with.loop

### DIFF
--- a/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
+++ b/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
@@ -94,7 +94,7 @@ typedef void * (*ziti_sdk_dial_cb)(const void *app_intercept_ctx, io_ctx_t *io);
 typedef int (*ziti_sdk_close_cb)(void *ziti_io_ctx);
 typedef ssize_t (*ziti_sdk_write_cb)(const void *ziti_io_ctx, void *write_ctx, const void *data, size_t len);
 typedef host_ctx_t * (*ziti_sdk_host_cb)(void *ziti_ctx, uv_loop_t *loop, const char *service_name, cfg_type_e cfg_type, const void *cfg);
-typedef void (*ziti_tunneler_call_cb)(void *ctx);
+typedef void (*ziti_tunneler_call_cb)(uv_loop_t *loop, void *ctx);
 
 /** data needed to intercept packets and dial the associated ziti service */
 typedef struct intercept_ctx_s  intercept_ctx_t;

--- a/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
+++ b/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
@@ -94,7 +94,6 @@ typedef void * (*ziti_sdk_dial_cb)(const void *app_intercept_ctx, io_ctx_t *io);
 typedef int (*ziti_sdk_close_cb)(void *ziti_io_ctx);
 typedef ssize_t (*ziti_sdk_write_cb)(const void *ziti_io_ctx, void *write_ctx, const void *data, size_t len);
 typedef host_ctx_t * (*ziti_sdk_host_cb)(void *ziti_ctx, uv_loop_t *loop, const char *service_name, cfg_type_e cfg_type, const void *cfg);
-typedef void (*ziti_tunneler_call_cb)(uv_loop_t *loop, void *ctx);
 
 /** data needed to intercept packets and dial the associated ziti service */
 typedef struct intercept_ctx_s  intercept_ctx_t;
@@ -132,11 +131,6 @@ typedef struct tunneler_sdk_options_s {
     ziti_sdk_write_cb   ziti_write;
     ziti_sdk_host_cb    ziti_host;
 } tunneler_sdk_options;
-
-typedef struct tunneler_cmd_request_s {
-    ziti_tunneler_call_cb tnl_cmd_cb;
-    void *ctx;
-} tunneler_cmd_request;
 
 extern address_t *parse_address(const char *ip_or_cidr);
 extern port_range_t *parse_port_range(uint16_t low, uint16_t high);
@@ -181,7 +175,8 @@ extern const char* ziti_tunneler_build_date();
 extern void ziti_tunnel_set_logger(tunnel_logger_f logger);
 extern void ziti_tunnel_set_log_level(int lvl);
 
-extern void ziti_tunneler_call_function(uv_loop_t *loop, ziti_tunneler_call_cb tnl_call_cb, void *ctx);
+typedef void (*ziti_tunnel_async_fn)(void *ctx);
+extern void ziti_tunnel_async_send(tunneler_context tctx, ziti_tunnel_async_fn f, void *arg);
 
 #ifdef __cplusplus
 }

--- a/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
+++ b/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
@@ -175,7 +175,7 @@ extern const char* ziti_tunneler_build_date();
 extern void ziti_tunnel_set_logger(tunnel_logger_f logger);
 extern void ziti_tunnel_set_log_level(int lvl);
 
-typedef void (*ziti_tunnel_async_fn)(void *ctx);
+typedef void (*ziti_tunnel_async_fn)(uv_loop_t *loop, void *ctx);
 extern void ziti_tunnel_async_send(tunneler_context tctx, ziti_tunnel_async_fn f, void *arg);
 
 #ifdef __cplusplus

--- a/lib/ziti-tunnel/ziti_tunnel.c
+++ b/lib/ziti-tunnel/ziti_tunnel.c
@@ -577,7 +577,7 @@ static void async_close_cb(uv_handle_t *async) {
 static void ziti_tunnel_async_wrapper(uv_async_t *async) {
     ziti_tunnel_async_call_t *call = async->data;
     if (call != NULL && call->f != NULL) {
-        call->f(call->arg);
+        call->f(async->loop, call->arg);
     }
     uv_close((uv_handle_t *)async, async_close_cb);
 }

--- a/lib/ziti-tunnel/ziti_tunnel.c
+++ b/lib/ziti-tunnel/ziti_tunnel.c
@@ -76,7 +76,7 @@ tunneler_context ziti_tunneler_init(tunneler_sdk_options *opts, uv_loop_t *loop)
         return NULL;
     }
     ctx->loop = loop;
-    uv_sem_init(ctx->sem, 0);
+    uv_sem_init(&ctx->sem, 0);
     uv_once(&default_loop_sem_init_once, default_loop_sem_init);
     memcpy(&ctx->opts, opts, sizeof(ctx->opts));
     LIST_INIT(&ctx->intercepts);
@@ -588,7 +588,7 @@ void ziti_tunnel_async_send(tunneler_context tctx, ziti_tunnel_async_fn f, void 
     uv_sem_t *sem = &default_loop_sem;
     if (tctx != NULL) {
         loop = tctx->loop;
-        sem = tctx->sem;
+        sem = &tctx->sem;
     }
 
     ziti_tunnel_async_call_t *call = calloc(1, sizeof(ziti_tunnel_async_call_t));
@@ -601,7 +601,7 @@ void ziti_tunnel_async_send(tunneler_context tctx, ziti_tunnel_async_fn f, void 
     int e = uv_async_init(loop, async, ziti_tunnel_async_wrapper);
     uv_sem_post(sem);
     if (e != 0) {
-        TNL_LOG(ERROR, "uv_async_init error: %s", uv_err_name(e));
+        TNL_LOG(ERR, "uv_async_init error: %s", uv_err_name(e));
         free(call);
         free(async);
         return;

--- a/lib/ziti-tunnel/ziti_tunnel.c
+++ b/lib/ziti-tunnel/ziti_tunnel.c
@@ -554,7 +554,7 @@ static void run_packet_loop(uv_loop_t *loop, tunneler_context tnlr_ctx) {
 
 void execute_tnl_after_cb(uv_work_t *wr, int status) {
     tunneler_cmd_request *tnl_cmd_req = wr->data;
-    tnl_cmd_req->tnl_cmd_cb(tnl_cmd_req->ctx);
+    tnl_cmd_req->tnl_cmd_cb(wr->loop, tnl_cmd_req->ctx);
 }
 
 void execute_tnl_cb(uv_work_t *wr) {

--- a/lib/ziti-tunnel/ziti_tunnel.c
+++ b/lib/ziti-tunnel/ziti_tunnel.c
@@ -555,6 +555,7 @@ static void run_packet_loop(uv_loop_t *loop, tunneler_context tnlr_ctx) {
 void execute_tnl_after_cb(uv_work_t *wr, int status) {
     tunneler_cmd_request *tnl_cmd_req = wr->data;
     tnl_cmd_req->tnl_cmd_cb(wr->loop, tnl_cmd_req->ctx);
+    free(wr);
 }
 
 void execute_tnl_cb(uv_work_t *wr) {

--- a/lib/ziti-tunnel/ziti_tunnel.c
+++ b/lib/ziti-tunnel/ziti_tunnel.c
@@ -55,6 +55,13 @@ static void run_packet_loop(uv_loop_t *loop, tunneler_context tnlr_ctx);
 
 STAILQ_HEAD(tlnr_ctx_list_s, tunneler_ctx_s) tnlr_ctx_list_head = STAILQ_HEAD_INITIALIZER(tnlr_ctx_list_head);
 
+// todo expose tunneler_context to modules that need `ziti_tunnel_async_send` (e.g. windows-scripts) so these can be removed
+static uv_once_t default_loop_sem_init_once = UV_ONCE_INIT;
+static uv_sem_t default_loop_sem;
+static void default_loop_sem_init(void) {
+    uv_sem_init(&default_loop_sem, 0);
+}
+
 tunneler_context ziti_tunneler_init(tunneler_sdk_options *opts, uv_loop_t *loop) {
     TNL_LOG(INFO, "Ziti Tunneler SDK (%s)", ziti_tunneler_version());
 
@@ -69,6 +76,8 @@ tunneler_context ziti_tunneler_init(tunneler_sdk_options *opts, uv_loop_t *loop)
         return NULL;
     }
     ctx->loop = loop;
+    uv_sem_init(ctx->sem, 0);
+    uv_once(&default_loop_sem_init_once, default_loop_sem_init);
     memcpy(&ctx->opts, opts, sizeof(ctx->opts));
     LIST_INIT(&ctx->intercepts);
     run_packet_loop(loop, ctx);
@@ -552,23 +561,53 @@ static void run_packet_loop(uv_loop_t *loop, tunneler_context tnlr_ctx) {
     uv_timer_start(&tnlr_ctx->lwip_timer_req, check_lwip_timeouts, 0, 10);
 }
 
-void execute_tnl_after_cb(uv_work_t *wr, int status) {
-    tunneler_cmd_request *tnl_cmd_req = wr->data;
-    tnl_cmd_req->tnl_cmd_cb(wr->loop, tnl_cmd_req->ctx);
-    free(wr);
+typedef struct ziti_tunnel_async_call_s {
+    ziti_tunnel_async_fn f;
+    void *               arg;
+} ziti_tunnel_async_call_t;
+
+static void async_close_cb(uv_handle_t *async) {
+    if (async->data != NULL) {
+        free(async->data);
+    }
+    free(async);
 }
 
-void execute_tnl_cb(uv_work_t *wr) {
-    TNL_LOG(TRACE, "Tunneler work queue called");
+/** invoke a caller-supplied function with argument. this is called by libuv on the loop thread */
+static void ziti_tunnel_async_wrapper(uv_async_t *async) {
+    ziti_tunnel_async_call_t *call = async->data;
+    if (call != NULL && call->f != NULL) {
+        call->f(call->arg);
+    }
+    uv_close((uv_handle_t *)async, async_close_cb);
 }
 
-void ziti_tunneler_call_function(uv_loop_t *loop, ziti_tunneler_call_cb tnl_call_cb, void *ctx) {
-    tunneler_cmd_request *tnl_cmd_req = calloc(1, sizeof(tunneler_cmd_request));
-    tnl_cmd_req->tnl_cmd_cb = tnl_call_cb;
-    tnl_cmd_req->ctx = ctx;
-    uv_work_t *loader = calloc(1, sizeof(uv_work_t));
-    loader->data = tnl_cmd_req;
-    uv_queue_work(loop, loader, execute_tnl_cb, execute_tnl_after_cb);
+/** sets up a function call on the specified loop */
+void ziti_tunnel_async_send(tunneler_context tctx, ziti_tunnel_async_fn f, void *arg) {
+    uv_loop_t *loop = uv_default_loop();
+    uv_sem_t *sem = &default_loop_sem;
+    if (tctx != NULL) {
+        loop = tctx->loop;
+        sem = tctx->sem;
+    }
+
+    ziti_tunnel_async_call_t *call = calloc(1, sizeof(ziti_tunnel_async_call_t));
+    call->f = f;
+    call->arg = arg;
+
+    uv_async_t *async = calloc(1, sizeof(uv_async_t));
+
+    uv_sem_wait(sem);
+    int e = uv_async_init(loop, async, ziti_tunnel_async_wrapper);
+    uv_sem_post(sem);
+    if (e != 0) {
+        TNL_LOG(ERROR, "uv_async_init error: %s", uv_err_name(e));
+        free(call);
+        free(async);
+        return;
+    }
+
+    uv_async_send(async);
 }
 
 #define _str(x) #x

--- a/lib/ziti-tunnel/ziti_tunnel_priv.h
+++ b/lib/ziti-tunnel/ziti_tunnel_priv.h
@@ -71,6 +71,7 @@ typedef struct tunneler_ctx_s {
     struct raw_pcb *tcp;
     struct raw_pcb *udp;
     uv_loop_t      *loop;
+    uv_sem_t     sem;
     uv_poll_t    netif_poll_req;
     uv_timer_t   lwip_timer_req;
     LIST_HEAD(intercept_ctx_list_s, intercept_ctx_s) intercepts;

--- a/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
+++ b/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
@@ -26,12 +26,12 @@
 #define BUFFER_SIZE 1024
 #endif
 
-void add_nrpt_rules(uv_async_t *ar);
-void remove_nrpt_rules(uv_async_t *ar);
+void add_nrpt_rules(uv_loop_t *loop, void *ctx);
+void remove_nrpt_rules(uv_loop_t *loop, void *ctx);
 void remove_all_nrpt_rules();
 bool is_nrpt_policies_effective(char* tns_ip);
 model_map *get_connection_specific_domains();
-void remove_and_add_nrpt_rules(uv_async_t *ar);
+void remove_and_add_nrpt_rules(uv_loop_t *loop, void *ctx);
 void update_interface_metric(uv_loop_t *ziti_loop, char* tun_name, int metric);
 void update_symlink(uv_loop_t *symlink_loop, char* symlink, char* filename);
 

--- a/programs/ziti-edge-tunnel/include/windows/windows-service.h
+++ b/programs/ziti-edge-tunnel/include/windows/windows-service.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-int SvcStart(TCHAR *);
+VOID SvcStart(VOID);
 VOID SvcInstall(void);
 VOID WINAPI SvcMain( DWORD, LPTSTR * );
 VOID ReportSvcStatus( DWORD, DWORD, DWORD );
@@ -30,7 +30,7 @@ DWORD LphandlerFunctionEx(
 );
 
 void scm_service_init(char *config_dir);
-void scm_service_run(void *);
+void scm_service_run(const char *);
 void scm_running_event();
 void scm_service_stop();
 void stop_windows_service();

--- a/programs/ziti-edge-tunnel/netif_driver/windows/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/windows/tun.c
@@ -494,13 +494,8 @@ static void cleanup_adapters(wchar_t *tun_name) {
     WintunEnumAdapters(L"Ziti", tun_delete_cb, tun_name);
 }
 
+// close session causes the segmentation fault when the adapter is running
 int tun_kill() {
-    uv_once(&wintunInit, InitializeWintun);
-    if (WINTUN == NULL) {
-        ZITI_LOG(DEBUG, "Failed to load wintun.dll");
-        return NULL;
-    }
-    BOOL rr;
     WINTUN_ADAPTER_HANDLE adapter = WintunOpenAdapter(L"Ziti", ZITI_TUN);
     if (adapter) {
         ZITI_LOG(DEBUG, "Closing wintun adapter");

--- a/programs/ziti-edge-tunnel/windows-scripts.c
+++ b/programs/ziti-edge-tunnel/windows-scripts.c
@@ -208,13 +208,10 @@ void add_nrpt_rules_script(uv_loop_t *nrpt_loop, struct add_or_edit_service_nrpt
     free(add_svc_req_data);
 }
 
-void add_nrpt_rules(uv_async_t *ar) {
+void add_nrpt_rules(uv_loop_t *nrpt_loop, void *ctx) {
     ZITI_LOG(VERBOSE, "Add nrpt rules");
 
-    struct add_or_edit_service_nrpt_req *add_svc_req_data = ar->data;
-    uv_loop_t *nrpt_loop = ar->loop;
-
-    uv_close((uv_handle_t *) ar, (uv_close_cb) free);
+    struct add_or_edit_service_nrpt_req *add_svc_req_data = ctx;
 
     add_nrpt_rules_script(nrpt_loop, add_svc_req_data);
 }
@@ -309,12 +306,9 @@ void remove_nrpt_rules_script(uv_loop_t *nrpt_loop, model_map *hostnames) {
     free(hostnames);
 }
 
-void remove_nrpt_rules(uv_async_t *ar) {
+void remove_nrpt_rules(uv_loop_t *nrpt_loop, void *ctx) {
     ZITI_LOG(VERBOSE, "Remove nrpt rules");
-    model_map *hostnames = ar->data;
-    uv_loop_t *nrpt_loop = ar->loop;
-
-    uv_close((uv_handle_t *) ar, (uv_close_cb) free);
+    model_map *hostnames = ctx;
 
     remove_nrpt_rules_script(nrpt_loop, hostnames);
 }
@@ -440,12 +434,9 @@ void remove_and_add_nrpt_rules_script(uv_loop_t *nrpt_loop, struct add_or_edit_s
     free(hostnames);
 }
 
-void remove_and_add_nrpt_rules(uv_async_t *ar) {
+void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, void *ctx) {
     ZITI_LOG(VERBOSE, "Remove and add nrpt rules");
-    struct add_or_edit_service_nrpt_req *add_or_edit_svc_req_data = ar->data;
-    uv_loop_t *nrpt_loop = ar->loop;
-
-    uv_close((uv_handle_t *) ar, (uv_close_cb) free);
+    struct add_or_edit_service_nrpt_req *add_or_edit_svc_req_data = ctx;
 
     remove_and_add_nrpt_rules_script(nrpt_loop, add_or_edit_svc_req_data);
 }

--- a/programs/ziti-edge-tunnel/windows-service.c
+++ b/programs/ziti-edge-tunnel/windows-service.c
@@ -456,8 +456,6 @@ DWORD LphandlerFunctionEx(
 
             // stops the running tunnel service
             scm_service_stop();
-            // stops the windows service in scm
-            stop_windows_service();
 
             return 0;
 

--- a/programs/ziti-edge-tunnel/windows-service.c
+++ b/programs/ziti-edge-tunnel/windows-service.c
@@ -40,7 +40,7 @@ HANDLE                  ghSvcRunningEvent = NULL;
 // Return value:
 //   None, defaults to 0 (zero)
 //
-int SvcStart(TCHAR *opt)
+VOID SvcStart(VOID)
 {
     // the service is probably being started by the SCM.
     // Add any additional services for the process to this table.
@@ -55,7 +55,7 @@ int SvcStart(TCHAR *opt)
 
     if (!StartServiceCtrlDispatcher( DispatchTable ))
     {
-        return 0;
+        printf("StartServiceCtrlDispatcher failed (%ld)\n", GetLastError());
     }
 }
 
@@ -77,7 +77,7 @@ VOID SvcInstall()
 
     if( !GetModuleFileName( NULL, szPath, MAX_PATH ) )
     {
-        printf("Cannot install service (%d)\n", GetLastError());
+        printf("Cannot install service (%ld)\n", GetLastError());
         return;
     }
 
@@ -90,7 +90,7 @@ VOID SvcInstall()
 
     if (NULL == schSCManager)
     {
-        printf("OpenSCManager failed (%d)\n", GetLastError());
+        printf("OpenSCManager failed (%ld)\n", GetLastError());
         return;
     }
 
@@ -113,7 +113,7 @@ VOID SvcInstall()
 
     if (schService == NULL)
     {
-        printf("CreateService failed (%d)\n", GetLastError());
+        printf("CreateService failed (%ld)\n", GetLastError());
         CloseServiceHandle(schSCManager);
         return;
     }
@@ -202,7 +202,7 @@ VOID SvcInit( DWORD dwArgc, LPTSTR *lpszArgv)
     }
 
     // start tunnel
-    CreateThread (NULL, 0, ServiceWorkerThread, lpszArgv, 0, NULL);
+    CreateThread (NULL, 0, ServiceWorkerThread, lpszArgv[0], 0, NULL);
 
     // Check whether the service is started
 
@@ -324,7 +324,7 @@ VOID SvcReportEvent(LPTSTR szMessage, DWORD eventType)
 
     if( NULL != hEventSource )
     {
-        snprintf(Buffer, 80, TEXT("%s, reported status : %d"), szMessage, GetLastError());
+        snprintf(Buffer, 80, TEXT("%s, reported status : %ld"), szMessage, GetLastError());
 
         lpszStrings[0] = SVCNAME;
         lpszStrings[1] = Buffer;
@@ -357,7 +357,6 @@ VOID SvcDelete()
 {
     SC_HANDLE schSCManager;
     SC_HANDLE schService;
-    SERVICE_STATUS ssStatus;
 
     // Get a handle to the SCM database.
 
@@ -368,7 +367,7 @@ VOID SvcDelete()
 
     if (NULL == schSCManager)
     {
-        printf("OpenSCManager failed (%d)\n", GetLastError());
+        printf("OpenSCManager failed (%ld)\n", GetLastError());
         return;
     }
 
@@ -381,7 +380,7 @@ VOID SvcDelete()
 
     if (schService == NULL)
     {
-        printf("OpenService failed (%d)\n", GetLastError());
+        printf("OpenService failed (%ld)\n", GetLastError());
         CloseServiceHandle(schSCManager);
         return;
     }
@@ -390,7 +389,7 @@ VOID SvcDelete()
 
     if (! DeleteService(schService) )
     {
-        printf("DeleteService failed (%d)\n", GetLastError());
+        printf("DeleteService failed (%ld)\n", GetLastError());
     }
     else printf("Service deleted successfully\n");
 
@@ -470,5 +469,11 @@ DWORD LphandlerFunctionEx(
                 endpoint_status_change(false, true);
             }
             break;
+
+        default:
+            //printf("unhandled control code from SCM (%ld)\n", dwControl);
+            break;
     }
+
+    return 0;
 }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1200,20 +1200,16 @@ static void on_event(const base_event *ev) {
                 struct add_or_edit_service_nrpt_req *edit_svc_req_data = calloc(1, sizeof(struct add_or_edit_service_nrpt_req));
                 edit_svc_req_data->hostnames = hostnamesToEdit;
                 edit_svc_req_data->dns_ip = get_dns_ip();
-
-                ziti_tunneler_call_function(main_ziti_loop, remove_and_add_nrpt_rules, edit_svc_req_data);
-
+                remove_and_add_nrpt_rules(main_ziti_loop, edit_svc_req_data);
             }
             if (model_map_size(hostnamesToAdd) > 0) {
                 struct add_or_edit_service_nrpt_req *add_svc_req_data = calloc(1, sizeof(struct add_or_edit_service_nrpt_req));
                 add_svc_req_data->hostnames = hostnamesToAdd;
                 add_svc_req_data->dns_ip = get_dns_ip();
-
-                ziti_tunneler_call_function(main_ziti_loop, add_nrpt_rules, add_svc_req_data);
-
+                add_nrpt_rules(main_ziti_loop, add_svc_req_data);
             }
             if (model_map_size(hostnamesToRemove) > 0) {
-                ziti_tunneler_call_function(main_ziti_loop, remove_nrpt_rules, hostnamesToRemove);
+                remove_nrpt_rules(main_ziti_loop, hostnamesToRemove);
             }
             if (model_map_size(hostnamesToAdd) == 0) {
                 free(hostnamesToAdd);
@@ -1408,7 +1404,7 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
         add_svc_req_data->hostnames = normalized_domains;
         add_svc_req_data->dns_ip = get_dns_ip();
 
-        ziti_tunneler_call_function(main_ziti_loop, add_nrpt_rules, add_svc_req_data);
+        add_nrpt_rules(main_ziti_loop, add_svc_req_data);
     }
 #endif
 

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2594,8 +2594,7 @@ void endpoint_status_change(bool woken, bool unlocked) {
     status_change->woken = woken;
     status_change->unlocked = unlocked;
 
-
-    ziti_tunneler_call_function(main_ziti_loop, endpoint_status_change_function, status_change);
+    ziti_tunnel_async_send(NULL, endpoint_status_change_function, status_change);
 }
 
 void scm_service_init(char *config_path) {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -510,6 +510,7 @@ static bool process_tunnel_commands(const tunnel_command *tnl_cmd, command_cb cb
                 scm_service_stop();
             }
             free_tunnel_service_control(&tunnel_service_control_opts);
+            break;
         }
 #endif
     }
@@ -2623,8 +2624,11 @@ void scm_service_run(void * name) {
     run(0, NULL);
 }
 
-void scm_service_stop() {
-    ZITI_LOG(INFO, "Control request to stop tunnel service received...");
+
+void scm_service_stop_event(uv_async_t *ar) {
+    ZITI_LOG(INFO, "Processing stop tunnel service request");
+
+    uv_close((uv_handle_t *) ar, (uv_close_cb) free);
 
     // ziti dump to log file / stdout
     tunnel_command *tnl_cmd = calloc(1, sizeof(tunnel_command));
@@ -2633,15 +2637,30 @@ void scm_service_stop() {
 
     remove_all_nrpt_rules();
 
-    tun_kill();
-
     cleanup_instance_config();
 
+    // wintun session close causes the seg fault, if you try to close it at this point. https://github.com/openziti/ziti-tunnel-sdk-c/issues/301
+    tun_kill();
+
     ZITI_LOG(INFO,"============================ service ends ==================================");
+
     if (main_ziti_loop != NULL) {
         uv_stop(main_ziti_loop);
         uv_loop_close(main_ziti_loop);
     }
+
+    // stops the windows service in scm
+    stop_windows_service();
+
+}
+
+void scm_service_stop() {
+    ZITI_LOG(INFO, "Control request to stop tunnel service received...");
+
+    uv_async_t *ar = calloc(1, sizeof(uv_async_t));
+    uv_async_init(main_ziti_loop, ar, scm_service_stop_event);
+    uv_async_send(ar);
+
 }
 
 static void move_config_from_previous_windows_backup(uv_loop_t *loop) {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -209,7 +209,7 @@ static void on_command_resp(const tunnel_result* result, void *ctx) {
                             }
 
                             if (model_map_size(hostnamesToRemove) > 0) {
-                                ziti_tunneler_call_function(main_ziti_loop, remove_nrpt_rules, hostnamesToRemove);
+                                remove_nrpt_rules(main_ziti_loop, hostnamesToRemove);
                             } else {
                                 free(hostnamesToRemove);
                             }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2594,6 +2594,7 @@ void endpoint_status_change(bool woken, bool unlocked) {
     status_change->woken = woken;
     status_change->unlocked = unlocked;
 
+
     ziti_tunneler_call_function(main_ziti_loop, endpoint_status_change_function, status_change);
 }
 
@@ -2604,9 +2605,9 @@ void scm_service_init(char *config_path) {
     }
 }
 
-void scm_service_run(void * name) {
+void scm_service_run(const char *name) {
     ZITI_LOG(INFO, "About to run tunnel service...");
-    ziti_set_app_info((char *)name, ziti_tunneler_version());
+    ziti_set_app_info(name, ziti_tunneler_version());
     run(0, NULL);
 }
 
@@ -2713,7 +2714,7 @@ int main(int argc, char *argv[]) {
     }
 
 #if _WIN32
-    SvcStart(NULL);
+    SvcStart();
 
     // if service is started by SCM, SvcStart will return only when it receives the stop request
     // started_by_scm will be set to true only if scm initializes the config value


### PR DESCRIPTION
Provide a helper function that any thread can use to run a function from the loop's thread.

Currently the tunneler context is not available to the windows SCM module. I envision changing the way the SCM code integrates into the tSDK, so that the tunneler context is visible and can be used when calling `ziti_tunnel_async_send`. In the meantime I added static semaphore
to protect the default loop when the tunneler context is passed as NULL.

I have not looked at using this to run the nrpt scripts. I wanted to understand more about the scripts before assuming `ziti_tunnel_async_send` is appropriate for them. 