### PR TITLE
update ziti-sdk-c to 0.30.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.30.1")
+    set(ZITI_SDK_C_BRANCH "0.30.2")
 endif()
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel


### PR DESCRIPTION
0.30.2 fixes build errors with mingw, which is used by zdew