### PR TITLE
fixes tun ip being incorrectly reported to zdew

### DIFF
--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -683,7 +683,7 @@ void set_ip_info(uint32_t dns_ip, uint32_t tun_ip, int bits) {
     }
     ip_addr_t dns_ip4 = IPADDR4_INIT(dns_ip);
     tnl_status.IpInfo = calloc(1, sizeof(ip_info));
-    tnl_status.IpInfo->Ip = strdup(ipaddr_ntoa(&dns_ip4));
+    tnl_status.IpInfo->Ip = strdup(ipaddr_ntoa(&tun_ip4));
     tnl_status.IpInfo->DNS = strdup(ipaddr_ntoa(&dns_ip4));
     tnl_status.IpInfo->MTU = 65535;
 
@@ -691,8 +691,8 @@ void set_ip_info(uint32_t dns_ip, uint32_t tun_ip, int bits) {
     netmask = htonl(netmask);
     ip_addr_t netmask_ipv4 = IPADDR4_INIT(netmask);
     tnl_status.IpInfo->Subnet = strdup(ipaddr_ntoa(&netmask_ipv4));
-
 }
+
 void set_log_level(const char* log_level) {
     if (log_level == NULL) {
         return;

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1798,7 +1798,6 @@ static void run(int argc, char *argv[]) {
     uint32_t dns_ip;
 
     if (!is_host_only()) {
-
         char *ip_range_temp = get_ip_range_from_config();
         if (ip_range_temp != NULL) {
             ip_range = ip_range_temp;
@@ -1818,8 +1817,8 @@ static void run(int argc, char *argv[]) {
             mask |= (ip[i] & 0xFFU);
         }
 
-        tun_ip = htonl(mask | 0x1);
-        dns_ip = htonl(mask | 0x2);
+        tun_ip = htonl(mask);
+        dns_ip = htonl(mask + 1);
 
         // set ip info into instance
         set_ip_info(dns_ip, tun_ip, bits);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1799,7 +1799,7 @@ static void run(int argc, char *argv[]) {
 
     uint32_t tun_ip;
     uint32_t dns_ip;
-    char* dns_range;
+    char* dns_range = calloc(sizeof(char), 32);
 
     if (!is_host_only()) {
         char *ip_range_temp = get_ip_range_from_config();
@@ -1828,8 +1828,7 @@ static void run(int argc, char *argv[]) {
         uint32_t dns_nw_addr = mask & (0xFFFFFFFFUL << (32 - bits)) & 0xFFFFFFFFUL;
 
         ip_addr_t dns_ip4_addr = IPADDR4_INIT(htonl(dns_nw_addr));
-        dns_range = strdup(ipaddr_ntoa(&dns_ip4_addr));
-        sprintf(dns_range, "%s/%d", strdup(ipaddr_ntoa(&dns_ip4_addr)), bits);
+        sprintf(dns_range, "%s/%d", ipaddr_ntoa(&dns_ip4_addr), bits);
 
         // set ip info into instance
         set_ip_info(dns_ip, tun_ip, bits);


### PR DESCRIPTION
closes #466 
closes #465

* use tun ip for the 'IP' field
* when calculating IP of tun - use the ip provided
* add to the tunip to get the dns ip