### PR TITLE
Feature/systemd socket activation

### DIFF
--- a/docs/systemd-socket-activation.md
+++ b/docs/systemd-socket-activation.md
@@ -33,17 +33,17 @@ After=ziti-edge-tunnel.socket
 Ziti Desktop Edge Integration:
 ------------------------------
 
-Integration with the `ziti-console` can be achieved like this:
+Integration with the [Ziti Desktop Edge](https://github.com/openziti/desktop-edge-ui) can be achieved like this:
 
 `/usr/share/application/zitidesktopedge.desktop`: 
 
 ```ini
 [Desktop Entry]
-Name=Ziti Desktop Edge Debug
+Name=Ziti Desktop Edge
 Exec=sudo /usr/bin/sh -c "/usr/bin/systemd-run --uid=$SUDO_USER --gid=ziti --setenv=DISPLAY=$DISPLAY --setenv=XAUTHORITY=$XAUTHORITY /usr/bin/zitidesktopedge"
 Type=Application
 Icon=zitidesktopedge
-Comment=Ziti Desktop Edge Debug
+Comment=Ziti Desktop Edge
 Categories=Utility;
 ```
 

--- a/docs/systemd-socket-activation.md
+++ b/docs/systemd-socket-activation.md
@@ -1,0 +1,62 @@
+systemd socket activation:
+==========================
+
+For systemd socket activation, we need systemd to start and manage both the command and events sockets on behalf of the ziti-edge-tunnel:
+
+`/etc/systemd/system/ziti-edge-tunnel.socket`: 
+
+```ini
+[Socket]
+ListenStream=/tmp/.ziti/ziti-edge-tunnel.sock
+ListenStream=/tmp/.ziti/ziti-edge-tunnel-event.sock
+SocketUser=ziti
+SocketGroup=ziti
+DirectoryMode=750
+RemoveOnStop=true
+
+
+[Install]
+WantedBy=sockets.target
+```
+
+Additionally, these additional settings override make the experience nice in terms of startup sequencing and lifetime.
+
+`/etc/systemd/system/ziti-edge-tunnel.service.d/override.conf`:
+
+```ini
+[Unit]
+CollectMode=inactive-or-failed
+BindsTo=ziti-edge-tunnel.socket
+After=ziti-edge-tunnel.socket
+```
+
+Ziti Desktop Edge Integration:
+------------------------------
+
+Integration with the `ziti-console` can be achieved like this:
+
+`/usr/share/application/zitidesktopedge.desktop`: 
+
+```ini
+[Desktop Entry]
+Name=Ziti Desktop Edge Debug
+Exec=sudo /usr/bin/sh -c "/usr/bin/systemd-run --uid=$SUDO_USER --gid=ziti --setenv=DISPLAY=$DISPLAY --setenv=XAUTHORITY=$XAUTHORITY /usr/bin/zitidesktopedge"
+Type=Application
+Icon=zitidesktopedge
+Comment=Ziti Desktop Edge Debug
+Categories=Utility;
+```
+
+For this to work, you need a `sudo` rule to authorize the above command like this:
+
+`/etc/sudoers.d/zde`:
+
+```
+%ziti ALL=(ALL) NOPASSWD: /bin/sh -c /usr/bin/systemd-run*zitidesktopedge
+```
+
+Finally, ensure that your login user is in the `ziti` group. 
+
+`sudo usermod -a -G ziti "$USER"`
+
+NOTE: you might need to log out and back in to ensure your user is in the group for your desktop session.

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -5,6 +5,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     set(NETIF_DRIVER_SOURCE netif_driver/linux/tun.c netif_driver/linux/resolvers.c netif_driver/linux/utils.c)
+    set(ZITI_INSTANCE_OS linux/libsystemd.c)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -5,7 +5,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     set(NETIF_DRIVER_SOURCE netif_driver/linux/tun.c netif_driver/linux/resolvers.c netif_driver/linux/utils.c)
-    set(ZITI_INSTANCE_OS linux/libsystemd.c)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
@@ -31,9 +30,6 @@ if (WIN32)
     set(ZITI_INSTANCE_OS windows-service.c include/windows/windows-service.h include/windows/windows-scripts.h windows-scripts.c windows/log_utils.c include/service-utils.h)
 endif ()
 
-add_executable(ziti-edge-tunnel ziti-edge-tunnel.c ${NETIF_DRIVER_SOURCE} ${ZITI_INSTANCE_COMMON} ${ZITI_INSTANCE_OS})
-set_property(TARGET ziti-edge-tunnel PROPERTY C_STANDARD 11)
-
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     option(DISABLE_LIBSYSTEMD_FEATURE "libsystemd library integration toggle" OFF)
     message("DISABLE_LIBSYSTEMD_FEATURE: ${DISABLE_LIBSYSTEMD_FEATURE}")
@@ -51,8 +47,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         else()
             message(FATAL_ERROR "libsystemd not found. To disable libsytemd feature, set DISABLE_LIBSYSTEMD_FEATURE=ON")
         endif()
+
+        set(ZITI_INSTANCE_OS linux/libsystemd.c)
     endif()
 endif()
+
+add_executable(ziti-edge-tunnel ziti-edge-tunnel.c ${NETIF_DRIVER_SOURCE} ${ZITI_INSTANCE_COMMON} ${ZITI_INSTANCE_OS})
+set_property(TARGET ziti-edge-tunnel PROPERTY C_STANDARD 11)
 
 target_include_directories(ziti-edge-tunnel
         PRIVATE include

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -30,6 +30,9 @@ if (WIN32)
     set(ZITI_INSTANCE_OS windows-service.c include/windows/windows-service.h include/windows/windows-scripts.h windows-scripts.c windows/log_utils.c include/service-utils.h)
 endif ()
 
+add_executable(ziti-edge-tunnel ziti-edge-tunnel.c ${NETIF_DRIVER_SOURCE} ${ZITI_INSTANCE_COMMON} ${ZITI_INSTANCE_OS})
+set_property(TARGET ziti-edge-tunnel PROPERTY C_STANDARD 11)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     option(DISABLE_LIBSYSTEMD_FEATURE "libsystemd library integration toggle" OFF)
     message("DISABLE_LIBSYSTEMD_FEATURE: ${DISABLE_LIBSYSTEMD_FEATURE}")
@@ -43,17 +46,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         if(LIBSYSTEMD_FOUND)
             if(LIBSYSTEMD_VERSION VERSION_LESS "229")
                 message(FATAL_ERROR "Unsupported version of libsystemd detected. To disable libsystmd feature, set DISABLE_LIBSYSTEMD_FEATURE=ON.")
+            else()
+                target_sources(ziti-edge-tunnel PRIVATE linux/libsystemd.c)
             endif()
         else()
             message(FATAL_ERROR "libsystemd not found. To disable libsytemd feature, set DISABLE_LIBSYSTEMD_FEATURE=ON")
         endif()
-
-        set(ZITI_INSTANCE_OS linux/libsystemd.c)
     endif()
 endif()
-
-add_executable(ziti-edge-tunnel ziti-edge-tunnel.c ${NETIF_DRIVER_SOURCE} ${ZITI_INSTANCE_COMMON} ${ZITI_INSTANCE_OS})
-set_property(TARGET ziti-edge-tunnel PROPERTY C_STANDARD 11)
 
 target_include_directories(ziti-edge-tunnel
         PRIVATE include

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -39,7 +39,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     message("DISABLE_LIBSYSTEMD_FEATURE: ${DISABLE_LIBSYSTEMD_FEATURE}")
 
     if (DISABLE_LIBSYSTEMD_FEATURE)
-        target_compile_definitions(ziti-edge-tunnel PRIVATE EXCLUDE_LIBSYSTEMD_RESOLVER)
+        target_compile_definitions(ziti-edge-tunnel PRIVATE DISABLE_LIBSYSTEMD EXCLUDE_LIBSYSTEMD_RESOLVER)
     else()
         find_package(PkgConfig REQUIRED)
         pkg_check_modules(LIBSYSTEMD IMPORTED_TARGET "libsystemd")

--- a/programs/ziti-edge-tunnel/include/linux/libsystemd.h
+++ b/programs/ziti-edge-tunnel/include/linux/libsystemd.h
@@ -1,0 +1,57 @@
+/*
+ Copyright 2021 NetFoundry Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#include <stdbool.h>
+
+#include <systemd/sd-bus-protocol.h>
+#include <systemd/sd-bus.h>
+#include <systemd/sd-daemon.h>
+
+#define _cleanup_(f) __attribute__((cleanup(f)))
+
+extern bool libsystemd_dl_success;
+
+
+extern int (*sd_booted_f)(void);
+extern int (*sd_bus_call_f)(sd_bus *bus, sd_bus_message *m, uint64_t usec, sd_bus_error *ret_error, sd_bus_message **reply);
+extern int (*sd_bus_call_method_f)(sd_bus *bus, const char *destination, const char *path, const char *interface, const char *member, sd_bus_error *ret_error, sd_bus_message **reply, const char *types, ...);
+extern void (*sd_bus_error_free_f)(sd_bus_error *e);
+extern int (*sd_bus_error_has_name_f)(const sd_bus_error *e, const char *name);
+extern int (*sd_bus_error_set_errno_f)(sd_bus_error *e, int error);
+extern sd_bus *(*sd_bus_flush_close_unref_f)(sd_bus *bus);
+extern int (*sd_bus_get_property_f)(sd_bus *bus, const char *destination, const char *path, const char *interface, const char *member, sd_bus_error *ret_error, sd_bus_message **reply, const char *type);
+extern int (*sd_bus_is_bus_client_f)(sd_bus *bus);
+extern int (*sd_bus_message_appendv_f)(sd_bus_message *m, const char *types, va_list ap);
+extern int (*sd_bus_message_enter_container_f)(sd_bus_message *m, char type, const char *contents);
+extern int (*sd_bus_message_exit_container_f)(sd_bus_message *m);
+extern int (*sd_bus_message_new_method_call_f)(sd_bus *bus, sd_bus_message **m, const char* destination, const char *path, const char *interface, const char *member);
+extern int (*sd_bus_message_read_f)(sd_bus_message *m, const char *types, ...);
+extern int (*sd_bus_message_read_strv_f)(sd_bus_message *m, char ***l);
+extern sd_bus_message *(*sd_bus_message_unref_f)(sd_bus_message *m);
+extern int (*sd_bus_open_system_f)(sd_bus **bus);
+extern int (*sd_listen_fds_f)(int unset_environment);
+extern int (*sd_is_socket_unix_f)(int fd, int type, int listening, const char *path, size_t length);
+
+void init_libsystemd(void);
+
+void sd_bus_flush_close_unrefp_f(sd_bus **p);
+void sd_bus_message_unrefp_f(sd_bus_message **p);
+void sd_bus_error_free_wrapper(sd_bus_error *e);
+
+int sd_bus_call_method_va(sd_bus *bus, const char *destination, const char *path, const char *interface, const char *member, sd_bus_error *error, sd_bus_message **reply, const char *types, va_list ap);
+
+int sd_bus_run_command(sd_bus *bus, const char *destination, const char* path, const char* interface,  const char* command);
+int sd_bus_is_acquired_name(sd_bus *bus, const char* bus_name);

--- a/programs/ziti-edge-tunnel/include/linux/libsystemd.h
+++ b/programs/ziti-edge-tunnel/include/linux/libsystemd.h
@@ -20,10 +20,7 @@
 #include <systemd/sd-bus.h>
 #include <systemd/sd-daemon.h>
 
-#define _cleanup_(f) __attribute__((cleanup(f)))
-
 extern bool libsystemd_dl_success;
-
 
 extern int (*sd_booted_f)(void);
 extern int (*sd_bus_call_f)(sd_bus *bus, sd_bus_message *m, uint64_t usec, sd_bus_error *ret_error, sd_bus_message **reply);

--- a/programs/ziti-edge-tunnel/linux/libsystemd.c
+++ b/programs/ziti-edge-tunnel/linux/libsystemd.c
@@ -1,0 +1,213 @@
+/*
+ Copyright 2021 NetFoundry Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <uv.h>
+
+#include "linux/libsystemd.h"
+#include <ziti/ziti_log.h>
+
+#define TRY_DL(dl_func) do{if ((dl_func) != 0) goto dl_error;} while(0)
+
+
+bool libsystemd_dl_success = true;
+static uv_lib_t libsystemd_h;
+
+int (*sd_booted_f)(void);
+int (*sd_bus_call_f)(sd_bus *bus, sd_bus_message *m, uint64_t usec, sd_bus_error *ret_error, sd_bus_message **reply);
+int (*sd_bus_call_method_f)(sd_bus *bus, const char *destination, const char *path, const char *interface, const char *member, sd_bus_error *ret_error, sd_bus_message **reply, const char *types, ...);
+void (*sd_bus_error_free_f)(sd_bus_error *e);
+int (*sd_bus_error_has_name_f)(const sd_bus_error *e, const char *name);
+int (*sd_bus_error_set_errno_f)(sd_bus_error *e, int error);
+sd_bus *(*sd_bus_flush_close_unref_f)(sd_bus *bus);
+int (*sd_bus_get_property_f)(sd_bus *bus, const char *destination, const char *path, const char *interface, const char *member, sd_bus_error *ret_error, sd_bus_message **reply, const char *type);
+int (*sd_bus_is_bus_client_f)(sd_bus *bus);
+int (*sd_bus_message_appendv_f)(sd_bus_message *m, const char *types, va_list ap);
+int (*sd_bus_message_enter_container_f)(sd_bus_message *m, char type, const char *contents);
+int (*sd_bus_message_exit_container_f)(sd_bus_message *m);
+int (*sd_bus_message_new_method_call_f)(sd_bus *bus, sd_bus_message **m, const char* destination, const char *path, const char *interface, const char *member);
+int (*sd_bus_message_read_f)(sd_bus_message *m, const char *types, ...);
+int (*sd_bus_message_read_strv_f)(sd_bus_message *m, char ***l);
+sd_bus_message *(*sd_bus_message_unref_f)(sd_bus_message *m);
+int (*sd_bus_open_system_f)(sd_bus **bus);
+int (*sd_listen_fds_f)(int unset_environment);
+int (*sd_is_socket_unix_f)(int fd, int type, int listening, const char *path, size_t length);
+
+void init_libsystemd(void) {
+    ZITI_LOG(INFO, "Initializing libsystemd");
+    TRY_DL(uv_dlopen("libsystemd.so.0", &libsystemd_h));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_booted", (void **) &sd_booted_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_call", (void **) &sd_bus_call_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_call_method", (void **) &sd_bus_call_method_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_error_free", (void **) &sd_bus_error_free_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_error_has_name", (void **) &sd_bus_error_has_name_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_error_set_errno", (void **) &sd_bus_error_set_errno_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_flush_close_unref", (void **) &sd_bus_flush_close_unref_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_get_property", (void **) &sd_bus_get_property_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_is_bus_client", (void **) &sd_bus_is_bus_client_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_appendv", (void **) &sd_bus_message_appendv_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_enter_container", (void **) &sd_bus_message_enter_container_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_exit_container", (void **) &sd_bus_message_exit_container_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_new_method_call", (void **) &sd_bus_message_new_method_call_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_read", (void **) &sd_bus_message_read_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_read_strv", (void **) &sd_bus_message_read_strv_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_unref", (void **) &sd_bus_message_unref_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_open_system", (void **) &sd_bus_open_system_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_listen_fds", (void **) &sd_listen_fds_f));
+    TRY_DL(uv_dlsym(&libsystemd_h, "sd_is_socket_unix", (void **) &sd_is_socket_unix_f));
+
+    goto done;
+
+    dl_error:
+    ZITI_LOG(WARN, "Failure during dynamic loading function: %s", uv_dlerror(&libsystemd_h));
+    libsystemd_dl_success=false;
+
+    done:
+    if (libsystemd_dl_success) {
+        ZITI_LOG(DEBUG, "Dynamically loaded libsystemd");
+    }
+    return;
+}
+
+// Added to work around preprocessor time symbols missing
+void sd_bus_flush_close_unrefp_f(sd_bus **p) {
+    if (*p) {
+        sd_bus_flush_close_unref_f(*p);
+    }
+}
+
+// Added to work around preprocessor time symbols missing
+void sd_bus_message_unrefp_f(sd_bus_message **p) {
+    if (*p) {
+        sd_bus_message_unref_f(*p);
+    }
+}
+
+// Added to work around preprocessor time symbols missing
+void sd_bus_error_free_wrapper(sd_bus_error *e) {
+    sd_bus_error_free_f(e);
+}
+
+// This replicates the functionality of
+// sd_bus_call_methodv introduced in
+// LIBSYSTEMD_246
+int sd_bus_call_method_va(
+        sd_bus *bus,
+        const char *destination,
+        const char *path,
+        const char *interface,
+        const char *member,
+        sd_bus_error *error,
+        sd_bus_message **reply,
+        const char *types,
+        va_list ap) {
+
+        _cleanup_(sd_bus_message_unrefp_f) sd_bus_message *m = NULL;
+        int r;
+
+        r = sd_bus_message_new_method_call_f(bus, &m, destination, path, interface, member);
+        if (r < 0) {
+            return sd_bus_error_set_errno_f(error, r);
+        }
+
+        if (types && !(types[0] == '\0')) {
+                r = sd_bus_message_appendv_f(m, types, ap);
+                if (r < 0) {
+                    return sd_bus_error_set_errno_f(error, r);
+                }
+        }
+
+        return sd_bus_call_f(bus, m, 0, error, reply);
+}
+
+int sd_bus_run_command(sd_bus *bus, const char *destination, const char* path, const char* interface,  const char* command) {
+    int r;
+    _cleanup_(sd_bus_error_free_wrapper) sd_bus_error error = SD_BUS_ERROR_NULL;
+
+    r = sd_bus_call_method_f(
+            bus,
+            destination,
+            path,
+            interface,
+            command,
+            &error,
+            NULL,
+            NULL);
+
+    if (r < 0) {
+        ZITI_LOG(ERROR, "Failed running command (%s): (%s, %s)", command, error.name, error.message);
+        return r;
+    }
+
+    ZITI_LOG(DEBUG, "Success in command invocation: %s", command);
+    return r;
+}
+
+int sd_bus_is_acquired_name(sd_bus *bus, const char* bus_name) {
+    int r;
+    _cleanup_(sd_bus_message_unrefp_f) sd_bus_message *reply = NULL;
+    _cleanup_(sd_bus_error_free_wrapper) sd_bus_error error = SD_BUS_ERROR_NULL;
+    char** acquired = NULL;
+
+    r = sd_bus_call_method_f(
+            bus,
+            "org.freedesktop.DBus",
+            "/org/freedesktop/DBUS",
+            "org.freedesktop.DBus",
+            "ListNames",
+            &error,
+            &reply,
+            NULL);
+
+    if (r < 0) {
+        ZITI_LOG(ERROR, "Could not retrieve DBus bus names: (%s, %s)", error.name, error.message);
+        return r;
+    }
+
+    r = sd_bus_message_read_strv_f(reply, &acquired);
+    if (r < 0) {
+        ZITI_LOG(ERROR, "Could not read DBus reply: %s", strerror(-r));
+        return r;
+    }
+
+    reply = sd_bus_message_unref_f(reply);
+
+    size_t i;
+    int found = 1;
+
+    for (i=0; acquired[i] != NULL; i++) {
+        if (strcmp(acquired[i], bus_name) == 0) {
+            ZITI_LOG(DEBUG, "systemd-resolved DBus name found: %s", acquired[i]);
+            found = 0;
+            break;
+        }
+    }
+
+    if (acquired != NULL) {
+        for (i=0; acquired[i] != NULL; i++) {
+            free(acquired[i]);
+        }
+        free(acquired);
+    }
+
+    if (found != 0) {
+        ZITI_LOG(DEBUG, "systemd-resolved DBus name is NOT acquired");
+    }
+
+    return found;
+}

--- a/programs/ziti-edge-tunnel/linux/libsystemd.c
+++ b/programs/ziti-edge-tunnel/linux/libsystemd.c
@@ -22,6 +22,8 @@
 #include "linux/libsystemd.h"
 #include <ziti/ziti_log.h>
 
+#define _cleanup_(f) __attribute__((cleanup(f)))
+
 #define TRY_DL(dl_func) do{if ((dl_func) != 0) goto dl_error;} while(0)
 
 

--- a/programs/ziti-edge-tunnel/netif_driver/linux/resolvers.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/resolvers.c
@@ -18,11 +18,7 @@
 #include <limits.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#ifndef EXCLUDE_LIBSYSTEMD_RESOLVER
-#include <net/if.h>
-#include <stdarg.h>
-#include "linux/libsystemd.h"
-#endif
+#include <string.h>
 
 #include <ziti/ziti_log.h>
 #include <uv.h>
@@ -30,7 +26,13 @@
 #include "resolvers.h"
 #include "utils.h"
 
+#define _cleanup_(f) __attribute__((cleanup(f)))
+
 #ifndef EXCLUDE_LIBSYSTEMD_RESOLVER
+#include <net/if.h>
+#include <stdarg.h>
+#include "linux/libsystemd.h"
+
 #define RET_ON_FAIL(bool_func) do{if (!(bool_func)) return;} while(0)
 
 static int detect_systemd_resolved_routing_domain_wildcard(sd_bus *bus, int32_t ifindex) {

--- a/programs/ziti-edge-tunnel/netif_driver/linux/resolvers.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/resolvers.c
@@ -18,13 +18,10 @@
 #include <limits.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <string.h>
 #ifndef EXCLUDE_LIBSYSTEMD_RESOLVER
 #include <net/if.h>
 #include <stdarg.h>
-#include <systemd/sd-bus-protocol.h>
-#include <systemd/sd-daemon.h>
-#include <systemd/sd-bus.h>
+#include "linux/libsystemd.h"
 #endif
 
 #include <ziti/ziti_log.h>
@@ -33,198 +30,8 @@
 #include "resolvers.h"
 #include "utils.h"
 
-#define _cleanup_(f) __attribute__((cleanup(f)))
 #ifndef EXCLUDE_LIBSYSTEMD_RESOLVER
-#define TRY_DL(dl_func) do{if ((dl_func) != 0) goto dl_error;} while(0)
 #define RET_ON_FAIL(bool_func) do{if (!(bool_func)) return;} while(0)
-
-static int sd_bus_is_acquired_name(sd_bus *bus, const char *bus_name);
-static int detect_systemd_resolved_routing_domain_wildcard(sd_bus *bus, int32_t ifindex);
-static bool set_systemd_resolved_link_setting(sd_bus *bus, const char *tun, const char *method, const char *method_type, ...);
-
-// libsystemd prototypes
-static uv_once_t guard;
-static uv_lib_t libsystemd_h;
-static bool libsystemd_dl_success = true;
-static int (*sd_booted_f)(void);
-static int (*sd_bus_call_f)(sd_bus *bus, sd_bus_message *m, uint64_t usec, sd_bus_error *ret_error, sd_bus_message **reply);
-static int (*sd_bus_call_method_f)(sd_bus *bus, const char *destination, const char *path, const char *interface, const char *member, sd_bus_error *ret_error, sd_bus_message **reply, const char *types, ...);
-static void (*sd_bus_error_free_f)(sd_bus_error *e);
-static int (*sd_bus_error_has_name_f)(const sd_bus_error *e, const char *name);
-static int (*sd_bus_error_set_errno_f)(sd_bus_error *e, int error);
-static sd_bus *(*sd_bus_flush_close_unref_f)(sd_bus *bus);
-static int (*sd_bus_get_property_f)(sd_bus *bus, const char *destination, const char *path, const char *interface, const char *member, sd_bus_error *ret_error, sd_bus_message **reply, const char *type);
-static int (*sd_bus_is_bus_client_f)(sd_bus *bus);
-static int (*sd_bus_message_appendv_f)(sd_bus_message *m, const char *types, va_list ap);
-static int (*sd_bus_message_enter_container_f)(sd_bus_message *m, char type, const char *contents);
-static int (*sd_bus_message_exit_container_f)(sd_bus_message *m);
-static int (*sd_bus_message_new_method_call_f)(sd_bus *bus, sd_bus_message **m, const char* destination, const char *path, const char *interface, const char *member);
-static int (*sd_bus_message_read_f)(sd_bus_message *m, const char *types, ...);
-static int (*sd_bus_message_read_strv_f)(sd_bus_message *m, char ***l);
-static sd_bus_message *(*sd_bus_message_unref_f)(sd_bus_message *m);
-static int (*sd_bus_open_system_f)(sd_bus **bus);
-
-static void init_libsystemd() {
-    ZITI_LOG(INFO, "Initializing libsystemd");
-    TRY_DL(uv_dlopen("libsystemd.so.0", &libsystemd_h));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_booted", (void **) &sd_booted_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_call", (void **) &sd_bus_call_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_call_method", (void **) &sd_bus_call_method_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_error_free", (void **) &sd_bus_error_free_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_error_has_name", (void **) &sd_bus_error_has_name_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_error_set_errno", (void **) &sd_bus_error_set_errno_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_flush_close_unref", (void **) &sd_bus_flush_close_unref_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_get_property", (void **) &sd_bus_get_property_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_is_bus_client", (void **) &sd_bus_is_bus_client_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_appendv", (void **) &sd_bus_message_appendv_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_enter_container", (void **) &sd_bus_message_enter_container_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_exit_container", (void **) &sd_bus_message_exit_container_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_new_method_call", (void **) &sd_bus_message_new_method_call_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_read", (void **) &sd_bus_message_read_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_read_strv", (void **) &sd_bus_message_read_strv_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_message_unref", (void **) &sd_bus_message_unref_f));
-    TRY_DL(uv_dlsym(&libsystemd_h, "sd_bus_open_system", (void **) &sd_bus_open_system_f));
-
-    goto done;
-
-    dl_error:
-    ZITI_LOG(WARN, "Failure during dynamic loading function: %s", uv_dlerror(&libsystemd_h));
-    libsystemd_dl_success=false;
-
-    done:
-    if (libsystemd_dl_success) {
-        ZITI_LOG(DEBUG, "Dynamically loaded libsystemd");
-    }
-    return;
-}
-
-// Added to work around preprocessor time symbols missing
-static void sd_bus_flush_close_unrefp_f(sd_bus **p) {
-    if (*p) {
-        sd_bus_flush_close_unref_f(*p);
-    }
-}
-
-// Added to work around preprocessor time symbols missing
-static void sd_bus_message_unrefp_f(sd_bus_message **p) {
-    if (*p) {
-        sd_bus_message_unref_f(*p);
-    }
-}
-
-// Added to work around preprocessor time symbols missing
-static void sd_bus_error_free_wrapper(sd_bus_error *e) {
-    sd_bus_error_free_f(e);
-}
-
-// This replicates the functionality of
-// sd_bus_call_methodv introduced in
-// LIBSYSTEMD_246
-static int sd_bus_call_method_va(
-        sd_bus *bus,
-        const char *destination,
-        const char *path,
-        const char *interface,
-        const char *member,
-        sd_bus_error *error,
-        sd_bus_message **reply,
-        const char *types,
-        va_list ap) {
-
-        _cleanup_(sd_bus_message_unrefp_f) sd_bus_message *m = NULL;
-        int r;
-
-        r = sd_bus_message_new_method_call_f(bus, &m, destination, path, interface, member);
-        if (r < 0) {
-            return sd_bus_error_set_errno_f(error, r);
-        }
-
-        if (types && !(types[0] == '\0')) {
-                r = sd_bus_message_appendv_f(m, types, ap);
-                if (r < 0) {
-                    return sd_bus_error_set_errno_f(error, r);
-                }
-        }
-
-        return sd_bus_call_f(bus, m, 0, error, reply);
-}
-
-static int sd_bus_run_command(sd_bus *bus, const char *destination, const char *path, const char *interface,  const char *command) {
-    int r;
-    _cleanup_(sd_bus_error_free_wrapper) sd_bus_error error = SD_BUS_ERROR_NULL;
-
-    r = sd_bus_call_method_f(
-            bus,
-            destination,
-            path,
-            interface,
-            command,
-            &error,
-            NULL,
-            NULL);
-
-    if (r < 0) {
-        ZITI_LOG(ERROR, "Failed running command (%s): (%s, %s)", command, error.name, error.message);
-        return r;
-    }
-
-    ZITI_LOG(DEBUG, "Success in command invocation: %s", command);
-    return r;
-}
-
-static int sd_bus_is_acquired_name(sd_bus *bus, const char* bus_name) {
-    int r;
-    _cleanup_(sd_bus_message_unrefp_f) sd_bus_message *reply = NULL;
-    _cleanup_(sd_bus_error_free_wrapper) sd_bus_error error = SD_BUS_ERROR_NULL;
-    char **acquired = NULL;
-
-    r = sd_bus_call_method_f(
-            bus,
-            "org.freedesktop.DBus",
-            "/org/freedesktop/DBUS",
-            "org.freedesktop.DBus",
-            "ListNames",
-            &error,
-            &reply,
-            NULL);
-
-    if (r < 0) {
-        ZITI_LOG(ERROR, "Could not retrieve DBus bus names: (%s, %s)", error.name, error.message);
-        return r;
-    }
-
-    r = sd_bus_message_read_strv_f(reply, &acquired);
-    if (r < 0) {
-        ZITI_LOG(ERROR, "Could not read DBus reply: %s", strerror(-r));
-        return r;
-    }
-
-    reply = sd_bus_message_unref_f(reply);
-
-    size_t i;
-    int found = 1;
-
-    for (i=0; acquired[i] != NULL; i++) {
-        if (strcmp(acquired[i], bus_name) == 0) {
-            ZITI_LOG(DEBUG, "systemd-resolved DBus name found: %s", acquired[i]);
-            found = 0;
-            break;
-        }
-    }
-
-    if (acquired != NULL) {
-        for (i=0; acquired[i] != NULL; i++) {
-            free(acquired[i]);
-        }
-        free(acquired);
-    }
-
-    if (found != 0) {
-        ZITI_LOG(DEBUG, "systemd-resolved DBus name is NOT acquired");
-    }
-
-    return found;
-}
 
 static int detect_systemd_resolved_routing_domain_wildcard(sd_bus *bus, int32_t ifindex) {
     _cleanup_(sd_bus_message_unrefp_f) sd_bus_message *reply = NULL;
@@ -329,7 +136,6 @@ static bool set_systemd_resolved_link_setting(sd_bus *bus, const char *tun, cons
 }
 
 bool try_libsystemd_resolver(void) {
-    uv_once(&guard, init_libsystemd);
     if (!libsystemd_dl_success) {
         return false;
     }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1731,7 +1731,7 @@ static void run_tunneler_loop(uv_loop_t* ziti_loop) {
     // set the service to running state
     scm_running_event();
 #elif __linux__ && !defined(DISABLE_LIBSYSTEMD)
-        static uv_once_t guard;
+    static uv_once_t guard;
     uv_once(&guard, init_libsystemd);
 
     if(libsystemd_dl_success) {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -34,6 +34,7 @@
 #include "netif_driver/darwin/utun.h"
 #elif __linux__
 #include "netif_driver/linux/tun.h"
+#include "linux/libsystemd.h"
 #elif _WIN32
 #include <time.h>
 #include "netif_driver/windows/tun.h"
@@ -154,6 +155,7 @@ static uv_mutex_t stop_mutex;
 static uv_cond_t stop_cond;
 IMPL_ENUM(event, EVENT_ACTIONS)
 
+static bool is_socket_activated = false;
 #if _WIN32
 static char sockfile[] = "\\\\.\\pipe\\ziti-edge-tunnel.sock";
 static char eventsockfile[] = "\\\\.\\pipe\\ziti-edge-tunnel-event.sock";
@@ -163,6 +165,11 @@ static char eventsockfile[] = "\\\\.\\pipe\\ziti-edge-tunnel-event.sock";
 static char sockfile[] = SOCKET_PATH "/ziti-edge-tunnel.sock";
 static char eventsockfile[] = SOCKET_PATH "/ziti-edge-tunnel-event.sock";
 #endif
+#if __linux__
+static int sockfile_fd = SD_LISTEN_FDS_START;
+static int eventsockfile_fd = SD_LISTEN_FDS_START + 1;
+#endif
+
 
 static int sizeof_event_clients_list() {
     struct event_conn_s *event_client;
@@ -674,8 +681,10 @@ static int start_cmd_socket(uv_loop_t *l) {
         return 0;
     }
 
-    uv_fs_t fs;
-    uv_fs_unlink(l, &fs, sockfile, NULL);
+    if (!is_socket_activated) {
+        uv_fs_t fs;
+        uv_fs_unlink(l, &fs, sockfile, NULL);
+    }
 
 #define CHECK_UV(op) do{ \
     int uv_rc = (op);    \
@@ -687,8 +696,12 @@ static int start_cmd_socket(uv_loop_t *l) {
 
 
     CHECK_UV(uv_pipe_init(l, &cmd_server, 0));
-    CHECK_UV(uv_pipe_bind(&cmd_server, sockfile));
-    CHECK_UV(uv_pipe_chmod(&cmd_server, UV_WRITABLE | UV_READABLE));
+    if (!is_socket_activated) {
+        CHECK_UV(uv_pipe_bind(&cmd_server, sockfile));
+        CHECK_UV(uv_pipe_chmod(&cmd_server, UV_WRITABLE | UV_READABLE));
+    } else {
+        CHECK_UV(uv_pipe_open(&cmd_server, sockfile_fd));
+    }
 
     uv_unref((uv_handle_t *) &cmd_server);
 
@@ -800,13 +813,18 @@ static int start_event_socket(uv_loop_t *l) {
     if (uv_is_active((const uv_handle_t *) &event_server)) {
         return 0;
     }
-
-    uv_fs_t fs;
-    uv_fs_unlink(l, &fs, eventsockfile, NULL);
+    if (!is_socket_activated) {
+        uv_fs_t fs;
+        uv_fs_unlink(l, &fs, eventsockfile, NULL);
+    }
 
     CHECK_UV(uv_pipe_init(l, &event_server, 0));
-    CHECK_UV(uv_pipe_bind(&event_server, eventsockfile));
-    CHECK_UV(uv_pipe_chmod(&event_server, UV_WRITABLE | UV_READABLE));
+    if (!is_socket_activated) {
+        CHECK_UV(uv_pipe_bind(&event_server, eventsockfile));
+        CHECK_UV(uv_pipe_chmod(&event_server, UV_WRITABLE | UV_READABLE));
+    } else {
+        CHECK_UV(uv_pipe_open(&event_server, eventsockfile_fd));
+    }
 
     uv_unref((uv_handle_t *) &event_server);
 
@@ -1682,11 +1700,46 @@ static int make_socket_path(uv_loop_t *loop) {
     return 0;
 }
 
-static void run_tunneler_loop(uv_loop_t* ziti_loop) {
+static void enforce_sockpath(int sockfd, const char* path) {
+    int r = sd_is_socket_unix_f(sockfd, SOCK_STREAM, 1, path, 0);
+    if (r < 0) {
+        fprintf(stderr, "error calling sd_is_socket_unix on fd=[%d]: err=%d[%s]", sockfd, r, strerror(r));
+        exit(EXIT_FAILURE);
+    }
+    if (!r) {
+        fprintf(ERROR, "socket fd=[%d] with path=[%s] is not a unix socket", sockfd, path);
+        exit(EXIT_FAILURE);
+    }
+    ZITI_LOG(DEBUG, "Received sockfd=[%d] with path=[%s]", sockfd, path);
+}
 
+static void run_tunneler_loop(uv_loop_t* ziti_loop) {
 #if _WIN32
     // set the service to running state
     scm_running_event();
+#elif __linux__
+    static uv_once_t guard;
+    uv_once(&guard, init_libsystemd);
+
+    if(libsystemd_dl_success) {
+
+	    int n = sd_listen_fds_f(0);
+
+	    if (n < 0) {
+		fprintf(stderr, "Failed calling sd_listen_fds: err=%d[%s]", n, strerror(n));
+		exit(EXIT_FAILURE);
+	    }
+
+	    if (n != 2) {
+		ZITI_LOG(DEBUG, "Too many or too few file descriptors for socket activation: LISTEN_FDS=%d. Proceeding normally...", n);
+	    }
+	    else {
+		enforce_sockpath(sockfile_fd, sockfile);
+		enforce_sockpath(eventsockfile_fd, eventsockfile);
+		ZITI_LOG(DEBUG, "Using socket activation for command and event sockets.");
+		is_socket_activated = true;
+	    }
+    }
 #endif
 
     CMD_CTRL = ziti_tunnel_init_cmd(ziti_loop, tunneler, on_event);


### PR DESCRIPTION
This PR allows the ziti-edge-tunnel to be systemd socket activated.  In the case of systemd socket activation, the IPC sockets for the ZET are managed by systemd via `.socket` unit files. When a client connects to one of these IPC sockets, systemd will dynamically start the `ziti-edge-tunnel.service` unit, and set file descriptors for the IPC sockets that are visible to the `ziti-edge-tunnel` process via libsystemd library functions. When such file descriptors are set, the ziti-edge-tunnel opens the existing file descriptors instead of creating it's own IPC sockets.

This allows clients to dynamically start the `ziti-edge-tunnel` process if they can connect to the sockets. 

Under normal circumstances, there is no effect to the startup or operation of the tunneler.

Most of the changes are simply to allow for the libsystemd dynamic loading to occur earlier in the `ziti-edge-tunnel.c` file. This file contains the bulk of the relevant changes. 