### PR TITLE
Stop service without uv stop

### DIFF
--- a/lib/ziti-tunnel-cbs/dns_host.h
+++ b/lib/ziti-tunnel-cbs/dns_host.h
@@ -22,7 +22,7 @@
 #define ZITI_TUNNELER_SDK_DNS_HOST_H
 
 #if _WIN32
-#include <windef.h>
+#include <windows.h>
 #include <windns.h>
 
 #define ns_rr DNS_RECORDA

--- a/programs/ziti-edge-tunnel/instance-config.c
+++ b/programs/ziti-edge-tunnel/instance-config.c
@@ -169,9 +169,11 @@ bool save_tunnel_status_to_file() {
 }
 
 void cleanup_instance_config() {
-    ZITI_LOG(TRACE, "Backing up current tunnel status");
+    ZITI_LOG(DEBUG,"xx Backing up current tunnel status ");
     save_tunnel_status_to_file();
+    ZITI_LOG(DEBUG,"xx save_tunnel_status_to_file done ");
     if (sem_initialized == 0) {
-        uv_sem_destroy(&sem);
+        //uv_sem_destroy(&sem);
+        ZITI_LOG(DEBUG,"xx uv_sem_destroy done");
     }
 }

--- a/programs/ziti-edge-tunnel/instance-config.c
+++ b/programs/ziti-edge-tunnel/instance-config.c
@@ -169,11 +169,11 @@ bool save_tunnel_status_to_file() {
 }
 
 void cleanup_instance_config() {
-    ZITI_LOG(DEBUG,"xx Backing up current tunnel status ");
+    ZITI_LOG(DEBUG,"Backing up current tunnel status ");
     save_tunnel_status_to_file();
-    ZITI_LOG(DEBUG,"xx save_tunnel_status_to_file done ");
+    ZITI_LOG(DEBUG,"save_tunnel_status_to_file done ");
     if (sem_initialized == 0) {
         //uv_sem_destroy(&sem);
-        ZITI_LOG(DEBUG,"xx uv_sem_destroy done");
+        ZITI_LOG(DEBUG,"uv_sem_destroy done");
     }
 }

--- a/programs/ziti-edge-tunnel/instance-config.c
+++ b/programs/ziti-edge-tunnel/instance-config.c
@@ -169,7 +169,7 @@ bool save_tunnel_status_to_file() {
 }
 
 void cleanup_instance_config() {
-    ZITI_LOG(DEBUG,"Backing up current tunnel status ");
+    ZITI_LOG(DEBUG,"Backing up current tunnel status");
     save_tunnel_status_to_file();
     ZITI_LOG(DEBUG,"save_tunnel_status_to_file done ");
     if (sem_initialized == 0) {

--- a/programs/ziti-edge-tunnel/windows-service.c
+++ b/programs/ziti-edge-tunnel/windows-service.c
@@ -244,7 +244,6 @@ VOID SvcInit( DWORD dwArgc, LPTSTR *lpszArgv)
 
     SvcReportEvent(TEXT("Ziti Edge Tunnel Stopped"), EVENTLOG_INFORMATION_TYPE);
     ReportSvcStatus( SERVICE_STOPPED, NO_ERROR, 0 );
-    return;
 }
 
 DWORD WINAPI ServiceWorkerThread (LPVOID lpParam)

--- a/programs/ziti-edge-tunnel/windows-service.c
+++ b/programs/ziti-edge-tunnel/windows-service.c
@@ -239,6 +239,8 @@ VOID SvcInit( DWORD dwArgc, LPTSTR *lpszArgv)
 
     WaitForSingleObject(ghSvcStopEvent, INFINITE);
 
+    ReportSvcStatus(SERVICE_STOP_PENDING, NO_ERROR, 0);
+
     scm_service_stop();
 
     SvcReportEvent(TEXT("Ziti Edge Tunnel Stopped"), EVENTLOG_INFORMATION_TYPE);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2715,12 +2715,18 @@ void stop_tunnel_and_cleanup() {
     ZITI_LOG(INFO,"closing/cleaning tun");
     tun_kill();
     ZITI_LOG(INFO,"tun closed/cleaned");
+    ZITI_LOG(INFO,"============================ service ends ==================================");
     uv_cond_signal(&stop_cond); //release the wait condition held in scm_service_stop
 }
 
 void scm_service_stop_event(uv_loop_t *loop, void *arg) {
     //function used to get back onto the loop
     stop_tunnel_and_cleanup();
+
+    if (arg != NULL && arg == "interrupted" && loop != NULL) {
+        uv_stop(loop);
+        uv_loop_close(loop);
+    }
 }
 
 // called by scm thread, it should not call any uv operations, because all uv operations except uv_async_send are not thread safe

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -501,6 +501,7 @@ static bool process_tunnel_commands(const tunnel_command *tnl_cmd, command_cb cb
                 if (!stop_windows_service()) {
                     ZITI_LOG(INFO, "Could not send stop signal to scm, Tunnel must not be started as service");
                     stop_tunnel_and_cleanup();
+                    uv_stop(main_ziti_loop);
                 }
             }
             free_tunnel_service_control(&tunnel_service_control_opts);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2734,7 +2734,7 @@ void scm_service_stop() {
     ZITI_LOG(INFO,"stopping via service");
     uv_mutex_lock(&stop_mutex);
     ZITI_LOG(DEBUG,"mutex established. sending stop event");
-    ziti_tunnel_async_send(tunneler, scm_service_stop_event, "interrupted");
+    ziti_tunnel_async_send(tunneler, scm_service_stop_event, NULL);
     ZITI_LOG(INFO,"service stop waiting on condition...");
     uv_cond_wait(&stop_cond, &stop_mutex);
     uv_mutex_unlock(&stop_mutex);


### PR DESCRIPTION
get back on the uv loop and clean up. use `uv_cond_wait` to wait until that process completes then exit the main thread after notifying the SCM.