### PR TITLE
declare "safe" dirs to Git if owned by another UID

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -69,10 +69,27 @@ jobs:
           chmod +x /root/git.sh
           update-alternatives --install /usr/bin/git git /root/git.sh 50
 
+      # /github/workspace is added to "safe" dirs in global config e.g.
+      # ~/.gitconfig so both runner and builder containers trust these dirs
+      # owned by different UIDs from that of Git's EUID. This is made necessary
+      # by newly-enforced directory boundaries in Git v2.35.2
+      # ref: https://lore.kernel.org/git/xmqqv8veb5i6.fsf@gitster.g/
+      - name: declare to Git "safe" directories owned by a different UID
+        run: |
+          for dir in /github/workspace /__w/ziti-tunnel-sdk-c/ziti-tunnel-sdk-c; do
+            git config --global --add safe.directory ${dir}
+          done
+
       - name: checkout workspace
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: compare UID of owner of Git "safe" directories
+        run: |
+          set -x
+          ls -dl /__w/ziti-tunnel-sdk-c/ziti-tunnel-sdk-c
+          id
 
       - name: configure build action for distro version
         env:


### PR DESCRIPTION
Container-based builds fail with the following error whenever the directory containing `.git` is owned by a different UID than the EUID of `git` >= 2.35.2 which became available in newer Ubuntu repos today, Tuesday. This immediately broke container-based builds unless the RUNAS UID of the runner container process happens to match the workspace owner on the runner VM.

> Error: fatal: unsafe repository ('/__w/ziti-tunnel-sdk-c/ziti-tunnel-sdk-c' is owned by someone else)

This also applies to Docker Actions that run directly on a runner VM or inside a runner container, and this PR addresses both where:
* `/__w/ziti-tunnel-sdk-c/ziti-tunnel-sdk-c` is the workspace directory that Git sees inside the runner container, and 
* `/github/workspace` is the workpace directory that Git sees inside the Docker Action aka "builder container" that's run by the runner container

GitHub announcement about this doesn't reference the implications for their own container builds, which is a head-scratcher. 
https://github.blog/2022-04-12-git-security-vulnerability-announced/
