### PR TITLE
Disregard route if update is a subnet of tun's address

### DIFF
--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.h
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.h
@@ -24,6 +24,7 @@
 struct netif_handle_s {
     int  fd;
     char name[IFNAMSIZ];
+    ziti_address addr;
 
     model_map *route_updates;
 };


### PR DESCRIPTION
As the ```tun_ip``` is derived from ```dns_block```, set the ```tun```'s address prefix length equal to ```dns_block``` prefix length. Then ignore any route updates that are a subnet of the ```tun```'s address. This becomes helpful when large number of DNS intercepts are employed (say wildcard), each causing a /32 route to be added.