### PR TITLE
Remove obsolete fgrep

### DIFF
--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -206,7 +206,7 @@ int tun_commit_routes(netif_handle tun, uv_loop_t *l) {
 static void dns_update_resolvectl(const char* tun, unsigned int ifindex, const char* addr) {
 
     run_command(RESOLVECTL " dns %s %s", tun, addr);
-    int s = run_command_ex(false, RESOLVECTL " domain | fgrep -v '%s' | fgrep -q '~.'",
+    int s = run_command_ex(false, RESOLVECTL " domain | grep -F -v '%s' | grep -F -q '~.'",
                            dns_maintainer.tun_name);
     // set wildcard domain if any other resolvers set it.
     if (s == 0) {
@@ -226,7 +226,7 @@ static void dns_update_resolvectl(const char* tun, unsigned int ifindex, const c
 
 static void dns_update_systemd_resolve(const char* tun, unsigned int ifindex, const char* addr) {
     run_command(SYSTEMD_RESOLVE " -i %s --set-dns=%s", tun, addr);
-    int s = run_command_ex(false, SYSTEMD_RESOLVE " --status | fgrep  'DNS Domain' | fgrep -q '~.'");
+    int s = run_command_ex(false, SYSTEMD_RESOLVE " --status | grep -F 'DNS Domain' | grep -F -q '~.'");
     // set wildcard domain if any other resolvers set it.
     if (s == 0) {
         run_command(SYSTEMD_RESOLVE " -i %s --set-domain='~.'", dns_maintainer.tun_name);


### PR DESCRIPTION
Newer versions of `grep` eagerly write:

`fgrep: warning: fgrep is obsolescent; using grep -F`

This PR aligns with the recomendation to use `grep -F` instead of `fgrep`.