### PR TITLE
use full mask when setting address on utun device

### DIFF
--- a/programs/ziti-edge-tunnel/netif_driver/darwin/utun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/darwin/utun.c
@@ -246,8 +246,11 @@ netif_driver utun_open(char *error, size_t error_len, const char *cidr) {
         if (prefix_sep != NULL) {
             ip_len = (int)(prefix_sep - cidr);
         }
+        long prefix = strtol(prefix_sep+1, NULL, 10);
+        in_addr_t netmask = (0xffffffff << (32 - prefix)) & 0xffffffff;
+        struct in_addr netmask_in = inet_makeaddr(netmask, 0);
         // add address to interface. darwin utun devices may only have "point to point" addresses
-        snprintf(cmd, sizeof(cmd), "ifconfig %s %.*s %.*s", tun->name, ip_len, cidr, ip_len, cidr);
+        snprintf(cmd, sizeof(cmd), "ifconfig %s %.*s %.*s netmask %s", tun->name, ip_len, cidr, ip_len, cidr, inet_ntoa(netmask_in));
         system(cmd);
 
         // add a route for the subnet if one was specified

--- a/programs/ziti-edge-tunnel/netif_driver/darwin/utun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/darwin/utun.c
@@ -246,11 +246,8 @@ netif_driver utun_open(char *error, size_t error_len, const char *cidr) {
         if (prefix_sep != NULL) {
             ip_len = (int)(prefix_sep - cidr);
         }
-        long prefix = strtol(prefix_sep+1, NULL, 10);
-        in_addr_t netmask = (0xffffffff << (32 - prefix)) & 0xffffffff;
-        struct in_addr netmask_in = inet_makeaddr(netmask, 0);
         // add address to interface. darwin utun devices may only have "point to point" addresses
-        snprintf(cmd, sizeof(cmd), "ifconfig %s %.*s %.*s netmask %s", tun->name, ip_len, cidr, ip_len, cidr, inet_ntoa(netmask_in));
+        snprintf(cmd, sizeof(cmd), "ifconfig %s %.*s %.*s netmask 255.255.255.255", tun->name, ip_len, cidr, ip_len, cidr);
         system(cmd);
 
         // add a route for the subnet if one was specified


### PR DESCRIPTION
This change allows multiple ziti-edge-tunnel instances on Darwin - as long as you give each one a unique DNS range. I know we don't officially support multiple instances, but I've been relying on it for my dev environment and it comes in handy.