### PR TITLE
get ziti-sdk-c 0.30.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 if(NOT ZITI_SDK_C_BRANCH)
     #allow using a different branch of the CSDK easily
-    set(ZITI_SDK_C_BRANCH "0.30.4")
+    set(ZITI_SDK_C_BRANCH "0.30.8")
 endif()
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel


### PR DESCRIPTION
ziti-sdk-c 0.30.8 fixes https://github.com/openziti/ziti-sdk-c/issues/475, which caused tunnelers to hang when intercept.v1 or host.v1 service configurations were updated