### PR TITLE
correct the deb and rpm hooks

### DIFF
--- a/programs/ziti-edge-tunnel/package/deb/postinst.in
+++ b/programs/ziti-edge-tunnel/package/deb/postinst.in
@@ -13,7 +13,10 @@ install -m 644 @CPACK_SHARE_DIR@/@SYSTEMD_UNIT_FILE_NAME@ @SYSTEMD_UNIT_DIR@/@SY
 # with an explanation or warning or link is an alternative to removing it, but it would only work for this deb, not the
 # rpm, artifact of this build because rpm creates unwanted *.rpmsave backups of files that were modified after the
 # specified version was installed
-unlink @CPACK_SHARE_DIR@/@SYSTEMD_UNIT_FILE_NAME@
+if [ -e @CPACK_SHARE_DIR@/@SYSTEMD_UNIT_FILE_NAME@ ]; then
+    unlink @CPACK_SHARE_DIR@/@SYSTEMD_UNIT_FILE_NAME@
+fi
+
 
 # Source debconf library.
 . /usr/share/debconf/confmodule
@@ -106,7 +109,7 @@ fi
 
 if [ "$1" = "configure" ]; then
     # if interactive and stdin is a tty
-    if [ $DEBIAN_FRONTEND != "noninteractive" -a -t 0 ]; then
+    if [ "$DEBIAN_FRONTEND" != "noninteractive" -a -t 0 ]; then
       ssize=$(tput cols)
     else
       ssize=80

--- a/programs/ziti-edge-tunnel/package/rpm/post.sh.in
+++ b/programs/ziti-edge-tunnel/package/rpm/post.sh.in
@@ -14,7 +14,9 @@ if [ $1 -ne 0 ]; then
     # delete the old copy of the unit file to reduce confusion; modifying the file with an explanation or warning or
     # link is an alternative to removing it, but that causes unwanted *.rpmsave backups since it is then presumed to be
     # a user modification
-    unlink @CPACK_SHARE_DIR@/$SYSTEMD_UNIT_FILE_NAME
+    if [ -e @CPACK_SHARE_DIR@/$SYSTEMD_UNIT_FILE_NAME ]; then
+        unlink @CPACK_SHARE_DIR@/$SYSTEMD_UNIT_FILE_NAME
+    fi
 fi
 
 %systemd_post $SYSTEMD_SERVICE_NAME


### PR DESCRIPTION
Fixes these install errors on Debian caused by failing to check if the file exists before unblinking, and failing to quote a variable that might be undefined.

```
Setting up ziti-edge-tunnel (0.22.22) ...
unlink: cannot unlink '/opt/openziti/share/ziti-edge-tunnel.service': No such file or directory
/var/lib/dpkg/info/ziti-edge-tunnel.postinst: 109: [: !=: unexpected operator
```