### PR TITLE
use string for ziti_dns_setup's dns_addr argument

### DIFF
--- a/lib/ziti-tunnel-cbs/include/ziti/ziti_dns.h
+++ b/lib/ziti-tunnel-cbs/include/ziti/ziti_dns.h
@@ -25,7 +25,7 @@
 #define DNS_REFUSE   5
 #define DNS_NOTZONE  9
 
-int ziti_dns_setup(tunneler_context tnlr, const ip_addr_t *dns_addr, const char *dns_cidr);
+int ziti_dns_setup(tunneler_context tnlr, const char *dns_addr, const char *dns_cidr);
 
 int ziti_dns_set_upstream(uv_loop_t *l, const char *host, uint16_t port);
 

--- a/lib/ziti-tunnel-cbs/ziti_dns.c
+++ b/lib/ziti-tunnel-cbs/ziti_dns.c
@@ -150,13 +150,17 @@ static int seed_dns(const char *dns_cidr) {
     return 0;
 }
 
-int ziti_dns_setup(tunneler_context tnlr, const ip_addr_t *dns_addr, const char *dns_cidr) {
+int ziti_dns_setup(tunneler_context tnlr, const char *dns_addr, const char *dns_cidr) {
     ziti_dns.tnlr = tnlr;
     seed_dns(dns_cidr);
 
     intercept_ctx_t *dns_intercept = intercept_ctx_new(tnlr, "ziti:dns-resolver", &ziti_dns);
     ziti_address dns_zaddr;
-    ziti_address_from_ip_addr(&dns_zaddr, dns_addr);
+    size_t dns_addr_json_buflen = strlen(dns_addr) + 3;
+    char *dns_addr_json = calloc(dns_addr_json_buflen, sizeof(char));
+    snprintf(dns_addr_json, dns_addr_json_buflen, "\"%s\"", dns_addr);
+    parse_ziti_address(&dns_zaddr, dns_addr_json, dns_addr_json_buflen);
+    free(dns_addr_json);
     intercept_ctx_add_address(dns_intercept, &dns_zaddr);
     intercept_ctx_add_port_range(dns_intercept, 53, 53);
     intercept_ctx_add_protocol(dns_intercept, "udp");

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1538,7 +1538,7 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
     tunneler = initialize_tunneler(tun, ziti_loop);
 
     ip_addr_t dns_ip4 = IPADDR4_INIT(dns_ip);
-    ziti_dns_setup(tunneler, &dns_ip4, ip_range);
+    ziti_dns_setup(tunneler, ipaddr_ntoa(&dns_ip4), ip_range);
     if (dns_upstream) {
         char *col = strchr(dns_upstream, ':');
         if (col) {


### PR DESCRIPTION
Replace the string argument to ziti_dns_setup. fwiw I originally changed it to ip_addr_t to avoid the int -> string -> int conversion that ziti-edge-tunnel was doing.