### PR TITLE
Docker get Ziti ID from env var instead of mounted file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,15 +3,15 @@ version: "3.9"
 x-base-service: &base-service
     image: openziti/ziti-edge-tunnel
     devices:
-    - /dev/net/tun:/dev/net/tun
+        - /dev/net/tun:/dev/net/tun
     volumes:
-    - .:/ziti-edge-tunnel
-    - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+        - .:/ziti-edge-tunnel
+        - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     environment:
-    - NF_REG_NAME                 # inherit when run like this: NF_REG_NAME=AcmeIdentity docker-compose up ziti-tun
-    - NF_REG_TOKEN                # NF_REG_NAME=AcmeIdentity NF_REG_TOKEN={JWT} docker-compose up ziti-tun
-    - PFXLOG_NO_JSON=true         # suppress JSON logging
-    network_mode: host            # use the Docker host's network, not the Docker bridge
+        - ZITI_IDENTITY_BASENAME                 # inherit when run like this: ZITI_IDENTITY_BASENAME=AcmeIdentity docker-compose up ziti-tun
+        - ZITI_ENROLL_TOKEN                # ZITI_IDENTITY_BASENAME=AcmeIdentity ZITI_ENROLL_TOKEN={JWT} docker-compose up ziti-tun
+        - PFXLOG_NO_JSON=true         # suppress JSON logging
+    network_mode: host                # use the Docker host's network, not the Docker bridge
     privileged: true
 
 services:
@@ -19,64 +19,70 @@ services:
     ziti-tun:                     # tunneler for one Ziti identity
         <<: *base-service
         command: 
-        - --verbose=4
-        - --dns-ip-range=100.64.64.0/18
+            - --verbose=4
+            - --dns-ip-range=100.64.64.0/18
 
     ziti-tun-dir:                 # tunneler for all identities in /ziti-edge-tunnel
         <<: *base-service
         command:
-        - --verbose=4
-        - --dns-ip-range=100.64.64.0/18
-        environment: []           # ignore NF_REG_NAME and load all identities in same dir
+            - --verbose=4
+            - --dns-ip-range=100.64.64.0/18
+        environment: []           # ignore ZITI_IDENTITY_BASENAME and load all identities in same dir
 
     ziti-test:                    # docker-compose exec ziti-test bash
         <<: *base-service
         entrypoint: ["sh", "-c", "while true; do sleep infinity; done"]
 
-    ziti-host:                    # tunneler for hosting services without providing DNS or IP routes
+
+    # enrolled identity JSON from env var is written to container filesystem /ziti-edge-tunnel/ziti_id.json
+    ziti-host:
         image: openziti/ziti-edge-tunnel
         environment:
-        - NF_REG_NAME
-        - NF_REG_TOKEN
-        volumes:
-        - .:/ziti-edge-tunnel
+            - ZITI_IDENTITY_JSON
         networks: 
-        - ziti-host
+            - ziti-host
         privileged: false         # no privileges necessary for run-host mode
         command: 
-        - run-host
-        - --verbose=4
+            - run-host
+            - --verbose=4
 
     ziti-host-wait:               # tunneler for hosting services that waits forever for the identity to become available
         image: openziti/ziti-edge-tunnel
         environment:
-        - NF_REG_NAME
-        - NF_REG_WAIT=-1          # optional seconds to wait for identity (or token) to become available, negative value is wait forever
+            - ZITI_IDENTITY_BASENAME
+            - ZITI_IDENTITY_WAIT=-1          # optional seconds to wait for identity (or token) to become available, negative value is wait forever
         volumes:
-        - .:/ziti-edge-tunnel
+            - .:/ziti-edge-tunnel
         networks: 
-        - ziti-host
+            - ziti-host
         privileged: false         # no privileges necessary for run-host mode
         command: 
-        - run-host
-        - --verbose=4
+            - run-host
+            - --verbose=4
 
     ziti-host-dir:                # tunneler for hosting services without providing DNS or IP routes
         image: openziti/ziti-edge-tunnel
-        environment: []           # ignore NF_REG_NAME and load all identities in same dir
+        environment: []           # ignore ZITI_IDENTITY_BASENAME and load all identities in same dir
         volumes:
-        - .:/ziti-edge-tunnel
+            - .:/ziti-edge-tunnel
         networks: 
-        - ziti-host
+            - ziti-host
         privileged: false         # no privileges necessary for run-host mode
         command: 
-        - run-host
-        - --verbose=4
+            - run-host
+            - --verbose=4
 
     hello:                       # http://hello:80 from bridge network "ziti-host"
         image: netfoundry/hello-world-webpage
         networks: 
-        - ziti-host
+            - ziti-host
+
+    httpbin:
+        image: mccutchen/go-httpbin
+        networks: 
+            - ziti-host
+        # ports:
+        #   - "127.0.0.1:8080:8080/tcp"
 
 networks:
     ziti-host:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,10 +8,10 @@ x-base-service: &base-service
         - .:/ziti-edge-tunnel
         - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     environment:
-        - ZITI_IDENTITY_BASENAME                 # inherit when run like this: ZITI_IDENTITY_BASENAME=AcmeIdentity docker-compose up ziti-tun
-        - ZITI_ENROLL_TOKEN                # ZITI_IDENTITY_BASENAME=AcmeIdentity ZITI_ENROLL_TOKEN={JWT} docker-compose up ziti-tun
-        - PFXLOG_NO_JSON=true         # suppress JSON logging
-    network_mode: host                # use the Docker host's network, not the Docker bridge
+        - ZITI_IDENTITY_BASENAME  # inherit when run like this: ZITI_IDENTITY_BASENAME=AcmeIdentity docker-compose up ziti-tun
+        - ZITI_ENROLL_TOKEN       # ZITI_IDENTITY_BASENAME=AcmeIdentity ZITI_ENROLL_TOKEN={JWT} docker-compose up ziti-tun
+        - PFXLOG_NO_JSON=true     # suppress JSON logging
+    network_mode: host            # use the Docker host's network, not the Docker bridge
     privileged: true
 
 services:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -37,10 +37,14 @@ fi
 
 if ! mountpoint "${IDENTITIES_DIR}" &>/dev/null; then
     echo "WARN: the identities directory is only available inside this container because ${IDENTITIES_DIR} is not a mounted volume. Be careful to not publish this image with identity inside or lose access to the identity by removing the image prematurely." >&2
+else
+    if [[ -n "${ZITI_IDENTITY_JSON:-}" ]]; then
+        echo "WARNING: you supplied the Ziti identity as an env var and you mounted a volume on the identities dir. You may avoid this warning and future errors by not mounting a volume on ${IDENTITIES_DIR} when ZITI_IDENTITY_JSON is defined." >&2
+    fi
 fi
 
 #
-## Map preferred, Ziti var names to legacy NF names. This allows us to begin using the preferred vars right away 
+## Map the preferred, Ziti var names to legacy NF names. This allows us to begin using the preferred vars right away 
 ##  while minimizing immediate differences to the main control structure. This eases code review. Later, the legacy
 ##  names can be retired and replaced.
 #


### PR DESCRIPTION
Also, start using Ziti env var names mapped to existing NF names e.g. `ZITI_ENROLL_TOKEN` instead of `NF_REG_TOKEN` while preserving backwards compat.