### PR TITLE
make the identities dir when building container image because it migh…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Pipfile
 compile_commands.json
 /docker/*.jwt
 /docker/*.json
+/docker/*.json.orig

--- a/docker/Dockerfile.copy
+++ b/docker/Dockerfile.copy
@@ -37,6 +37,7 @@ COPY --from=fetch-ziti-artifacts /etc/ssl/certs/ca-certificates.crt /etc/ssl/cer
 COPY --from=fetch-ziti-artifacts /tmp/${ZITI_TUNNELER_BIN} /usr/local/bin
 COPY ${DOCKER_BUILD_DIR}/docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
+RUN mkdir -p /ziti-edge-tunnel
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD [ "run" ]


### PR DESCRIPTION
…t not be a bind volume mountpoint