### PR TITLE
simplify tun IP configuration

### DIFF
--- a/programs/ziti-edge-tunnel/include/instance.h
+++ b/programs/ziti-edge-tunnel/include/instance.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef MAXTUNPREFIXLENGTH
-#define MAXTUNPREFIXLENGTH 18
+#define MAXTUNPREFIXLENGTH 24
 #endif
 
 #ifdef __cplusplus

--- a/programs/ziti-edge-tunnel/include/instance.h
+++ b/programs/ziti-edge-tunnel/include/instance.h
@@ -58,7 +58,7 @@ void delete_identity_from_instance(char* identifier);
 
 void set_ip_info(uint32_t dns_ip, uint32_t tun_ip, int bits);
 
-void set_log_level(char* log_level);
+void set_log_level(const char* log_level);
 
 void set_service_version();
 

--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -695,7 +695,7 @@ void set_ip_info(uint32_t dns_ip, uint32_t tun_ip, int bits) {
 
 }
 
-void set_log_level(char* log_level) {
+void set_log_level(const char* log_level) {
     if (log_level == NULL) {
         return;
     }

--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -684,7 +684,7 @@ void set_ip_info(uint32_t dns_ip, uint32_t tun_ip, int bits) {
     }
     ip_addr_t dns_ip4 = IPADDR4_INIT(dns_ip);
     tnl_status.IpInfo = calloc(1, sizeof(ip_info));
-    tnl_status.IpInfo->Ip = strdup(ipaddr_ntoa(&dns_ip4));
+    tnl_status.IpInfo->Ip = strdup(ipaddr_ntoa(&tun_ip4));
     tnl_status.IpInfo->DNS = strdup(ipaddr_ntoa(&dns_ip4));
     tnl_status.IpInfo->MTU = 65535;
 

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -96,7 +96,6 @@ int tun_uv_poll_init(netif_handle tun, uv_loop_t *loop, uv_poll_t *tun_poll_req)
 }
 
 int tun_add_route(netif_handle tun, const char *dest) {
-    char cmd[1024];
     address_t *rt = parse_address(dest);
     if (rt == NULL) {
         ZITI_LOG(ERROR, "failed to parse route '%s'", dest);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1630,9 +1630,7 @@ static void run(int argc, char *argv[]) {
     init = log_init(ziti_loop, multi_writer);
 
     signal(SIGINT, interrupt_handler);
-#endif
 
-#if _WIN32
     if (init) {
         ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, ziti_log_writer);
         struct tm *start_time = get_log_start_time();
@@ -1679,8 +1677,8 @@ static void run(int argc, char *argv[]) {
         tun_ip |= (ip[i] & 0xFFU);
     }
 
-    tun_ip = htonl(tun_ip);
     uint32_t dns_ip = htonl(tun_ip + 0x1);
+    tun_ip = htonl(tun_ip);
 
 #if __unix__ || __unix
     // prevent termination when running under valgrind


### PR DESCRIPTION
- use the base of the dns IP range as the tun IP address
- add 1 (instead of bitwise OR) to the tun IP to get the DNS server listen IP. bitwise OR leads to unexpected values when host portion of base IP is not 0.
- populate IpInfo->IP with the tun IP instead of the DNS IP.