### PR TITLE
Use correct has_arg when parsing command line options with getopt_long

### DIFF
--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1950,9 +1950,9 @@ static int parse_enroll_opts(int argc, char *argv[]) {
     static struct option opts[] = {
             {"jwt", required_argument, NULL, 'j'},
             {"identity", required_argument, NULL, 'i'},
-            {"key", optional_argument, NULL, 'k'},
-            {"cert", optional_argument, NULL, 'c'},
-            { "name", optional_argument, NULL, 'n'}
+            {"key", required_argument, NULL, 'k'},
+            {"cert", required_argument, NULL, 'c'},
+            { "name", required_argument, NULL, 'n'}
     };
     int c, option_index, errors = 0;
     optind = 0;

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2038,8 +2038,8 @@ static tunnel_command *cmd;
 
 static int dump_opts(int argc, char *argv[]) {
     static struct option opts[] = {
-            {"identity", optional_argument, NULL, 'i'},
-            {"dump_path", optional_argument, NULL, 'p'},
+            {"identity", required_argument, NULL, 'i'},
+            {"dump_path", required_argument, NULL, 'p'},
     };
     int c, option_index, errors = 0;
     optind = 0;

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1670,8 +1670,8 @@ static struct option run_options[] = {
 static struct option run_host_options[] = {
         { "identity", required_argument, NULL, 'i' },
         { "identity-dir", required_argument, NULL, 'I'},
-        { "verbose", optional_argument, NULL, 'v'},
-        { "refresh", optional_argument, NULL, 'r'},
+        { "verbose", required_argument, NULL, 'v'},
+        { "refresh", required_argument, NULL, 'r'},
 };
 
 #ifndef DEFAULT_DNS_CIDR
@@ -1686,6 +1686,7 @@ static int run_opts(int argc, char *argv[]) {
 
     int c, option_index, errors = 0;
     optind = 0;
+    bool identity_provided = false;
 
     while ((c = getopt_long(argc, argv, "i:I:v:r:d:u:",
                             run_options, &option_index)) != -1) {
@@ -1694,10 +1695,12 @@ static int run_opts(int argc, char *argv[]) {
                 struct cfg_instance_s *inst = calloc(1, sizeof(struct cfg_instance_s));
                 inst->cfg = strdup(optarg);
                 LIST_INSERT_HEAD(&load_list, inst, _next);
+                identity_provided = true;
                 break;
             }
             case 'I':
                 config_dir = optarg;
+                identity_provided = true;
                 break;
             case 'v':
                 setenv("ZITI_LOG", optarg, true);
@@ -1731,18 +1734,21 @@ static int run_host_opts(int argc, char *argv[]) {
 
     int c, option_index, errors = 0;
     optind = 0;
+    bool identity_provided = false;
 
     while ((c = getopt_long(argc, argv, "i:I:v:r:",
-                            run_options, &option_index)) != -1) {
+                            run_host_options, &option_index)) != -1) {
         switch (c) {
             case 'i': {
                 struct cfg_instance_s *inst = calloc(1, sizeof(struct cfg_instance_s));
                 inst->cfg = strdup(optarg);
                 LIST_INSERT_HEAD(&load_list, inst, _next);
+                identity_provided = true;
                 break;
             }
             case 'I':
                 config_dir = optarg;
+                identity_provided = true;
                 break;
             case 'v':
                 setenv("ZITI_LOG", optarg, true);
@@ -1757,7 +1763,7 @@ static int run_host_opts(int argc, char *argv[]) {
             }
         }
     }
-    if (errors > 0) {
+    if (errors > 0 || !identity_provided) {
         commandline_help(stderr);
         exit(1);
     }
@@ -2510,9 +2516,9 @@ static int set_log_level_opts(int argc, char *argv[]) {
 
 static int update_tun_ip_opts(int argc, char *argv[]) {
     static struct option opts[] = {
-            {"tunip", optional_argument, NULL, 't'},
-            {"prefixlength", optional_argument, NULL, 'p'},
-            {"addDNS", optional_argument, NULL, 'd'},
+            {"tunip", required_argument, NULL, 't'},
+            {"prefixlength", required_argument, NULL, 'p'},
+            {"addDNS", required_argument, NULL, 'd'},
     };
     int c, option_index, errors = 0;
     optind = 0;

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1982,7 +1982,7 @@ static int parse_enroll_opts(int argc, char *argv[]) {
             }
         }
     }
-    if (errors > 0) {
+    if (errors > 0 || enroll_opts.jwt == NULL || enroll_opts.enroll_key == NULL) {
         commandline_help(stderr);
         exit(1);
     }


### PR DESCRIPTION
`getopt_long` takes an array of `struct option` to represent recognized command line options. `struct option` has a field `has_arg` which specifies whether or not the command line option has an associated argument; possible values are:

- `no_argument`:            no argument to the option is expected
- `required_argument`:      an argument to the option is required
- `optional_argument`:      an argument to the option may be presented

We've been incorrectly setting this field to `optional_argument` in some cases when the intent was to make the command line option itself optional. This PR sets `has_arg` to `required_argument` where appropriate, and adds logic to ensure that required options are passed.