### PR TITLE
upload deb to arch subkey

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -218,7 +218,7 @@ jobs:
         run: >
           jf rt upload
           ./build/ziti-edge-tunnel-*.${{ matrix.distro.type }}
-          /zitipax-openziti-deb-stable/pool/ziti-edge-tunnel/${{ matrix.distro.release_name }}/ 
+          /zitipax-openziti-deb-stable/pool/ziti-edge-tunnel/${{ matrix.distro.release_name }}/${{ matrix.arch.deb }}/
           --deb=${{ matrix.distro.release_name }}/main/${{ matrix.arch.deb }}
           --recursive=false
           --flat=true 


### PR DESCRIPTION
Now that we serve multiple architectures, we need to partition the upload keyspace by architecture. The architecture is also stored in the metadata of the Debian package. Still, the uploads for 0.20.10 were clobbered because all architectures uploaded to the same path, and the package build artifacts have identical filenames.