### PR TITLE
get cmake 3.22 when building on ubuntu 20

### DIFF
--- a/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/Dockerfile
@@ -1,4 +1,8 @@
+ARG CMAKE_VERSION="3.22.3"
+
 FROM ubuntu:focal
+
+ARG CMAKE_VERSION
 
 LABEL org.opencontainers.image.authors="steven.broderick@netfoundry.io,kenneth.bingham@netfoundry.io"
 
@@ -12,7 +16,6 @@ WORKDIR /root/
 RUN apt-get -y update \
     && apt-get -y install \
         build-essential \
-        cmake \
         curl \
         doxygen \
         git \
@@ -24,6 +27,10 @@ RUN apt-get -y update \
         zlib1g-dev \
         libssl-dev \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-linux-x86_64.sh -o cmake.sh \
+    && (bash cmake.sh --skip-license --prefix=/usr/local) \
+    && rm cmake.sh
 
 COPY ./entrypoint.sh /root/
 ENTRYPOINT [ "/root/entrypoint.sh" ]


### PR DESCRIPTION
The cmake scripts now reference `CMAKE_C_BYTE_ORDER`, which is defined by cmake 3.20 and later.