### PR TITLE
un_ref the check_lwip_timeouts timer 

### DIFF
--- a/lib/ziti-tunnel/ziti_tunnel.c
+++ b/lib/ziti-tunnel/ziti_tunnel.c
@@ -547,6 +547,7 @@ static void run_packet_loop(uv_loop_t *loop, tunneler_context tnlr_ctx) {
     }
 
     uv_timer_init(loop, &tnlr_ctx->lwip_timer_req);
+    uv_unref(&tnlr_ctx->lwip_timer_req);
     uv_timer_start(&tnlr_ctx->lwip_timer_req, check_lwip_timeouts, 0, 10);
 }
 


### PR DESCRIPTION
(allows uv_loop to exit following ziti_shutdown)