### PR TITLE
Assume http proxy if type is not specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 
 set(ZITI_SDK_DIR "" CACHE FILEPATH "developer option: use local ziti-sdk-c checkout")
-set(ZITI_SDK_VERSION "1.0.2" CACHE STRING "ziti-sdk-c version or branch to use")
+set(ZITI_SDK_VERSION "1.0.3" CACHE STRING "ziti-sdk-c version or branch to use")
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1835,10 +1835,15 @@ static int init_proxy_connector(const char *url) {
 
     struct tlsuv_url_s proxy_url;
     int r = tlsuv_parse_url(&proxy_url, url);
-    if (r == 0 && proxy_url.scheme != NULL) {
-    } else {
+    if (r != 0) {
         ZITI_LOG(ERROR, "failed to parse '%s' as 'type://[username[:password]@]hostname:port'", url);
         return -1;
+    }
+
+    // assume http if no protocol was specified
+    if (proxy_url.scheme == NULL) {
+        proxy_url.scheme = "http";
+        proxy_url.scheme_len = strlen(proxy_url.scheme);
     }
 
     if (strncmp(proxy_url.scheme, "http", proxy_url.scheme_len) != 0) {


### PR DESCRIPTION
This matches the behavior of [golang's proxy url processing](https://cs.opensource.google/go/x/net/+/master:http/httpproxy/proxy.go;drc=66e838c6fbf5387ecedc26ce490b5f4d6864a854;l=146), and enables HTTP_PROXY to be set with the same format that the ER recognizes.