### PR TITLE
Ensure that BYTE_ORDER is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.30.2")
+    set(ZITI_SDK_C_BRANCH "0.30.4")
 endif()
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel

--- a/lib/ziti-tunnel/CMakeLists.txt
+++ b/lib/ziti-tunnel/CMakeLists.txt
@@ -35,7 +35,7 @@ set (LWIP_INCLUDE_DIRS
 include(${LWIP_DIR}/src/Filelists.cmake)
 
 target_sources(lwipcore PRIVATE ${lwip_sys_srcs} lwip/lwiphooks_ip6.c lwip/lwiphooks_ip4.c lwip/lwip_cloned_fns.c)
-target_compile_definitions(lwipcore PUBLIC CMAKE_C_BYTE_ORDER=${CMAKE_C_BYTE_ORDER})
+#target_compile_definitions(lwipcore PUBLIC CMAKE_C_BYTE_ORDER=${CMAKE_C_BYTE_ORDER})
 
 target_include_directories(ziti-tunnel-sdk-c
         PUBLIC ${LWIP_INCLUDE_DIRS}

--- a/lib/ziti-tunnel/CMakeLists.txt
+++ b/lib/ziti-tunnel/CMakeLists.txt
@@ -35,7 +35,7 @@ set (LWIP_INCLUDE_DIRS
 include(${LWIP_DIR}/src/Filelists.cmake)
 
 target_sources(lwipcore PRIVATE ${lwip_sys_srcs} lwip/lwiphooks_ip6.c lwip/lwiphooks_ip4.c lwip/lwip_cloned_fns.c)
-#target_compile_definitions(lwipcore PUBLIC CMAKE_C_BYTE_ORDER=${CMAKE_C_BYTE_ORDER})
+target_compile_definitions(lwipcore PUBLIC CMAKE_C_BYTE_ORDER=${CMAKE_C_BYTE_ORDER})
 
 target_include_directories(ziti-tunnel-sdk-c
         PUBLIC ${LWIP_INCLUDE_DIRS}

--- a/lib/ziti-tunnel/CMakeLists.txt
+++ b/lib/ziti-tunnel/CMakeLists.txt
@@ -35,6 +35,7 @@ set (LWIP_INCLUDE_DIRS
 include(${LWIP_DIR}/src/Filelists.cmake)
 
 target_sources(lwipcore PRIVATE ${lwip_sys_srcs} lwip/lwiphooks_ip6.c lwip/lwiphooks_ip4.c lwip/lwip_cloned_fns.c)
+target_compile_definitions(lwipcore PUBLIC CMAKE_C_BYTE_ORDER=${CMAKE_C_BYTE_ORDER})
 
 target_include_directories(ziti-tunnel-sdk-c
         PUBLIC ${LWIP_INCLUDE_DIRS}

--- a/lib/ziti-tunnel/intercept.c
+++ b/lib/ziti-tunnel/intercept.c
@@ -108,7 +108,6 @@ const ziti_address *address_match(const ziti_address *addr, const address_list_t
 
     STAILQ_FOREACH(a, addresses, entries) {
         score = ziti_address_match(addr, &a->za);
-        TNL_LOG(VERBOSE, "ziti_address_match score %d", score);
         if (score < 0) continue;
         if (best_score == -1 || score < best_score) {
             best_score = score;

--- a/lib/ziti-tunnel/lwip/lwipopts.h
+++ b/lib/ziti-tunnel/lwip/lwipopts.h
@@ -12,7 +12,12 @@
 #if __linux__
 #include <endian.h>
 #elif _WIN32
+#ifdef _MSC_VER
+#include <netiodef.h>
+#endif
+#ifdef __MINGW32__
 #include <sys/param.h>
+#endif
 #elif __APPLE__ && __MACH__
 #include <machine/endian.h>
 #endif

--- a/lib/ziti-tunnel/lwip/lwipopts.h
+++ b/lib/ziti-tunnel/lwip/lwipopts.h
@@ -8,21 +8,16 @@
 #endif
 
 // make sure BYTE_ORDER is defined early, otherwise some lwip sources will be compiled with inconsistent values.
+#include "lwip/arch.h" // defines BIG_ENDIAN, LITTLE_ENDIAN
 #ifndef BYTE_ORDER
-#if __linux__
-#include <endian.h>
-#elif _WIN32
-#ifdef _MSC_VER
-#include <netiodef.h>
-#endif
-#ifdef __MINGW32__
-#include <sys/param.h>
-#endif
-#elif __APPLE__ && __MACH__
-#include <machine/endian.h>
-#endif
-#ifndef BYTE_ORDER
-#error "BYTE_ORDER is not defined"
+#error "could not determine BYTE_ORDER"
+#else
+#if BYTE_ORDER == LITTLE_ENDIAN
+#warning "BYTE_ORDER == LITTLE_ENDIAN"
+#elif BYTE_ORDER == BIG_ENDIAN
+#warning "BYTE_ORDER == BIG_ENDIAN"
+#else
+#error "we need BYTE_ORDER"
 #endif
 #endif
 

--- a/lib/ziti-tunnel/lwip/lwipopts.h
+++ b/lib/ziti-tunnel/lwip/lwipopts.h
@@ -65,7 +65,7 @@
 #define BYTE_ORDER CMAKE_C_BYTE_ORDER // define BYTE_ORDER before including arch.h. the default is dumb.
 #include "lwip/arch.h" // defines BIG_ENDIAN, etc
 
-#if (BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN && BYTE_ORDER != PDP_ENDIAN)
+#if (BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN)
 #error "BYTE_ORDER is not defined"
 #endif
 #endif

--- a/lib/ziti-tunnel/lwip/lwipopts.h
+++ b/lib/ziti-tunnel/lwip/lwipopts.h
@@ -7,17 +7,13 @@
 #define MEM_SIZE              524288      /* the size of the heap memory (1600) */
 #endif
 
-// make sure BYTE_ORDER is defined early, otherwise some lwip sources will be compiled with inconsistent values.
-#include "lwip/arch.h" // defines BIG_ENDIAN, LITTLE_ENDIAN
 #ifndef BYTE_ORDER
-#error "could not determine BYTE_ORDER"
-#else
-#if BYTE_ORDER == LITTLE_ENDIAN
-#warning "BYTE_ORDER == LITTLE_ENDIAN"
-#elif BYTE_ORDER == BIG_ENDIAN
-#warning "BYTE_ORDER == BIG_ENDIAN"
-#else
-#error "we need BYTE_ORDER"
+// make sure BYTE_ORDER is defined early, otherwise lwip sources will be compiled with inconsistent values.
+#define BYTE_ORDER CMAKE_C_BYTE_ORDER // define BYTE_ORDER before including arch.h. the default is dumb.
+#include "lwip/arch.h" // defines BIG_ENDIAN, etc
+
+#if (BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN && BYTE_ORDER != PDP_ENDIAN)
+#error "BYTE_ORDER is not defined"
 #endif
 #endif
 

--- a/lib/ziti-tunnel/lwip/lwipopts.h
+++ b/lib/ziti-tunnel/lwip/lwipopts.h
@@ -7,6 +7,13 @@
 #define MEM_SIZE              524288      /* the size of the heap memory (1600) */
 #endif
 
+#ifndef BYTE_ORDER
+#include <endian.h>
+#ifndef BYTE_ORDER
+#error "BYTE_ORDER is not defined"
+#endif
+#endif
+
 #if SCAREY_DEBUGGING_LWIP
 #define MEMP_OVERFLOW_CHECK   2           /* reserves bytes before and after each memp element in every pool and fills it with a prominent default value */
 #define MEMP_SANITY_CHECK     1           /* run a sanity check after each mem_free() to make sure that the linked list of heap elements is not corrupted */

--- a/lib/ziti-tunnel/lwip/lwipopts.h
+++ b/lib/ziti-tunnel/lwip/lwipopts.h
@@ -7,16 +7,6 @@
 #define MEM_SIZE              524288      /* the size of the heap memory (1600) */
 #endif
 
-#ifndef BYTE_ORDER
-// make sure BYTE_ORDER is defined early, otherwise lwip sources will be compiled with inconsistent values.
-#define BYTE_ORDER CMAKE_C_BYTE_ORDER // define BYTE_ORDER before including arch.h. the default is dumb.
-#include "lwip/arch.h" // defines BIG_ENDIAN, etc
-
-#if (BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN && BYTE_ORDER != PDP_ENDIAN)
-#error "BYTE_ORDER is not defined"
-#endif
-#endif
-
 #if SCAREY_DEBUGGING_LWIP
 #define MEMP_OVERFLOW_CHECK   2           /* reserves bytes before and after each memp element in every pool and fills it with a prominent default value */
 #define MEMP_SANITY_CHECK     1           /* run a sanity check after each mem_free() to make sure that the linked list of heap elements is not corrupted */
@@ -68,6 +58,16 @@
 #ifdef _WIN32
 #define LWIP_NORAND 1
 #define LWIP_NO_UNISTD_H 1
+#endif
+
+#ifndef BYTE_ORDER
+// make sure BYTE_ORDER is defined early, otherwise lwip sources will be compiled with inconsistent values.
+#define BYTE_ORDER CMAKE_C_BYTE_ORDER // define BYTE_ORDER before including arch.h. the default is dumb.
+#include "lwip/arch.h" // defines BIG_ENDIAN, etc
+
+#if (BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN && BYTE_ORDER != PDP_ENDIAN)
+#error "BYTE_ORDER is not defined"
+#endif
 #endif
 
 // hooks

--- a/lib/ziti-tunnel/lwip/lwipopts.h
+++ b/lib/ziti-tunnel/lwip/lwipopts.h
@@ -7,8 +7,15 @@
 #define MEM_SIZE              524288      /* the size of the heap memory (1600) */
 #endif
 
+// make sure BYTE_ORDER is defined early, otherwise some lwip sources will be compiled with inconsistent values.
 #ifndef BYTE_ORDER
+#if __linux__
 #include <endian.h>
+#elif _WIN32
+#include <sys/param.h>
+#elif __APPLE__ && __MACH__
+#include <machine/endian.h>
+#endif
 #ifndef BYTE_ORDER
 #error "BYTE_ORDER is not defined"
 #endif


### PR DESCRIPTION
The `BYTE_ORDER` C preprocessor macro is needed by lwip, but the lwip includes (and -contrib packages) don't always include the correct system includes to pick up a definition of `BYTE_ORDER`. It turns out that there is no standard include file for getting `BYTE_ORDER`, so this PR relies on a `cmake` variable, but only if `BYTE_ORDER` is not already defined.