### PR TITLE
wait for systemd tun device unit to be active before configuring dns

### DIFF
--- a/programs/ziti-edge-tunnel/netif_driver/linux/resolvers.h
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/resolvers.h
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef EXCLUDE_LIBSYSTEMD_RESOLVER
-bool try_libsystemd_resolver(void);
+bool try_libsystemd_resolver(const char *tun_name);
 #endif
 bool is_systemd_resolved_primary_resolver(void);
 bool is_resolvconf_systemd_resolved(void);

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -245,7 +245,7 @@ static void dns_update_systemd_resolve(const char* tun, unsigned int ifindex, co
 
 static void find_dns_updater() {
 #ifndef EXCLUDE_LIBSYSTEMD_RESOLVER
-    if(try_libsystemd_resolver()) {
+    if(try_libsystemd_resolver(dns_maintainer.tun_name)) {
         dns_updater = dns_update_systemd_resolved;
         return;
     }


### PR DESCRIPTION
this PR fixes an issue that was observed in the smoke tests where IP of ZET's DNS server was. not configured into the host's resolver. all of the systemd API calls that we make to set up the resolver with the IP of our DNS server were successful. I added debug logs to check the resolver settings (with `resolvectl dns ziti0`)  immediately after they were made and the settings were as expected, but once in a while shortly after this check, the DNS server list was cleared.