### PR TITLE
get ziti-sdk-c 1.0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 
 set(ZITI_SDK_DIR "" CACHE FILEPATH "developer option: use local ziti-sdk-c checkout")
-set(ZITI_SDK_VERSION "1.0.3" CACHE STRING "ziti-sdk-c version or branch to use")
+set(ZITI_SDK_VERSION "1.0.4" CACHE STRING "ziti-sdk-c version or branch to use")
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)


### PR DESCRIPTION
includes fixes to prevent new requests when controller is unavailable