### PR TITLE
Handle proxy dns responses correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 
 set(ZITI_SDK_DIR "" CACHE FILEPATH "developer option: use local ziti-sdk-c checkout")
-set(ZITI_SDK_VERSION "0.36.7" CACHE STRING "ziti-sdk-c version or branch to use")
+set(ZITI_SDK_VERSION "0.36.9" CACHE STRING "ziti-sdk-c version or branch to use")
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)

--- a/lib/ziti-tunnel-cbs/include/ziti/ziti_dns.h
+++ b/lib/ziti-tunnel-cbs/include/ziti/ziti_dns.h
@@ -20,6 +20,7 @@
 #include <ziti/ziti_tunnel.h>
 
 #define DNS_NO_ERROR 0
+#define DNS_FORMERR  1
 #define DNS_SERVFAIL 2
 #define DNS_NXDOMAIN 3
 #define DNS_NOT_IMPL 4


### PR DESCRIPTION
There were two issues that prevented proxied dns queries from working:

1. The ziti connection that dns queries are sent over is not established (by design) when the first request is sent with `ziti_write`. The intent is to rely on `ziti_write` queueing the message until the connection is established, but there was a problem in ziti-sdk-c that caused crypto hash checks to fail for messages that were sent before the connection was ready. This was fixed with ziti-sdk-c 0.36.9.
2. The write callback associated with sending the dns query to the hosting tunneler was incorrectly treating the "length" parameter as "status", so even when a message was sent successfully, the tsdk responded to the original DNS client with `SRVFAIL`.