### PR TITLE
Fix bug where log doesn't rotate at the end of a month.

### DIFF
--- a/programs/ziti-edge-tunnel/windows/log_utils.c
+++ b/programs/ziti-edge-tunnel/windows/log_utils.c
@@ -109,7 +109,7 @@ void flush_log(uv_check_t *handle) {
 
     if (handle->data) {
         struct tm *orig_time = handle->data;
-        if (orig_time->tm_mday < tm->tm_mday) {
+        if (orig_time->tm_mday < tm->tm_mday || orig_time->tm_mon < tm->tm_mon || orig_time->tm_year < tm->tm_year) {
             if (rotate_log()) {
                 uv_async_t *ar = calloc(1, sizeof(uv_async_t));
                 uv_async_init(handle->loop, ar, update_symlink_async);


### PR DESCRIPTION
Resolves #486. Check also a month and year difference (will prevent a bug where log would not be rotated at the end of the year).