### PR TITLE
advance map iterators with model_map_it_remove when removing map items

### DIFF
--- a/lib/ziti-tunnel-cbs/ziti_dns.c
+++ b/lib/ziti-tunnel-cbs/ziti_dns.c
@@ -370,22 +370,24 @@ void ziti_dns_deregister_intercept(void *intercept) {
         dns_entry_t *e = model_map_it_value(it);
         model_map_remove_key(&e->intercepts, &intercept, sizeof(intercept));
         if (model_map_size(&e->intercepts) == 0 && (e->domain == NULL || model_map_size(&e->domain->intercepts) == 0)) {
-            model_map_remove(&ziti_dns.hostnames, e->name);
+            it = model_map_it_remove(it);
             model_map_removel(&ziti_dns.ip_addresses, ip_2_ip4(&e->addr)->addr);
             ZITI_LOG(DEBUG, "%zu active hostnames mapped to %zu IPs", model_map_size(&ziti_dns.hostnames), model_map_size(&ziti_dns.ip_addresses));
             ZITI_LOG(INFO, "DNS mapping %s -> %s is now inactive", e->name, e->ip);
+        } else {
+            it = model_map_it_next(it);
         }
-        it = model_map_it_next(it);
     }
 
     it = model_map_iterator(&ziti_dns.domains);
     while (it != NULL) {
         dns_domain_t *domain = model_map_it_value(it);
         if (model_map_size(&domain->intercepts) == 0) {
-            model_map_remove(&ziti_dns.domains, domain->name);
+            it = model_map_it_remove(it);
             ZITI_LOG(INFO, "wildcard domain[*%s] is now inactive", domain->name);
+        } else {
+            it = model_map_it_next(it);
         }
-        it = model_map_it_next(it);
     }
 }
 


### PR DESCRIPTION
Using a map iterator after removing the last item from the map can lead to invalid reads.

```
==1994639== Invalid read of size 8
==1994639==    at 0x159779: model_map_it_next (model_collections.c:245)
==1994639==    by 0x16FB6C: ziti_dns_deregister_intercept (ziti_dns.c:378)
==1994639==    by 0x163231: stop_intercept (ziti_tunnel_cbs.c:503)
==1994639==    by 0x163231: ziti_sdk_c_on_service (ziti_tunnel_cbs.c:571)
==1994639==    by 0x167948: on_service (ziti_tunnel_ctrl.c:725)
==1994639==    by 0x167DF7: on_ziti_event (ziti_tunnel_ctrl.c:800)
```