### PR TITLE
if log_level is not set, return default INFO

### DIFF
--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -722,6 +722,9 @@ static const char *const level_labels[] = {
 };
 
 int get_log_level(const char* log_level) {
+    if(!log_level) {
+        return INFO; //no log level supplied - use INFO as default
+    }
     int lvl = 0;
     int num_levels = sizeof(level_labels) / sizeof(const char *);
     for (int i = 0;i < num_levels; i++) {

--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -723,7 +723,12 @@ static const char *const level_labels[] = {
 
 int get_log_level(const char* log_level) {
     if(!log_level) {
-        return INFO; //no log level supplied - use INFO as default
+        char* loglvl = getenv("ZITI_LOG");
+        if(!loglvl) {
+            return (int) INFO; //no log level supplied - use INFO as default
+        } else {
+            return (int) strtol(loglvl, NULL, 10);
+        }
     }
     int lvl = 0;
     int num_levels = sizeof(level_labels) / sizeof(const char *);


### PR DESCRIPTION
closes #454

`-i` doesn't read the config file. have to decide if we want that or not when using `-i`