### PR TITLE
move doc fragments about tunnelers to main article in ziti-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,78 +9,9 @@ that are useful to Ziti Tunnelers.
 
 ## What's a Ziti Tunneler?
 
-Ziti Tunnelers allow pre-existing TCP/IP applications to access or provide
-services on a secure Ziti network. A Ziti Tunneler is a Ziti-native application
-that communicates with local peers using TCP/IP and proxies the payload to/from
-a Ziti service.
-
-Note that embedding the Ziti SDK directly into an application is preferable to
-using a Ziti Tunneler, if possible. A Ziti-native application is secured and
-encrypted to the farthest edges of the communication path - all the way to the
-application's internal buffers. A Ziti Tunneler cannot secure the communication
-between itself and the TCP/IP application.
-
-Ziti Tunnelers are intended for situations where going Ziti-native is expensive
-or impossible to implement (e.g. a third-party applications or libraries). Ziti
-Tunnelers enable standard TCP/IP applications to reap _most_ of the security and
-reliability benefits offered by Ziti networks without changing a line of code.
-
-### Running `ziti-edge-tunnel`
-Download appropriate version from [Releases](https://github.com/openziti/ziti-tunnel-sdk-c/releases/latest)
-
-#### Linux
-Enrollment
-
-```
-$ ziti-edge-tunnel enroll -j <enrollment JWT file> -i <output identity file>
-```
-
-Run tunnel with default options (DNS configured with systemd-resolved)
-
-```
-$ ziti-edge-tunnel run -i <identity file>
-```
-
-Sample service file
-``` 
-[Unit]
-Description=Ziti Edge Tunnel
-After=network-online.target
-
-[Service]
-Type=simple
-ExecStart=/opt/openziti/bin/ziti-edge-tunnel run -i /opt/openziti/etc/id.json
-Restart=always
-RestartSec=3
-
-[Install]
-WantedBy=multi-user.target
-```
-
-#### How does ziti-edge-tunnel configure nameservers?
-
-`ziti-edge-tunnel run` provides a built-in nameserver that will answer queries
-that exactly match authorized OpenZiti services' intercept domain names, and
-will respond with a hard-fail `NXDOMAIN` code if the query does not match an
-authorized service.
-
-Optionally, you may enable DNS recursion by specifying an upstream nameserver
-to answer queries for other domain names that are not services' intercept
-domain names: `ziti-edge-tunnel run --dns-upstream 208.67.222.222`.
-
-`ziti-edge-tunnel` uses the `libsystemd` D-Bus RPC client and will try to
-configure the OS's resolvers with `systemd-resolved`. If that's not possible
-for any reason then `ziti-edge-tunnel run` will fall back to shell commands
-like `resolvectl`. If those too do not succeed then `ziti-edge-tunnel run` will
-attempt to modify `/etc/resolv.conf` directly to install the built-in
-nameserver as the primary resolver.
-
-`process_host_req()` in [`/lib/ziti-tunnel-cbs/ziti_dns.c`](/lib/ziti-tunnel-cbs/ziti_dns.c) looks up the queried
-hostname in the internal map. If the entry exists it returns the answer and
-sets query status to `NO_ERROR`. If it does not exist in the map, it sends the
-query to an upstream DNS server if available, and otherwise sets the query status to
-`REFUSE`. This implies to the caller they *should* keep trying to resolve the
-domain name with other nameservers.
+The main article about tunnellers is
+https://openziti.github.io/ziti/clients/tunneler.html. Editors may follow the
+"Improve this doc" link on any page.
 
 ## What is the Ziti Tunneler SDK?
 


### PR DESCRIPTION
Relates to https://github.com/openziti/ziti-doc/pull/138