### PR TITLE
codespell: Add spelling check and fix all issues

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,17 @@
+name: Linters
+
+on: pull_request
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run code spelling check
+        uses: codespell-project/actions-codespell@v2
+        with:
+          ignore_words_list: ans,nd,precendence,seh,uknown

--- a/BUILD.md
+++ b/BUILD.md
@@ -6,7 +6,7 @@ tool chain used. These steps should work properly for you but if your OS has var
 ## Prerequisites
 
 This repository expects the user to have at least a basic understanding of what a Ziti Network
-is. To use this library it is also required to have a functioning Ziti Network availalbe to use.
+is. To use this library it is also required to have a functioning Ziti Network available to use.
 To learn more about what Ziti is or how to learn how to setup a Ziti Network head over to [the official documentation
 site](https://openziti.github.io/ziti/overview.html).
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
 ```
 
 Once the Ziti Tunneler SDK is initialized with a network device and ziti-sdk
-callbacks, a tunneler application only needs to indiciate which service(s)
+callbacks, a tunneler application only needs to indicate which service(s)
 that should be  
 
 ## Run with Docker

--- a/programs/ziti-edge-tunnel/package/deb/postrm.in
+++ b/programs/ziti-edge-tunnel/package/deb/postrm.in
@@ -11,7 +11,7 @@ if [ "$1" = "purge" ]; then
         deb-systemd-helper unmask @SYSTEMD_UNIT_FILE_NAME@ >/dev/null || true
     fi
 fi
-# End copied seciton
+# End copied section
 
 if [ -L @SYSTEMD_UNIT_DIR@/@SYSTEMD_UNIT_FILE_NAME@ ]; then
     unlink @SYSTEMD_UNIT_DIR@/@SYSTEMD_UNIT_FILE_NAME@

--- a/scripts/openwrt-build.sh
+++ b/scripts/openwrt-build.sh
@@ -112,7 +112,7 @@ cmake $CMAKE_OPTS "${ziti_src}"
 #echo
 
 echo
-echo Starting the buid
+echo Starting the build
 echo
 
 cmake --build . --target bundle


### PR DESCRIPTION
Hi,

this is a trivial PR, adding the [codespell](https://github.com/codespell-project/actions-codespell) tool to the CI, and fixing some non-code misspelling cases.

The CI file is called `linters.yml`, so that this can be extended in a future with other linter tools.

Best regards,

Mario