### PR TITLE
Add ability to dial by fqdn with addressable terminators for use with wildcard DNS

### DIFF
--- a/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
@@ -342,29 +342,25 @@ void * ziti_sdk_c_dial(const void *intercept_ctx, struct io_ctx_s *io) {
         if (dst_addr != NULL) {
             char *proto, *ip, *port;
             strncpy(resolved_dial_identity, dial_opts.identity, sizeof(resolved_dial_identity));
-            parse_socket_address(dst_addr, &proto, &ip, &port);
             tunneler_app_data app_data;
-            parse_tunneler_app_data(&app_data, (char *)app_data_json, json_len);
-            if (proto != NULL) {
-                string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_protocol", proto);
-                free(proto);
-            }
-            if (ip != NULL) {
-                string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_ip", ip);
-                free(ip);
-            }
-            if (port != NULL) {
-                string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_port", port);
-                free(port);
-            }
-            if (app_data.dst_hostname != NULL){
-                string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_hostname", app_data.dst_hostname);
+            if (parse_tunneler_app_data(&app_data, (char *)app_data_json, json_len) >= 0){
+                if (app_data.dst_protocol != NULL) {
+                    string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_protocol", app_data.dst_protocol);
+                }
+                if (app_data.dst_ip != NULL) {
+                    string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_ip", app_data.dst_ip);
+                }
+                if (app_data.dst_port != NULL) {
+                    string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_port", app_data.dst_port);
+                }
+                if (app_data.dst_hostname != NULL){
+                    string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_hostname", app_data.dst_hostname);
+                }
                 free_tunneler_app_data(&app_data);
             }
         }
         dial_opts.identity = resolved_dial_identity;
     }
-
 
     dial_opts.app_data_sz = (size_t) json_len;
     dial_opts.app_data = app_data_json;

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
@@ -335,6 +335,9 @@ void * ziti_sdk_c_dial(const void *intercept_ctx, struct io_ctx_s *io) {
             char *proto, *ip, *port;
             strncpy(resolved_dial_identity, dial_opts.identity, sizeof(resolved_dial_identity));
             parse_socket_address(dst_addr, &proto, &ip, &port);
+            const char *dst_host_ip = ip;
+            const char *dst_host = ziti_dns_reverse_lookup(dst_host_ip);
+            printf("\ndest_addr=%s\n", dst_host);
             if (proto != NULL) {
                 string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_protocol", proto);
                 free(proto);
@@ -346,6 +349,9 @@ void * ziti_sdk_c_dial(const void *intercept_ctx, struct io_ctx_s *io) {
             if (port != NULL) {
                 string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_port", port);
                 free(port);
+            }
+            if (dst_host != NULL){
+                string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_host", dst_host);
             }
         }
         dial_opts.identity = resolved_dial_identity;

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
@@ -33,6 +33,7 @@
 #include "ziti_instance.h"
 #include "ziti_hosting.h"
 
+
 typedef int (*cfg_parse_fn)(void *, const char *, size_t);
 typedef void* (*cfg_alloc_fn)();
 typedef void (*cfg_free_fn)(void *);
@@ -328,6 +329,13 @@ void * ziti_sdk_c_dial(const void *intercept_ctx, struct io_ctx_s *io) {
             break;
     }
 
+    ssize_t json_len = get_app_data_json(app_data_json, sizeof(app_data_json), io->tnlr_io, ziti_ctx, source_ip);
+    if (json_len < 0) {
+        ZITI_LOG(ERROR, "service[%s] failed to encode app_data", zi_ctx->service_name);
+        free(ziti_io_ctx);
+        return NULL;
+    }
+  
     char resolved_dial_identity[128];
     if (dial_opts.identity != NULL && dial_opts.identity[0] != '\0') {
         const char *dst_addr = get_intercepted_address(io->tnlr_io);
@@ -335,9 +343,8 @@ void * ziti_sdk_c_dial(const void *intercept_ctx, struct io_ctx_s *io) {
             char *proto, *ip, *port;
             strncpy(resolved_dial_identity, dial_opts.identity, sizeof(resolved_dial_identity));
             parse_socket_address(dst_addr, &proto, &ip, &port);
-            const char *dst_host_ip = ip;
-            const char *dst_host = ziti_dns_reverse_lookup(dst_host_ip);
-            printf("\ndest_addr=%s\n", dst_host);
+            tunneler_app_data app_data;
+            parse_tunneler_app_data(&app_data, (char *)app_data_json, json_len);
             if (proto != NULL) {
                 string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_protocol", proto);
                 free(proto);
@@ -350,19 +357,14 @@ void * ziti_sdk_c_dial(const void *intercept_ctx, struct io_ctx_s *io) {
                 string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_port", port);
                 free(port);
             }
-            if (dst_host != NULL){
-                string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_host", dst_host);
+            if (app_data.dst_hostname != NULL){
+                string_replace(resolved_dial_identity, sizeof(resolved_dial_identity), "$dst_hostname", app_data.dst_hostname);
+                free_tunneler_app_data(&app_data);
             }
         }
         dial_opts.identity = resolved_dial_identity;
     }
 
-    ssize_t json_len = get_app_data_json(app_data_json, sizeof(app_data_json), io->tnlr_io, ziti_ctx, source_ip);
-    if (json_len < 0) {
-        ZITI_LOG(ERROR, "service[%s] failed to encode app_data", zi_ctx->service_name);
-        free(ziti_io_ctx);
-        return NULL;
-    }
 
     dial_opts.app_data_sz = (size_t) json_len;
     dial_opts.app_data = app_data_json;


### PR DESCRIPTION
[refactored refactored resolved_dial_identity in ziti_tunnel_cbs.c to reduce lookups/parcings performed to retrieve dest_xxx variable values as well as add fqdn addressable terminator dialing for use with wildcard DNS.