### PR TITLE
Disable intercepts in host only mode, supports intercepts only mode

### DIFF
--- a/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
+++ b/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
@@ -181,6 +181,9 @@ extern void ziti_tunnel_set_log_level(int lvl);
 typedef void (*ziti_tunnel_async_fn)(uv_loop_t *loop, void *ctx);
 extern void ziti_tunnel_async_send(tunneler_context tctx, ziti_tunnel_async_fn f, void *arg);
 
+extern bool ziti_tunneler_hosts_service(tunneler_context t_ctx);
+extern bool ziti_tunneler_intercepts_service(tunneler_context t_ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
+++ b/lib/ziti-tunnel/include/ziti/ziti_tunnel.h
@@ -143,6 +143,7 @@ extern bool port_match(int port, const port_range_list_t *port_ranges);
 
 extern tunneler_context ziti_tunneler_init(tunneler_sdk_options *opts, uv_loop_t *loop);
 extern tunneler_context ziti_tunneler_init_host_only(tunneler_sdk_options *opts, uv_loop_t *loop);
+extern tunneler_context ziti_tunneler_init_intercept_only(tunneler_sdk_options *opts, uv_loop_t *loop);
 
 extern void ziti_tunneler_exclude_route(tunneler_context tnlr_ctx, const char* dst);
 

--- a/lib/ziti-tunnel/ziti_tunnel.c
+++ b/lib/ziti-tunnel/ziti_tunnel.c
@@ -56,7 +56,7 @@ static void default_loop_sem_init(void) {
     uv_sem_init(&default_loop_sem, 1);
 }
 
-static tunneler_context create_tunneler_ctx(tunneler_sdk_options *opts, uv_loop_t *loop) {
+static tunneler_context create_tunneler_ctx(tunneler_sdk_options *opts, uv_loop_t *loop, bool host_service, bool intercept_service) {
     TNL_LOG(INFO, "Ziti Tunneler SDK (%s)", ziti_tunneler_version());
 
     if (opts == NULL) {
@@ -73,15 +73,17 @@ static tunneler_context create_tunneler_ctx(tunneler_sdk_options *opts, uv_loop_
     uv_sem_init(&ctx->sem, 1);
     uv_once(&default_loop_sem_init_once, default_loop_sem_init);
     memcpy(&ctx->opts, opts, sizeof(ctx->opts));
+    ctx->host_service = host_service;
+    ctx->intercept_service = intercept_service;
     return ctx;
 }
 
 tunneler_context ziti_tunneler_init_host_only(tunneler_sdk_options *opts, uv_loop_t *loop) {
-    return create_tunneler_ctx(opts, loop);
+    return create_tunneler_ctx(opts, loop, true, false);
 }
 
 tunneler_context ziti_tunneler_init(tunneler_sdk_options *opts, uv_loop_t *loop) {
-    struct tunneler_ctx_s *ctx = create_tunneler_ctx(opts, loop);
+    struct tunneler_ctx_s *ctx = create_tunneler_ctx(opts, loop, true, true);
     if (ctx == NULL) {
         return NULL;
     }
@@ -632,6 +634,14 @@ void ziti_tunnel_async_send(tunneler_context tctx, ziti_tunnel_async_fn f, void 
     }
 
     uv_async_send(async);
+}
+
+bool ziti_tunneler_hosts_service(tunneler_context t_ctx) {
+    return t_ctx->host_service;
+}
+
+bool ziti_tunneler_intercepts_service(tunneler_context t_ctx) {
+    return t_ctx->intercept_service;
 }
 
 #define _str(x) #x

--- a/lib/ziti-tunnel/ziti_tunnel.c
+++ b/lib/ziti-tunnel/ziti_tunnel.c
@@ -78,20 +78,29 @@ static tunneler_context create_tunneler_ctx(tunneler_sdk_options *opts, uv_loop_
     return ctx;
 }
 
+tunneler_context initialize_intercepts_and_run(uv_loop_t *tun_loop, tunneler_context t_ctx) {
+    if (t_ctx == NULL) {
+        return NULL;
+    }
+
+    LIST_INIT(&t_ctx->intercepts);
+    run_packet_loop(tun_loop, t_ctx);
+
+    return t_ctx;
+}
+
 tunneler_context ziti_tunneler_init_host_only(tunneler_sdk_options *opts, uv_loop_t *loop) {
     return create_tunneler_ctx(opts, loop, true, false);
 }
 
+tunneler_context ziti_tunneler_init_intercept_only(tunneler_sdk_options *opts, uv_loop_t *loop) {
+    struct tunneler_ctx_s *ctx = create_tunneler_ctx(opts, loop, false, true);
+    return initialize_intercepts_and_run(loop, ctx);
+}
+
 tunneler_context ziti_tunneler_init(tunneler_sdk_options *opts, uv_loop_t *loop) {
     struct tunneler_ctx_s *ctx = create_tunneler_ctx(opts, loop, true, true);
-    if (ctx == NULL) {
-        return NULL;
-    }
-
-    LIST_INIT(&ctx->intercepts);
-    run_packet_loop(loop, ctx);
-
-    return ctx;
+    return initialize_intercepts_and_run(loop, ctx);
 }
 
 void ziti_tunneler_exclude_route(tunneler_context tnlr_ctx, const char *dst) {

--- a/lib/ziti-tunnel/ziti_tunnel_priv.h
+++ b/lib/ziti-tunnel/ziti_tunnel_priv.h
@@ -76,6 +76,8 @@ typedef struct tunneler_ctx_s {
     uv_sem_t     sem;
     uv_poll_t    netif_poll_req;
     uv_timer_t   lwip_timer_req;
+    bool    host_service;
+    bool    intercept_service;
     LIST_HEAD(intercept_ctx_list_s, intercept_ctx_s) intercepts;
 //    STAILQ_HEAD(hosted_service_ctx_list_s, hosted_service_ctx_s) hosts;
     LIST_HEAD(exclusions, excluded_route_s) excluded_rts;

--- a/programs/ziti-edge-tunnel/config-utils.c
+++ b/programs/ziti-edge-tunnel/config-utils.c
@@ -67,4 +67,3 @@ char* get_backup_config_file_name(char* config_path) {
         return "config.json.backup";
     }
 }
-

--- a/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
+++ b/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
@@ -36,5 +36,7 @@ model_map *get_connection_specific_domains();
 void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip);
 void update_interface_metric(uv_loop_t *ziti_loop, char* tun_name, int metric);
 void update_symlink(uv_loop_t *symlink_loop, char* symlink, char* filename);
+void check_elevated_privilege();
+bool has_elevated_privilege();
 
 #endif //ZITI_TUNNEL_SDK_C_WINDOWS_SCRIPTS_H

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1653,6 +1653,7 @@ static void run(int argc, char *argv[]) {
 
 #if _WIN32
     remove_all_nrpt_rules();
+    check_elevated_privilege();
 
     bool multi_writer = true;
     if (started_by_scm) {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -62,6 +62,7 @@ static void send_tunnel_command_inline(tunnel_command *tnl_cmd, void *ctx);
 static void scm_service_stop_event(uv_loop_t *loop, void *arg);
 static void stop_tunnel_and_cleanup();
 static bool is_host_only();
+static bool is_intercept_only();
 static void run_tunneler_loop(uv_loop_t* ziti_loop);
 static tunneler_context initialize_tunneler(netif_driver tun, uv_loop_t* ziti_loop);
 
@@ -1526,6 +1527,8 @@ static tunneler_context initialize_tunneler(netif_driver tun, uv_loop_t* ziti_lo
 
     if (is_host_only()) {
         return ziti_tunneler_init_host_only(&tunneler_opts, ziti_loop);
+    } else if (is_intercept_only()) {
+        return ziti_tunneler_init_intercept_only(&tunneler_opts, ziti_loop);
     } else {
         return ziti_tunneler_init(&tunneler_opts, ziti_loop);
     }
@@ -1574,6 +1577,7 @@ static const char* ip_range = "100.64.0.0/10";
 static const char* dns_impl = NULL;
 static const char* dns_upstream = NULL;
 static bool host_only = false;
+static bool intercept_only = false;
 
 static int run_opts(int argc, char *argv[]) {
     printf("About to run tunnel service... %s", main_cmd.name);
@@ -1620,6 +1624,52 @@ static int run_opts(int argc, char *argv[]) {
     return optind;
 }
 
+static int run_intercepts_opts(int argc, char *argv[]) {
+    printf("About to run tunnel service that intercepts services... %s", main_cmd.name);
+    ziti_set_app_info(main_cmd.name, ziti_tunneler_version());
+
+    int c, option_index, errors = 0;
+    optind = 0;
+
+    while ((c = getopt_long(argc, argv, "i:I:v:r:d:u:",
+                            run_options, &option_index)) != -1) {
+        switch (c) {
+            case 'i': {
+                struct cfg_instance_s *inst = calloc(1, sizeof(struct cfg_instance_s));
+                inst->cfg = strdup(optarg);
+                LIST_INSERT_HEAD(&load_list, inst, _next);
+                break;
+            }
+            case 'I':
+                config_dir = optarg;
+                break;
+            case 'v':
+                setenv("ZITI_LOG", optarg, true);
+                break;
+            case 'r':
+                refresh_interval = strtol(optarg, NULL, 10);
+                break;
+            case 'd': // ip range
+                ip_range = optarg;
+                break;
+            case 'u':
+                dns_upstream = optarg;
+                break;
+            default: {
+                ZITI_LOG(ERROR, "Unknown option '%c'", c);
+                errors++;
+                break;
+            }
+        }
+    }
+    if (errors > 0) {
+        commandline_help(stderr);
+        exit(1);
+    }
+    intercept_only = true;
+    return optind;
+}
+
 static int run_host_opts(int argc, char *argv[]) {
     printf("About to run tunnel service that hosts services... %s", main_cmd.name);
     ziti_set_app_info(main_cmd.name, ziti_tunneler_version());
@@ -1628,7 +1678,7 @@ static int run_host_opts(int argc, char *argv[]) {
     optind = 0;
 
     while ((c = getopt_long(argc, argv, "i:I:v:r:",
-                            run_options, &option_index)) != -1) {
+                            run_host_options, &option_index)) != -1) {
         switch (c) {
             case 'i': {
                 struct cfg_instance_s *inst = calloc(1, sizeof(struct cfg_instance_s));
@@ -1778,8 +1828,10 @@ static void run(int argc, char *argv[]) {
 
     int rc;
     if (is_host_only()) {
+        ZITI_LOG(INFO, "Tunnel is running in host only mode, it supports only hosting services");
         rc = run_tunnel_host_mode(ziti_loop);
     } else {
+        ZITI_LOG(INFO, "Tunnel supports hosting and intercepting services");
         rc = run_tunnel(ziti_loop, tun_ip, dns_ip, ip_range, dns_upstream);
     }
     exit(rc);
@@ -2651,6 +2703,16 @@ static CommandLine run_host_cmd = make_command("run_host", "run Ziti tunnel to h
                                           "\t-v|--verbose N\tset log level, higher level -- more verbose (default 3)\n"
                                           "\t-r|--refresh N\tset service polling interval in seconds (default 10)\n",
                                           run_host_opts, run);
+static CommandLine run_intercepts_cmd = make_command("run_intercepts", "run Ziti tunnel to intercept services (required superuser access)",
+                                          "-i <id.file> [-r N] [-v N] [-d|--dns-ip-range N.N.N.N/n] [-n|--dns <internal|dnsmasq=<dnsmasq hosts dir>>]",
+                                          "\t-i|--identity <identity>\trun with provided identity file (required)\n"
+                                          "\t-I|--identity-dir <dir>\tload identities from provided directory\n"
+                                          "\t-v|--verbose N\tset log level, higher level -- more verbose (default 3)\n"
+                                          "\t-r|--refresh N\tset service polling interval in seconds (default 10)\n"
+                                          "\t-d|--dns-ip-range <ip range>\tspecify CIDR block in which service DNS names"
+                                          " are assigned in N.N.N.N/n format (default 100.64.0.0/10)\n"
+                                          "\t-n|--dns <internal|dnsmasq=<dnsmasq opts>> DNS configuration setting (default internal)\n",
+                                          run_intercepts_opts, run);
 static CommandLine dump_cmd = make_command("dump", "dump the identities information", "[-i <identity>] [-p <dir>]",
                                            "\t-i|--identity\tdump identity info\n"
                                            "\t-p|--dump_path\tdump into path\n", dump_opts, send_message_to_tunnel_fn);
@@ -2703,6 +2765,7 @@ static CommandLine *main_cmds[] = {
         &enroll_cmd,
         &run_cmd,
         &run_host_cmd,
+        &run_intercepts_cmd,
         &on_off_id_cmd,
         &enable_id_cmd,
         &dump_cmd,
@@ -2885,6 +2948,10 @@ static void move_config_from_previous_windows_backup(uv_loop_t *loop) {
 
 static bool is_host_only() {
     return host_only;
+}
+
+static bool is_intercept_only() {
+    return intercept_only;
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
This PR contains the following changes
1. Disable intercepts while running the tunnel in host only mode.
2. New command run_intercepts is added that supports intercepts only mode
3. run certain windows script, only if the user is running the tunnel using admin privileges