### PR TITLE
Allow ZDEW to enumerate all/more/most processes when eval'ing posture checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.28.13")
+    set(ZITI_SDK_C_BRANCH "0.29.1")
 endif()
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
@@ -1158,7 +1158,7 @@ static void on_sigdump(uv_signal_t *sig, int signum) {
 
     char time_str[32];
     struct tm* start_tm = gmtime(&dump_time.tv_sec);
-    strftime(time_str, sizeof(time_str), "%FT%T", start_tm);
+    strftime(time_str, sizeof(time_str), "%Y-%m-%dT%H:%M:%S", start_tm);
 
     CHECK(cleanup, fprintf(dumpfile, "ZIti Dump starting: %s\n",time_str));
     const char *k;

--- a/programs/ziti-edge-tunnel/include/log-utils.h
+++ b/programs/ziti-edge-tunnel/include/log-utils.h
@@ -34,7 +34,7 @@ void stop_log_check();
 struct tm* get_log_start_time();
 char* get_log_file_name();
 
-bool log_init(uv_loop_t *, bool);
+bool log_init(uv_loop_t *);
 void ziti_log_writer(int , const char *, const char *, size_t);
 
 #ifdef __cplusplus

--- a/programs/ziti-edge-tunnel/include/windows/windows-service.h
+++ b/programs/ziti-edge-tunnel/include/windows/windows-service.h
@@ -38,7 +38,7 @@ bool stop_windows_service();
 
 DWORD get_process_path(LPTSTR, DWORD);
 
-void scm_grant_se_debug();
+bool scm_grant_se_debug();
 
 #ifdef __cplusplus
 }

--- a/programs/ziti-edge-tunnel/include/windows/windows-service.h
+++ b/programs/ziti-edge-tunnel/include/windows/windows-service.h
@@ -38,6 +38,8 @@ bool stop_windows_service();
 
 DWORD get_process_path(LPTSTR, DWORD);
 
+void scm_grant_se_debug();
+
 #ifdef __cplusplus
 }
 #endif

--- a/programs/ziti-edge-tunnel/windows-service.c
+++ b/programs/ziti-edge-tunnel/windows-service.c
@@ -472,3 +472,42 @@ DWORD LphandlerFunctionEx(
 
     return 0;
 }
+
+
+BOOL SetPrivilege(HANDLE hToken, LPCTSTR lpszPrivilege, BOOL bEnablePrivilege)
+{
+    LUID luid;
+    BOOL bRet=FALSE;
+
+    if (LookupPrivilegeValue(NULL, lpszPrivilege, &luid))
+    {
+        TOKEN_PRIVILEGES tp;
+
+        tp.PrivilegeCount=1;
+        tp.Privileges[0].Luid=luid;
+        tp.Privileges[0].Attributes=(bEnablePrivilege) ? SE_PRIVILEGE_ENABLED: 0;
+        //
+        //  Enable the privilege or disable all privileges.
+        //
+        if (AdjustTokenPrivileges(hToken, FALSE, &tp, NULL, (PTOKEN_PRIVILEGES)NULL, (PDWORD)NULL))
+        {
+            //
+            //  Check to see if you have proper access.
+            //  You may get "ERROR_NOT_ALL_ASSIGNED".
+            //
+            bRet=(GetLastError() == ERROR_SUCCESS);
+        }
+    }
+    return bRet;
+}
+
+void scm_grant_se_debug() {
+    HANDLE hProcess=GetCurrentProcess();
+    HANDLE hToken;
+
+    if (OpenProcessToken(hProcess, TOKEN_ADJUST_PRIVILEGES, &hToken))
+    {
+        SetPrivilege(hToken, SE_DEBUG_NAME, TRUE);
+        CloseHandle(hToken);
+    }
+}

--- a/programs/ziti-edge-tunnel/windows-service.c
+++ b/programs/ziti-edge-tunnel/windows-service.c
@@ -501,13 +501,15 @@ BOOL SetPrivilege(HANDLE hToken, LPCTSTR lpszPrivilege, BOOL bEnablePrivilege)
     return bRet;
 }
 
-void scm_grant_se_debug() {
+bool scm_grant_se_debug() {
     HANDLE hProcess=GetCurrentProcess();
     HANDLE hToken;
 
     if (OpenProcessToken(hProcess, TOKEN_ADJUST_PRIVILEGES, &hToken))
     {
-        SetPrivilege(hToken, SE_DEBUG_NAME, TRUE);
+        bool worked = SetPrivilege(hToken, SE_DEBUG_NAME, TRUE);
         CloseHandle(hToken);
+        return worked;
     }
+    return false;
 }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1747,7 +1747,6 @@ static void interrupt_handler(int sig) {
 static void run(int argc, char *argv[]) {
     uv_loop_t *ziti_loop = uv_default_loop();
     main_ziti_loop = ziti_loop;
-    bool init = false;
     uv_cond_init(&stop_cond);
     uv_mutex_init(&stop_mutex);
 
@@ -1759,13 +1758,13 @@ static void run(int argc, char *argv[]) {
     }
 
 #if _WIN32
-    remove_all_nrpt_rules();
-
-    bool multi_writer = true;
     if (started_by_scm) {
-        multi_writer = false;
+        log_init(ziti_loop);
+        ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, ziti_log_writer);
+    } else {
+        ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, NULL);
     }
-    init = log_init(ziti_loop, multi_writer);
+    remove_all_nrpt_rules();
 
     signal(SIGINT, interrupt_handler);
 #endif
@@ -1811,19 +1810,20 @@ static void run(int argc, char *argv[]) {
     set_service_version();
 
 #if _WIN32
-    if (init) {
-        ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, ziti_log_writer);
-        struct tm *start_time = get_log_start_time();
-        char time_val[32];
-        strftime(time_val, sizeof(time_val), "%a %b %d %Y, %X %p", start_time);
-        ZITI_LOG(INFO,"============================ service begins ================================");
-        ZITI_LOG(INFO,"Logger initialization");
-        ZITI_LOG(INFO,"	- initialized at   : %s", time_val);
-        ZITI_LOG(INFO,"	- log file location: %s", get_log_file_name());
-        ZITI_LOG(INFO,"============================================================================");
-    } else {
-        ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, NULL);
-    }
+    uv_timeval64_t dump_time;
+    uv_gettimeofday(&dump_time);
+    char time_str[32];
+    struct tm* start_tm = gmtime(&dump_time.tv_sec);
+    strftime(time_str, sizeof(time_str), "%Y-%m-%dT%H:%M:%S", start_tm);
+
+    start_tm = localtime(&dump_time.tv_sec);
+    char time_val[32];
+    strftime(time_val, sizeof(time_val), "%a %b %d %Y, %X %p", start_tm);
+    ZITI_LOG(INFO,"============================ service begins ================================");
+    ZITI_LOG(INFO,"Logger initialization");
+    ZITI_LOG(INFO,"	- initialized at   : %s (local time), %s (UTC)", time_val, time_str);
+    ZITI_LOG(INFO,"	- log file location: %s", get_log_file_name());
+    ZITI_LOG(INFO,"============================================================================");
     move_config_from_previous_windows_backup(ziti_loop);
 #else
     ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, NULL);
@@ -2965,6 +2965,7 @@ int main(int argc, char *argv[]) {
     }
 
 #if _WIN32
+    scm_grant_se_debug();
     SvcStart();
 
     // if service is started by SCM, SvcStart will return only when it receives the stop request

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1825,6 +1825,12 @@ static void run(int argc, char *argv[]) {
     ZITI_LOG(INFO,"	- log file location: %s", get_log_file_name());
     ZITI_LOG(INFO,"============================================================================");
     move_config_from_previous_windows_backup(ziti_loop);
+
+    ZITI_LOG(DEBUG, "granting se_debug privilege to current process to allow access to privileged processes during posture checks");
+    //ensure this process has the necessary access token to get the full path of privileged processes
+    if (!scm_grant_se_debug()){
+        ZITI_LOG(WARN, "could not set se debug access token on process. if process posture checks seem inconsistent this may be why");
+    }
 #else
     ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, NULL);
 #endif
@@ -2965,7 +2971,6 @@ int main(int argc, char *argv[]) {
     }
 
 #if _WIN32
-    scm_grant_se_debug();
     SvcStart();
 
     // if service is started by SCM, SvcStart will return only when it receives the stop request


### PR DESCRIPTION
closes #444 

* remove multiwriter bool and related stuff
* update format away from %FT%T as it is inconsistent on windows. replace with long form
* add function to grant SE_DEBUG to the executing process
* change the way dates print to not be reliant on log init