### PR TITLE
fix the service stop issue

### DIFF
--- a/programs/ziti-edge-tunnel/windows-service.c
+++ b/programs/ziti-edge-tunnel/windows-service.c
@@ -257,8 +257,6 @@ DWORD WINAPI ServiceWorkerThread (LPVOID lpParam)
 {
     //  Periodically check if the service has been requested to stop
     scm_service_run(APPNAME);
-    // when service stops and returns, stop the service in scm
-    stop_windows_service();
     return ERROR_SUCCESS;
 }
 
@@ -426,7 +424,6 @@ void scm_running_event() {
 //
 void stop_windows_service() {
     SetEvent(ghSvcStopEvent);
-    ReportSvcStatus(gSvcStatus.dwCurrentState, NO_ERROR, 0);
 }
 
 DWORD get_process_path(LPTSTR lpBuffer, DWORD  nBufferLength) {
@@ -453,7 +450,7 @@ DWORD LphandlerFunctionEx(
 
     switch (dwControl) {
         case SERVICE_CONTROL_STOP:
-            ReportSvcStatus(SERVICE_STOP_PENDING, NO_ERROR, 0);
+            ReportSvcStatus(SERVICE_STOP_PENDING, NO_ERROR, 60000);
 
             // stops the running tunnel service
             scm_service_stop();

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2690,7 +2690,6 @@ void scm_service_run(const char *name) {
     run(0, NULL);
 }
 
-
 void scm_service_stop_event(uv_loop_t *loop, void *arg) {
     ZITI_LOG(INFO, "Processing stop tunnel service request");
 
@@ -2709,8 +2708,13 @@ void scm_service_stop_event(uv_loop_t *loop, void *arg) {
     ZITI_LOG(INFO,"============================ service ends ==================================");
 
     if (main_ziti_loop != NULL) {
+
         uv_stop(main_ziti_loop);
-        uv_loop_close(main_ziti_loop);
+        int result = uv_loop_close(main_ziti_loop);
+        if (result == UV_EBUSY)
+        {
+            ZITI_LOG(INFO, "loop is busy, exiting...");
+        }
     }
 
     // stops the windows service in scm
@@ -2720,7 +2724,7 @@ void scm_service_stop_event(uv_loop_t *loop, void *arg) {
 
 void scm_service_stop() {
     ZITI_LOG(INFO, "Control request to stop tunnel service received...");
-    ziti_tunnel_async_send(NULL, scm_service_stop_event, NULL);
+    scm_service_stop_event(NULL, NULL);
 }
 
 static void move_config_from_previous_windows_backup(uv_loop_t *loop) {


### PR DESCRIPTION
when you call the scm stop function, the stop operation should be performed in the same thread. If you use async function to stop, scm will throw error. You can stop ziti using async function when you interrupt it or when you sen the stop command line operation