### PR TITLE
Update macOS runner

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,11 +24,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macOS-11
+          - os: macOS-12
             name: macOS x86_64
             preset: macOS-x64
 
-          - os: macOS-11
+          - os: macOS-12
             name: macOS arm64
             preset: macOS-arm64
 


### PR DESCRIPTION
macOS-11 currently has scheduled brownouts and will be deprecated soon