### PR TITLE
build linux artifacts in containers. re-use cmake workflow.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,9 +7,15 @@ on:
   pull_request:
     branches: [ main ]
 
+  workflow_call:
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    env:
+      common_ubuntu_deps: curl doxygen libssl-dev libsystemd-dev pkg-config zlib1g-dev zip
+
     strategy:
       fail-fast: false
       matrix:
@@ -23,58 +29,76 @@ jobs:
             name: Windows x86_64
             arch: x86_64
 
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             container: ubuntu:18.04
             name: Linux x86_64
-            install: libsystemd-dev
+            install: $common_ubuntu_deps build-essential
             arch: x86_64
 
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             container: ubuntu:18.04
             name: Linux arm
-            install: crossbuild-essential-armhf libsystemd-dev
+            install: $common_ubuntu_deps crossbuild-essential-armhf
             toolchain: Linux-arm.cmake
             cmake_opts: -DCMAKE_BUILD_TYPE=Release
             arch: arm
 
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             container: ubuntu:18.04
             name: Linux arm64
-            install: crossbuild-essential-arm64 libsystemd-dev
+            install: $common_ubuntu_deps crossbuild-essential-arm64
             toolchain: Linux-arm64.cmake
             cmake_opts: -DCMAKE_BUILD_TYPE=Release
             arch: arm64
 
     steps:
+      - name: install tools
+        if: ${{ matrix.install != null }}
+        run: |
+          apt -y update
+          apt -y install ${{ matrix.install }}
+
+      - name: install contemporary git
+        if: ${{ matrix.container != null }}
+        run: |
+          apt -y update
+          apt -y install software-properties-common
+          add-apt-repository -y ppa:git-core/ppa
+          apt -y update
+          apt -y install git
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git --version
+
+      - name: install contemporary cmake
+        if: ${{ matrix.container != null }}
+        run: |
+          curl -L https://cmake.org/files/v3.24/cmake-3.24.2-linux-x86_64.sh -o cmake.sh
+          bash cmake.sh --skip-license --prefix=/usr/local
+          rm cmake.sh
+
       - name: checkout workspace
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: make build dir
-        run: cmake -E make_directory ${{runner.workspace}}/build
-
-      - name: install toolchain
-        if: ${{ matrix.install != null }}
-        run: |
-          sudo apt -y update
-          sudo apt -y install ${{ matrix.install }}
+        run: cmake -E make_directory ./build
 
       - name: configure cmake
         env:
-          TOOLCHAIN: ${{ matrix.toolchain && format('{0}/toolchains/{1}', github.workspace, matrix.toolchain) || '' }}
-        run: cmake ${{matrix.cmake_opts}} -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" -S ${{ github.workspace }} -B ${{github.workspace}}/build
+          TOOLCHAIN: ${{ matrix.toolchain && format('./toolchains/{0}', matrix.toolchain) || '' }}
+        run: cmake ${{matrix.cmake_opts}} -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" -S . -B ./build
 
       - name: build ziti-edge-tunnel bundle target
-        run: cmake --build ${{github.workspace}}/build --target bundle --verbose
+        run: cmake --build ./build --target bundle --verbose
 
       - name: list bundle artifacts
         run: ls -R
-        working-directory: ${{ github.workspace }}/build/bundle/
+        working-directory: ./build/bundle/
 
       - name: list program artifacts
         run: ls -R
-        working-directory: ${{ github.workspace }}/build/programs/ziti-edge-tunnel/
+        working-directory: ./build/programs/ziti-edge-tunnel/
 
       - name: upload bundle artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -71,10 +71,7 @@ jobs:
 
       - name: install contemporary cmake
         if: ${{ matrix.container != null }}
-        run: |
-          curl -L https://cmake.org/files/v3.24/cmake-3.24.2-linux-x86_64.sh -o cmake.sh
-          bash cmake.sh --skip-license --prefix=/usr/local
-          rm cmake.sh
+        uses: lukka/get-cmake@latest
 
       - name: checkout workspace
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,130 +4,57 @@ on:
     types:
       - published
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: macOS-10.15
-            name: macOS x86_64
-            arch: x86_64
-            toolchain: default.cmake
-
-          - os: windows-latest
-            name: Windows x86_64
-            arch: x86_64
-
-          - os: ubuntu-latest
-            container: ubuntu:18.04
-            name: Linux x86_64
-            install: libsystemd-dev
-            toolchain: default.cmake
-            arch: x86_64
-
-          - os: ubuntu-latest
-            container: ubuntu:18.04
-            name: Linux arm
-            install: crossbuild-essential-armhf libsystemd-dev
-            toolchain: Linux-arm.cmake
-            cmake_opts: -DCMAKE_BUILD_TYPE=Release
-            arch: arm
-
-          - os: ubuntu-latest
-            container: ubuntu:18.04
-            name: Linux arm64
-            install: crossbuild-essential-arm64 libsystemd-dev
-            toolchain: Linux-arm64.cmake
-            cmake_opts: -DCMAKE_BUILD_TYPE=Release
-            arch: arm64
-
-    steps:
-    - name: checkout workspace
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: make build dir
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: install toolchain
-      if: ${{ matrix.install != null }}
-      run: |
-        sudo apt -y update
-        sudo apt -y install ${{ matrix.install }}
-
-    - name: configure cmake
-      env:
-        TOOLCHAIN: ${{ matrix.toolchain && format('{0}/toolchains/{1}', github.workspace, matrix.toolchain) || '' }}
-      run: cmake ${{matrix.cmake_opts}} -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" -S ${{ github.workspace }} -B ${{github.workspace}}/build
-
-    - name: build ziti-edge-tunnel bundle target
-      run: cmake --build ${{github.workspace}}/build --target bundle --verbose
-
-    - name: list bundle artifacts
-      run: ls -R
-      working-directory: ${{ github.workspace }}/build/bundle/
-
-    - name: list program artifacts
-      run: ls -R
-      working-directory: ${{ github.workspace }}/build/programs/ziti-edge-tunnel/
-
-    - name: upload bundle artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ runner.os }}-${{ matrix.arch }}
-        path: |
-          ./build/bundle/ziti-edge-tunnel-*.zip
-        if-no-files-found: error
+  call-cmake-build:
+    uses: ./.github/workflows/cmake.yml
 
   release:
     name: Download Release Artifacts
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [ call-cmake-build ]
     steps:
-    - name: download
-      uses: actions/download-artifact@v2
-      with:
-        path: ${{ runner.workspace }}/downloads/
+      - name: download
+        uses: actions/download-artifact@v2
+        with:
+          path: ${{ runner.workspace }}/downloads/
 
-    - name: List Release Artifacts
-      run: ls -horRAS ${{runner.workspace}}/downloads/
+      - name: List Release Artifacts
+        run: ls -horRAS ${{runner.workspace}}/downloads/
 
-    - name: Release
-      id: get_release
-      uses: softprops/action-gh-release@v1
-      with:
-        # name: defaults to tag name
-        # tag_name: defaults to github.ref
-        # token: defaults to github.token
-        draft: false
-        prerelease: false
-        fail_on_unmatched_files: true
-        files: |
-          ${{ runner.workspace }}/downloads/Linux-x86_64/ziti-edge-tunnel-Linux_x86_64.zip
-          ${{ runner.workspace }}/downloads/Linux-arm/ziti-edge-tunnel-Linux_arm.zip
-          ${{ runner.workspace }}/downloads/macOS-x86_64/ziti-edge-tunnel-Darwin_x86_64.zip
+      - name: Release
+        id: get_release
+        uses: softprops/action-gh-release@v1
+        with:
+          # name: defaults to tag name
+          # tag_name: defaults to github.ref
+          # token: defaults to github.token
+          draft: false
+          prerelease: false
+          fail_on_unmatched_files: true
+          files: |
+            ${{ runner.workspace }}/downloads/Linux-x86_64/ziti-edge-tunnel-Linux_x86_64.zip
+            ${{ runner.workspace }}/downloads/Linux-arm/ziti-edge-tunnel-Linux_arm.zip
+            ${{ runner.workspace }}/downloads/macOS-x86_64/ziti-edge-tunnel-Darwin_x86_64.zip
 
-    # These final two steps are only necessary because we prefer a different
-    # release artifact name than is created by CMake, and so we could change
-    # the CMake configuration or add an inline (shell) run step to manipulate
-    # the filenames. The pre-release build doesn't rename the artifacts.
-    - name: upload Linux ARM64 with different name
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
-        asset_path: ${{ runner.workspace }}/downloads/Linux-arm64/ziti-edge-tunnel-Linux_aarch64.zip
-        asset_name: ziti-edge-tunnel-Linux_arm64.zip
-        asset_content_type: application/octet-stream
+      # These final two steps are only necessary because we prefer a different
+      # release artifact name than is created by CMake, and so we could change
+      # the CMake configuration or add an inline (shell) run step to manipulate
+      # the filenames. The pre-release build doesn't rename the artifacts.
+      - name: upload Linux ARM64 with different name
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ${{ runner.workspace }}/downloads/Linux-arm64/ziti-edge-tunnel-Linux_aarch64.zip
+          asset_name: ziti-edge-tunnel-Linux_arm64.zip
+          asset_content_type: application/octet-stream
 
-    - name: upload Windows with different name
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
-        asset_path: ${{ runner.workspace }}/downloads/Windows-x86_64/ziti-edge-tunnel-Windows_AMD64.zip
-        asset_name: ziti-edge-tunnel-Windows_x86_64.zip
-        asset_content_type: application/octet-stream
+      - name: upload Windows with different name
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ${{ runner.workspace }}/downloads/Windows-x86_64/ziti-edge-tunnel-Windows_AMD64.zip
+          asset_name: ziti-edge-tunnel-Windows_x86_64.zip
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
Use containers when building linux artifacts. this lets us use any version of any distro that we want for builds, without needing to "upgrade" when GitHub deprecates linux runners.

For now the runner is pinned at ubuntu-20.04 to ensure the oldest possible kernel. I left the build os at ubuntu-18.04, so that the builds are effectively unchanged from what we were getting before this PR. Of course we can now easily go back to an older distro if we want.

The release workflow also re-uses the cmake workflow instead of copying/pasting it. I'm sure we can use similar tricks to fold some of the cpack workflow, but this seems like a worthwhile improvement for now.