### PR TITLE
use info on startup until processing actual log level. fix a warn->debug

### DIFF
--- a/lib/ziti-tunnel/ziti_tunnel.c
+++ b/lib/ziti-tunnel/ziti_tunnel.c
@@ -96,7 +96,7 @@ tunneler_context ziti_tunneler_init(tunneler_sdk_options *opts, uv_loop_t *loop)
 
 void ziti_tunnel_commit_routes(tunneler_context tnlr_ctx) {
     if (tnlr_ctx->opts.netif_driver == NULL) {
-        TNL_LOG(WARN, "No netif_driver found tun is running in host only mode and intercepts are disabled");
+        TNL_LOG(DEBUG, "No netif_driver found tun is running in host only mode and intercepts are disabled");
         return;
     }
 
@@ -107,7 +107,7 @@ void ziti_tunnel_commit_routes(tunneler_context tnlr_ctx) {
 
 void ziti_tunneler_exclude_route(tunneler_context tnlr_ctx, const char *dst) {
     if (tnlr_ctx->opts.netif_driver == NULL) {
-        TNL_LOG(WARN, "No netif_driver found tun is running in host only mode and intercepts are disabled");
+        TNL_LOG(DEBUG, "No netif_driver found tun is running in host only mode and intercepts are disabled");
         return;
     }
 

--- a/programs/ziti-edge-tunnel/instance-config.c
+++ b/programs/ziti-edge-tunnel/instance-config.c
@@ -118,7 +118,7 @@ bool save_tunnel_status_to_file() {
         if (sem_initialized == 0) {
             uv_sem_wait(&sem);
         } else {
-            ZITI_LOG(ERROR, "Could not save the config file [%s] due to semaphore lock not initialized error.", config_file_name);
+            ZITI_LOG(ZITI_WTF, "Could not save the config file [%s] due to semaphore lock not initialized error.", config_file_name);
             free(config_file_name);
             free(bkp_config_file_name);
             free(config_path);
@@ -155,9 +155,8 @@ bool save_tunnel_status_to_file() {
             fclose(config);
             ZITI_LOG(DEBUG, "Saved current tunnel status into Config file %s", config_file_name);
         }
-        if (sem_initialized == 0) {
-            uv_sem_post(&sem);
-        }
+        uv_sem_post(&sem);
+        
         ZITI_LOG(TRACE, "Cleaning up resources used for the backup of tunnel config file %s", config_file_name);
 
         free(config_file_name);
@@ -175,5 +174,7 @@ void cleanup_instance_config() {
     if (sem_initialized == 0) {
         //uv_sem_destroy(&sem);
         ZITI_LOG(DEBUG,"uv_sem_destroy done");
+    } else {
+        ZITI_LOG(ZITI_WTF, "Could not clean instance config. The semaphore is not initialized.");
     }
 }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1782,12 +1782,15 @@ static void run(int argc, char *argv[]) {
         load_tunnel_status_from_file(ziti_loop);
     }
 
+    //initialize logger to INFO here. logger will be set further down
 #if _WIN32
     log_init(ziti_loop);
-    ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, ziti_log_writer);
+    ziti_log_init(ziti_loop, INFO, ziti_log_writer);
     remove_all_nrpt_rules();
 
     signal(SIGINT, interrupt_handler);
+#else
+    ziti_log_init(ziti_loop, INFO, NULL);
 #endif
 
     uint32_t tun_ip;
@@ -1852,8 +1855,6 @@ static void run(int argc, char *argv[]) {
     if (!scm_grant_se_debug()){
         ZITI_LOG(WARN, "could not set se debug access token on process. if process posture checks seem inconsistent this may be why");
     }
-#else
-    ziti_log_init(ziti_loop, ZITI_LOG_DEFAULT_LEVEL, NULL);
 #endif
 
     // set log level from instance/config, if NULL is returned, the default log level will be used

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1775,12 +1775,7 @@ static void run(int argc, char *argv[]) {
     uv_cond_init(&stop_cond);
     uv_mutex_init(&stop_mutex);
 
-    // generate tunnel status instance and save active state and start time
-    if (config_dir != NULL) {
-        set_identifier_path(config_dir);
-        initialize_instance_config();
-        load_tunnel_status_from_file(ziti_loop);
-    }
+    initialize_instance_config();
 
     //initialize logger to INFO here. logger will be set further down
 #if _WIN32
@@ -1792,6 +1787,12 @@ static void run(int argc, char *argv[]) {
 #else
     ziti_log_init(ziti_loop, INFO, NULL);
 #endif
+
+    // generate tunnel status instance and save active state and start time
+    if (config_dir != NULL) {
+        set_identifier_path(config_dir);
+        load_tunnel_status_from_file(ziti_loop);
+    }
 
     uint32_t tun_ip;
     uint32_t dns_ip;


### PR DESCRIPTION
closes #464 

change two warns to debug and stop using `ZITI_LOG_DEFAULT_LEVEL` since the c sdk changed behaviors recently. Use INFO explicitly until processing the actual setting so certain startup messages are not skipped