### PR TITLE
Linux: Manage routes in a routing table dedicated to ZET.

### DIFF
--- a/lib/ziti-tunnel-cbs/CMakeLists.txt
+++ b/lib/ziti-tunnel-cbs/CMakeLists.txt
@@ -8,6 +8,7 @@ target_compile_definitions(ziti-tunnel-sdk-c
 add_library(ziti-tunnel-cbs-c STATIC
         ziti_tunnel_cbs.c
         ziti_hosting.c
+        ziti_hosting_socket.c
         ziti_tunnel_ctrl.c
         ziti_instance.h
         ziti_dns.c

--- a/lib/ziti-tunnel-cbs/ziti_hosting_socket.c
+++ b/lib/ziti-tunnel-cbs/ziti_hosting_socket.c
@@ -1,0 +1,11 @@
+#include <uv.h>
+
+extern int ziti_tunnel_hosting_socket(uv_os_sock_t *, const struct addrinfo *ai);
+
+int
+ziti_tunnel_hosting_socket(uv_os_sock_t *sock, const struct addrinfo *ai)
+{
+    (void) sock;
+    (void) ai;
+    return UV_ENOSYS;
+}

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -1,10 +1,13 @@
 project(ziti-edge-tunnel)
 
+include(CheckFunctionExists)
+
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(NETIF_DRIVER_SOURCE netif_driver/darwin/utun.c)
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-    set(NETIF_DRIVER_SOURCE netif_driver/linux/tun.c netif_driver/linux/resolvers.c netif_driver/linux/utils.c netif_driver/linux/libiproute.c)
+    set(NETIF_DRIVER_SOURCE netif_driver/linux/tun.c netif_driver/linux/resolvers.c netif_driver/linux/utils.c netif_driver/linux/libiproute.c netif_driver/linux/capability.c)
+    check_function_exists(capget ZITI_TUNNELER_SDK_HAVE_CAPGET)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -4,7 +4,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(NETIF_DRIVER_SOURCE netif_driver/darwin/utun.c)
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-    set(NETIF_DRIVER_SOURCE netif_driver/linux/tun.c netif_driver/linux/resolvers.c netif_driver/linux/utils.c)
+    set(NETIF_DRIVER_SOURCE netif_driver/linux/tun.c netif_driver/linux/resolvers.c netif_driver/linux/utils.c netif_driver/linux/libiproute.c)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)

--- a/programs/ziti-edge-tunnel/netif_driver/linux/capability.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/capability.c
@@ -1,0 +1,177 @@
+#include "capability.h"
+
+#define _GNU_SOURCE
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <linux/capability.h>
+#include <sysexits.h>
+
+#include <ziti/ziti_log.h>
+
+#ifndef _LINUX_CAPABILITY_VERSION_1
+#  define _LINUX_CAPABILITY_VERSION_1  0x19980330
+#endif
+
+#ifndef _LINUX_CAPABILITY_U32S_1
+#  define _LINUX_CAPABILITY_U32S_1      1
+#endif
+
+#ifndef _LINUX_CAPABILITY_VERSION_3
+#  define _LINUX_CAPABILITY_VERSION_3   0x20080522
+#endif
+
+#ifndef _LINUX_CAPABILITY_U32S_3
+#  define _LINUX_CAPABILITY_U32S_3      2
+#endif
+
+/* declarations not provided */
+extern int capget(cap_user_header_t cap_header, cap_user_data_t cap_data);
+extern int capset(cap_user_header_t cap_header, const cap_user_data_t cap_data);
+
+#ifndef ZITI_TUNNELER_SDK_HAVE_CAPGET
+/**
+ * not all libc's provide wrappers
+ */
+
+#include <unistd.h>
+#include <sys/syscall.h>
+
+int
+capget(cap_user_header_t header, cap_user_data_t data)
+{
+    return (int) syscall(SYS_capget, header, data);
+}
+
+int
+capset(cap_user_header_t header, const cap_user_data_t data)
+{
+    return (int) syscall(SYS_capset, header, data);
+}
+
+#endif /* ZITI_TUNNELER_SDK_HAVE_CAPGET */
+
+struct cap_struct {
+    struct __user_cap_header_struct header;
+    struct __user_cap_data_struct data[_LINUX_CAPABILITY_U32S_3 > _LINUX_CAPABILITY_U32S_1 ? _LINUX_CAPABILITY_U32S_3 : _LINUX_CAPABILITY_U32S_1];
+};
+
+static __thread struct {
+    struct cap_struct saved_cap;
+    bool armed;
+} thread_state = {
+  .saved_cap.header = { _LINUX_CAPABILITY_VERSION_3 },
+};
+
+static int
+ziti__cap_assert(unsigned long linux_cap_mask, unsigned long flags)
+{
+    struct cap_struct cap = { .header = thread_state.saved_cap.header };
+    struct cap_struct saved_cap;
+    int sys_rc;
+
+    (void) flags;
+
+    sys_rc = capget(&cap.header, cap.data);
+    /**
+     * Fallback to _LINUX_CAPABILITY_VERSION_1 when signalled
+     */
+    if (sys_rc && errno == EINVAL && cap.header.version < thread_state.saved_cap.header.version) {
+        cap.header.version = _LINUX_CAPABILITY_VERSION_1;
+        sys_rc = capget(&cap.header, cap.data);
+    }
+
+    if (sys_rc < 0) {
+        int saved_errno = errno;
+
+        ZITI_LOG(ERROR, "failed to get thread's capabilities: (%d) %s",
+            -saved_errno, strerror(saved_errno));
+        return -saved_errno;
+    }
+
+    saved_cap = cap;
+
+    cap.data[0].effective |= linux_cap_mask;
+    cap.data[0].permitted |= linux_cap_mask;
+
+    /**
+     * Don't calling capset() if no new capabilities are needed.
+     */
+    if ((cap.data[0].effective ^ saved_cap.data[0].effective) == 0
+        && (cap.data[0].permitted ^ saved_cap.data[0].permitted) == 0)
+        goto out;
+
+    sys_rc = capset(&cap.header, cap.data);
+    if (sys_rc < 0) {
+        int saved_errno = errno;
+
+        ZITI_LOG(ERROR, "failed to raise thread's capabilities: (%d) %s",
+            -saved_errno, strerror(saved_errno));
+        return -saved_errno;
+    }
+
+    if (!thread_state.armed)
+        thread_state.saved_cap = saved_cap;
+
+    thread_state.armed = true;
+
+out:
+    return 0;
+}
+
+static int
+ziti__cap_restore(void)
+{
+    int sys_rc;
+
+    if (!thread_state.armed) {
+        sys_rc = capget(&thread_state.saved_cap.header, thread_state.saved_cap.data);
+        if (sys_rc < 0) {
+            int saved_errno = errno;
+
+            ZITI_LOG(ERROR, "failed to restore thread's capabilities: (%d) %s",
+                -saved_errno, strerror(saved_errno));
+            return -saved_errno;
+        }
+        thread_state.armed = false;
+    }
+
+    return 0;
+}
+
+#define ZITI__LINUX_CAP_VALID(capability)                              \
+  static_assert(CAP_TO_INDEX(capability)==0, "capability ordinal is too large for the available bit set.")
+
+ZITI__LINUX_CAP_VALID(CAP_NET_ADMIN);
+ZITI__LINUX_CAP_VALID(CAP_SYS_ADMIN);
+
+void
+ziti_cap_assert(unsigned long cap_mask)
+{
+    unsigned long linux_cap_mask =
+      ((cap_mask & ZITI_CAP_NETADMIN) ? CAP_TO_MASK(CAP_NET_ADMIN) : 0)
+      | ((cap_mask & ZITI_CAP_SYSADMIN) ? CAP_TO_MASK(CAP_SYS_ADMIN) : 0);
+    int saved_errno = errno;
+
+    if (ziti__cap_assert(linux_cap_mask, 0) < 0)
+        exit(EX_NOPERM);
+
+    errno = saved_errno;
+}
+
+void
+ziti_cap_restore(void)
+{
+    int saved_errno = errno;
+    int sys_rc;
+
+    sys_rc = ziti__cap_restore();
+    if (sys_rc < 0)
+        exit(EX_NOPERM);
+
+    errno = saved_errno;
+}

--- a/programs/ziti-edge-tunnel/netif_driver/linux/capability.h
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/capability.h
@@ -1,0 +1,13 @@
+#ifndef ZITI_TUNNELER_SDK_NETIF_LINUX_CAPABILITY_H
+#define ZITI_TUNNELER_SDK_NETIF_LINUX_CAPABILITY_H
+
+// mask
+enum {
+  ZITI_CAP_NETADMIN = 1UL << 0,
+  ZITI_CAP_SYSADMIN = 1UL << 1,
+};
+
+extern void ziti_cap_assert(unsigned long capabilities);
+extern void ziti_cap_restore(void);
+
+#endif /* ZITI_INCLUDED_NETIF_LINUX_CAPABILITY_H */

--- a/programs/ziti-edge-tunnel/netif_driver/linux/libiproute.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/libiproute.c
@@ -1,0 +1,661 @@
+#include <linux/rtnetlink.h>
+#define _GNU_SOURCE
+#include "libiproute.h"
+
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include <asm-generic/errno.h>
+#include <asm-generic/socket.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <linux/netlink.h>
+#include <linux/fib_rules.h>
+
+#include <ziti/ziti_model.h>
+#include <ziti/ziti_log.h>
+
+#ifndef NLMSG_BUFSIZE
+#  define NLMSG_BUFSIZ  8192UL
+#endif
+
+struct nlmsg_batch {
+  union {
+    uint8_t buf[NLMSG_BUFSIZ];
+    struct nlmsghdr nlh;
+  };
+  ptrdiff_t pos; // current iterator position
+  ptrdiff_t len; // end of data
+  bool trunc;    // overflowed or truncated
+};
+
+#define NLMSG_BATCH_NLMSGHDR(batch, off) ((struct nlmsghdr *)&((batch)->buf[NLMSG_ALIGN(off)]))
+
+#define NLMSG_BATCH_ITER(batch)   NLMSG_BATCH_NLMSGHDR((batch),(batch)->pos)
+
+#define NLMSG_BATCH_TAIL(batch)   NLMSG_BATCH_NLMSGHDR((batch),(batch)->len)
+
+struct rtnetlink {
+    int sd;
+    uint32_t port;
+    uint32_t seqno;
+
+    union {
+      struct nlmsg_batch req;
+      struct nlmsg_batch reply;
+    };
+};
+
+static const char whitespace[] = " \t\n\r";
+static const int timeout = 5; // seconds
+
+static inline bool
+streq(const char s1[static 1],const char s2[static 1])
+{
+  return strcmp(s1, s2) == 0;
+}
+
+static inline bool
+startswith(const char prefix[restrict static 1], const char string[restrict static 1])
+{
+    size_t len = strlen(prefix);
+    return strncmp(string, prefix, len + !len) == 0;
+}
+
+static void
+nlmsg_batch_reset(struct nlmsg_batch *msg, size_t size)
+{
+    bool overflow = size > NLMSG_BUFSIZ;
+
+    msg->pos = 0;
+    msg->len = overflow ? NLMSG_BUFSIZ : size;
+    msg->trunc = overflow;
+}
+
+static uint8_t *
+nlmsg_batch_buf(struct nlmsg_batch *msg)
+{
+    return msg->buf;
+}
+
+static ptrdiff_t
+nlmsg_batch_bufsize(const struct nlmsg_batch *msg)
+{
+    (void) msg;
+    return NLMSG_BUFSIZ;
+}
+
+static ptrdiff_t
+nlmsg_batch_length(const struct nlmsg_batch *msg)
+{
+    return msg->len;
+}
+
+static ptrdiff_t
+nlmsg_batch_room(const struct nlmsg_batch *msg)
+{
+    return NLMSG_BUFSIZ - NLMSG_ALIGN(msg->len);
+}
+
+// iterator
+static struct nlmsghdr *
+nlmsg_batch_first(struct nlmsg_batch *batch)
+{
+    return &batch->nlh;
+}
+
+static bool
+nlmsg_batch_ok(struct nlmsg_batch *msg)
+{
+    struct nlmsghdr *nlh = NLMSG_BATCH_ITER(msg);
+    ptrdiff_t remain = msg->len - msg->pos;
+
+    return NLMSG_OK(nlh, remain);
+}
+
+static struct nlmsghdr *
+nlmsg_batch_next(struct nlmsg_batch *msg)
+{
+  struct nlmsghdr *nlh = NLMSG_BATCH_ITER(msg);
+
+  msg->pos += NLMSG_ALIGN(nlh->nlmsg_len);
+  return NLMSG_BATCH_ITER(msg);
+}
+
+static bool
+nlmsg_batch_trunc(struct nlmsg_batch *msg)
+{
+    return msg->trunc;
+}
+
+static bool
+nlmsg_batch_more(struct nlmsg_batch *msg)
+{
+    return msg->pos != msg->len;
+}
+
+// construction
+static struct nlmsghdr *
+nlmsg_batch_put(struct nlmsg_batch *msg, int paylen)
+{
+    if (!msg->trunc && NLMSG_SPACE(paylen) <= nlmsg_batch_room(msg))
+        return NLMSG_BATCH_TAIL(msg);
+    return NULL;
+}
+
+static bool
+nlmsg_batch_push(struct nlmsg_batch *msg)
+{
+    struct nlmsghdr *nlh = NLMSG_BATCH_TAIL(msg);
+    bool ok = NLMSG_OK(nlh, nlmsg_batch_room(msg));
+
+    if (ok)
+        msg->len = NLMSG_ALIGN(msg->len) + nlh->nlmsg_len;
+    else
+        msg->trunc = true;
+
+    return ok;
+}
+
+static int
+netlink_socket(struct rtnetlink *h, int proto)
+{
+    int sd;
+
+    sd = socket(AF_NETLINK, SOCK_RAW|SOCK_CLOEXEC, proto);
+    if (sd < 0)
+        return -errno;
+
+    int rcvbuf = 2*NLMSG_BUFSIZ;
+    if (setsockopt(sd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof rcvbuf) < 0) {
+        int saved_errno = errno;
+
+        ZITI_LOG(INFO, "Failed to configure SO_RCVBUF on socket: %d/%s",
+            saved_errno, strerror(saved_errno));
+    }
+
+    int sndbuf = 2*NLMSG_BUFSIZ;
+    if (setsockopt(sd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof sndbuf) < 0) {
+        int saved_errno = errno;
+
+        ZITI_LOG(INFO, "Failed to configure SO_SNDBUF on socket: %d/%s",
+            saved_errno, strerror(saved_errno));
+    }
+
+    struct timeval timeo = { .tv_sec = timeout };
+    if (setsockopt(sd, SOL_SOCKET, SO_RCVTIMEO, &timeo, sizeof timeo) < 0) {
+        int saved_errno = errno;
+
+        ZITI_LOG(INFO, "Failed to configure SO_RCVTIMEO on socket: %d/%s",
+            saved_errno, strerror(saved_errno));
+    }
+
+    int cap_ack = 1;
+    if (setsockopt(sd, SOL_NETLINK, NETLINK_CAP_ACK, &cap_ack, sizeof cap_ack) < 0) {
+        int saved_errno = errno;
+
+        ZITI_LOG(INFO, "Failed to set NETLINK_CAP_ACK on socket: %d/%s",
+            saved_errno, strerror(saved_errno));
+    }
+
+#ifdef NETLINK_GET_STRICT_CHK
+    int strict_chk = 1;
+    if (setsockopt(sd, SOL_NETLINK, NETLINK_GET_STRICT_CHK, &strict_chk, sizeof strict_chk) < 0) {
+        int saved_errno = errno;
+
+        ZITI_LOG(INFO, "Failed to set NETLINK_GET_STRICK_CHK on socket: %d/%s",
+            saved_errno, strerror(saved_errno));
+    }
+#endif
+
+    struct sockaddr_nl nl_sa = { .nl_family = AF_NETLINK };
+    if (bind(sd, (struct sockaddr *) &nl_sa, sizeof nl_sa) < 0) {
+close_and_exit:;
+        int saved_errno = errno;
+        return (void) close(sd), -saved_errno;
+    }
+
+    socklen_t nl_salen = sizeof nl_sa;
+    if (getsockname(sd, (struct sockaddr *)&nl_sa, &nl_salen) < 0) {
+        goto close_and_exit;
+    }
+
+    struct timespec t;
+    if (clock_gettime(CLOCK_MONOTONIC, &t) < 0) {
+        goto close_and_exit;
+    }
+
+    h->sd = sd;
+    h->port = nl_sa.nl_pid;
+    h->seqno = t.tv_nsec;
+
+    return 0;
+}
+
+static char *
+next_token(char **ps)
+{
+    char *s, *r;
+
+    if (!ps)
+        return NULL;
+
+    s = *ps;
+
+    // trim leading whitespace
+    s += strspn(s, whitespace);
+    // find end of token
+    r = s + strcspn(s, whitespace);
+    // store starting place
+    *ps = r + !!*r;
+    // terminate token
+    *r = '\0';
+
+    return *s ? s : NULL;
+}
+
+static int
+get_u32(const char *s, uint32_t *pu32)
+{
+    // skip leading whitespace
+    s += strspn(s, whitespace);
+
+    // save sign
+    int minus = s[0] == '-';
+    s += (minus || s[0] == '+' );
+
+    // decode base
+    int base = 10;
+    if (s[0] == '0' && s[1]) {
+        switch(s[1]) {
+        case 'B': case 'b':
+            base = 2;
+            s += 2;
+            break;
+        case 'O': case 'o':
+            base = 8;
+            s += 2;
+            break;
+        case 'X': case 'x':
+            base = 16;
+            s += 2;
+            break;
+        default:
+            base = 8;
+            s += 1;
+        }
+    }
+
+    errno = 0;
+    char *ep;
+    unsigned long ul = strtoul(s, &ep, base);
+
+    if (ul == 0 && errno != 0)
+        return -errno;
+
+    if (s == ep)
+        return -EINVAL;
+
+    if (!(ul <= UINT32_MAX))
+        return -ERANGE;
+
+    *pu32 = minus ? -ul : ul;
+
+    return 0;
+}
+
+void
+rtnetlink_free(rtnetlink h)
+{
+    if (h) {
+        if (h->sd > -1)
+            (void) close(h->sd);
+        free(h);
+    }
+}
+
+int
+rtnetlink_new(rtnetlink *ph)
+{
+    struct rtnetlink *h;
+    int err;
+
+    h = calloc(1, sizeof(*h));
+    if (!h)
+        return -ENOMEM;
+
+    *h = (struct rtnetlink) { .sd = -1 };
+
+    if ((err = netlink_socket(h, NETLINK_ROUTE)) < 0)
+        goto error;
+
+    *ph = h;
+
+    return 0;
+
+error:
+    free(h);
+    *ph = NULL;
+    return err;
+}
+
+static int
+rtattr_put(struct nlmsghdr *nlh, size_t maxsize, int type, const void *restrict data, int dlen)
+{
+    struct rtattr *rta;
+    int alen = RTA_LENGTH(dlen);
+
+    if (NLMSG_ALIGN(nlh->nlmsg_len) > maxsize || RTA_ALIGN(alen) > maxsize - NLMSG_ALIGN(nlh->nlmsg_len)) {
+        ZITI_LOG(ERROR, "netlink message length will exceeds bounds (%zu)", maxsize);
+        return -ENOMEM;
+    }
+
+    rta = (struct rtattr *)((char *)nlh + NLMSG_ALIGN(nlh->nlmsg_len));
+    rta->rta_type = type;
+    rta->rta_len = alen;
+    if (data) {
+        memcpy(RTA_DATA(rta), data, dlen);
+    } else {
+        // memcpy should never have a null parameter
+    }
+    nlh->nlmsg_len = NLMSG_ALIGN(nlh->nlmsg_len) + RTA_ALIGN(alen);
+    return 0;
+}
+
+static int
+rtattr_put32(struct nlmsghdr *nlh, int maxsize, int type, uint32_t u32)
+{
+  return rtattr_put(nlh, maxsize, type, &u32, sizeof u32);
+}
+
+static int
+get_error(const struct nlmsghdr *restrict nlh)
+{
+    const struct nlmsgerr *restrict nle;
+
+    if (nlh->nlmsg_type != NLMSG_ERROR)
+        return -ENOMSG;
+
+    if (nlh->nlmsg_len < NLMSG_LENGTH(sizeof *nle))
+        return -EBADMSG;
+
+    nle = NLMSG_DATA(nlh);
+
+    return nle->error;
+}
+
+static int
+netlink_call(struct rtnetlink *h)
+{
+    struct sockaddr_nl sa = { .nl_family = AF_NETLINK };
+    uint32_t seqno = h->seqno;
+    unsigned int ntx = 0;
+    ssize_t sysrc;
+
+    for (struct nlmsghdr *nlh = nlmsg_batch_first(&h->req); nlmsg_batch_ok(&h->req); nlh = nlmsg_batch_next(&h->req)) {
+
+        if ((nlh->nlmsg_flags & NLM_F_REQUEST) != NLM_F_REQUEST) {
+            // debug
+        }
+
+        nlh->nlmsg_flags |= NLM_F_ACK;
+
+        nlh->nlmsg_seq = seqno + ntx;
+
+        ++ntx;
+    }
+
+    h->seqno += ntx;
+
+    do {
+        sysrc = sendto(h->sd, nlmsg_batch_buf(&h->req), nlmsg_batch_length(&h->req),
+            0, (struct sockaddr *)&sa, sizeof(sa));
+    } while (sysrc < 0 && errno == EINTR);
+
+    if (sysrc < 0)
+        return errno == ENOBUFS ? -EAGAIN : -errno;
+
+    unsigned int nrx = 0;
+    while(true) {
+        socklen_t salen = sizeof(sa);
+        do {
+            sysrc = recvfrom(h->sd, nlmsg_batch_buf(&h->reply), nlmsg_batch_bufsize(&h->reply),
+                MSG_TRUNC, (struct sockaddr *)&sa, &salen);
+        } while (sysrc < 0 && errno == EINTR);
+
+        if (sysrc < 0)
+            return errno == EAGAIN ? -ETIMEDOUT : -errno;
+
+        nlmsg_batch_reset(&h->reply, (size_t) sysrc);
+
+        if (salen != sizeof sa || sa.nl_family != AF_NETLINK) {
+            // debug
+            return -ENOPROTOOPT;
+        }
+
+        if (sa.nl_pid != 0U) {
+            // warn
+            continue;
+        }
+
+        if (sa.nl_groups != 0U) {
+            // warn
+            continue;
+        }
+
+        int err = 0;
+        for (struct nlmsghdr *nlh = nlmsg_batch_first(&h->reply); nlmsg_batch_ok(&h->reply); nlh = nlmsg_batch_next(&h->reply)) {
+
+            if (nlh->nlmsg_pid != h->port) {
+                // warn
+                continue;
+            }
+
+            // seqno may wrap
+            if (nlh->nlmsg_seq - seqno >= ntx) {
+                // warn
+                continue;
+            }
+
+            if (nlh->nlmsg_type != NLMSG_ERROR)
+                continue;
+
+            nrx++;
+
+            // record first error
+            if (!err)
+                err = get_error(nlh);
+        }
+
+        // if all expected messages are received, return error
+        if (ntx == nrx)
+            return err;
+
+        if (nlmsg_batch_trunc(&h->reply)) {
+            // warn
+            return -ENOMEM;
+        }
+
+        if (nlmsg_batch_more(&h->reply)) {
+            // warn
+            return -EBADMSG;
+        }
+
+        // receive the next batch of messages
+    }
+}
+
+
+static int
+iprule_modify(rtnetlink h, iprule_modify_type cmd, char rule[static 1])
+{
+    struct nlmsghdr *nlh;
+    struct fib_rule_hdr *frh;
+    char *s, *t;
+    int maxsize;
+    int ret;
+
+    nlmsg_batch_reset(&h->req, 0);
+
+    if (!(nlh = nlmsg_batch_put(&h->req, sizeof *frh)))
+        return -ENOMEM;
+
+    maxsize = nlmsg_batch_room(&h->req);
+
+    *nlh = (struct nlmsghdr) {
+        .nlmsg_len = NLMSG_LENGTH(sizeof(*frh)),
+        .nlmsg_flags = NLM_F_REQUEST,
+    };
+
+    frh = NLMSG_DATA(nlh);
+    *frh = (struct fib_rule_hdr) {
+        .family = AF_UNSPEC,
+        .action = FR_ACT_UNSPEC,
+    };
+
+    switch (cmd) {
+    case IPRULE_ADD:
+        nlh->nlmsg_type = RTM_NEWRULE;
+        nlh->nlmsg_flags |= NLM_F_CREATE|NLM_F_EXCL;
+        frh->action = FR_ACT_TO_TBL;
+        break;
+    case IPRULE_DEL:
+        nlh->nlmsg_type = RTM_DELRULE;
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    s = rule;
+
+    while ((t = next_token(&s))) {
+
+        if (streq(t, "not")) {
+            frh->flags |= FIB_RULE_INVERT;
+        } else if (streq(t, "from")
+            || streq(t, "to")) {
+            int is_src = t[0] == 'f';
+
+            if ((t = next_token(&s)) == 0)
+                goto invalid_argument;
+
+            ziti_address prefix = { 0 };
+            if (parse_ziti_address_str(&prefix, t) < 0)
+                goto invalid_argument;
+
+            if (prefix.type != ziti_address_cidr)
+                goto invalid_argument;
+
+            frh->family = prefix.addr.cidr.af;
+
+            int type;
+            if (is_src) {
+                frh->src_len = prefix.addr.cidr.bits;
+                type = FRA_SRC;
+            } else {
+                frh->dst_len = prefix.addr.cidr.bits;
+                type = FRA_DST;
+            }
+
+            size_t iplen = prefix.addr.cidr.af == AF_INET ? sizeof(struct in_addr) : sizeof(struct in6_addr);
+            if (prefix.addr.cidr.bits > 0
+                && (ret = rtattr_put(nlh, maxsize, type, &prefix.addr.cidr.ip, iplen)) < 0)
+                goto done;
+        } else if (streq(t, "fwmark")) {
+            char *slash;
+            uint32_t fwmark, fwmask;
+
+            if ((t = next_token(&s)) == 0)
+                goto invalid_argument;
+
+            if ((slash = strchr(t, '/')))
+                *slash = '\0';
+
+            if (get_u32(t, &fwmark) < 0)
+                goto invalid_argument;
+
+            if ((ret = rtattr_put32(nlh, maxsize, FRA_FWMARK, fwmark)) < 0)
+                goto done;
+
+            if (slash) {
+                if (get_u32(slash+1, &fwmask) < 0)
+                    goto invalid_argument;
+
+                if ((ret = rtattr_put32(nlh, maxsize, FRA_FWMASK, fwmark)) < 0)
+                    goto done;
+            }
+        } else if (startswith(t, "preference")
+                   || startswith(t, "priority")) {
+            uint32_t pref;
+
+            if ((t = next_token(&s)) == 0)
+                goto invalid_argument;
+
+            if (get_u32(t, &pref) < 0)
+                goto invalid_argument;
+
+            if ((ret = rtattr_put32(nlh, maxsize, FRA_PRIORITY, pref)) < 0)
+                goto done;
+
+        } else if (startswith(t, "table")
+                    || startswith(t, "lookup")) {
+            uint32_t tid;
+
+            if ((t = next_token(&s)) == 0)
+                goto invalid_argument;
+
+            if (get_u32(t, &tid) < 0)
+                goto invalid_argument;
+
+            frh->action = FR_ACT_TO_TBL;
+
+            if (tid > 255) {
+                frh->table = RT_TABLE_UNSPEC;
+                if ((ret = rtattr_put32(nlh, maxsize, FRA_TABLE, tid)) < 0)
+                    goto done;
+            } else {
+                frh->table = tid;
+            }
+        } else {
+invalid_argument:
+             return -EINVAL;
+        }
+    }
+
+    nlmsg_batch_push(&h->req);
+
+    ret = netlink_call(h);
+done:
+    return ret;
+}
+
+int
+zt_iprule_modify(rtnetlink h, iprule_modify_type cmd, const char *rule, ...)
+{
+    va_list ap;
+    char *str;
+    int ret;
+
+    va_start(ap, rule);
+    ret = vasprintf(&str, rule, ap);
+    va_end(ap);
+
+    if (ret < 0)
+        return -ENOMEM;
+
+    ret = iprule_modify(h, cmd, str);
+
+    free(str);
+
+    return ret;
+}

--- a/programs/ziti-edge-tunnel/netif_driver/linux/libiproute.h
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/libiproute.h
@@ -1,0 +1,16 @@
+#ifndef ZITI_TUNNELER_SDK_LIBIPROUTE_H
+#define ZITI_TUNNELER_SDK_LIBIPROUTE_H
+
+typedef struct rtnetlink *rtnetlink;
+
+typedef enum {
+  IPRULE_ADD = 1,
+  IPRULE_DEL,
+} iprule_modify_type;
+
+extern int rtnetlink_new(rtnetlink*);
+extern void rtnetlink_free(rtnetlink);
+
+extern int zt_iprule_modify(rtnetlink h, iprule_modify_type cmd, const char *rule, ...);
+
+#endif /* !ZITI_TUNNELER_SDK_LIBIPROUTE_H */

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -407,7 +407,8 @@ static const char *get_tun_name(netif_handle tun) {
     return tun->name;
 }
 
-netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const char *dns_block, char *error, size_t error_len) {
+netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const char *dns_block, char *error, size_t error_len,
+    const struct netif_options *opts) {
     if (error != NULL) {
         memset(error, 0, error_len * sizeof(char));
     }
@@ -440,6 +441,8 @@ netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const c
     }
 
     strncpy(tun->name, ifr.ifr_name, sizeof(tun->name));
+
+    tun->rt_table = ZET__select_routing_table(opts);
 
     struct netif_driver_s *driver = calloc(1, sizeof(struct netif_driver_s));
     if (driver == NULL) {

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -654,3 +654,25 @@ uv_os_sock_t tlsuv_socket(const struct addrinfo *ai, bool blocking)
 
     return sd;
 }
+
+/**
+ * Override ziti_hosting_cbs socket factory. This factory is used to create
+ * the sockets used for `hosted` services.
+ */
+int
+ziti_tunnel_hosting_socket(uv_os_sock_t *psock, const struct addrinfo *ai)
+{
+    uv_os_sock_t sd;
+
+    sd = make_bypass_socket(ai, true);
+    if (sd < 0) {
+        int uv_err = uv_translate_sys_error(errno);
+
+        *psock = -1;
+        return uv_err;
+    }
+
+    *psock = sd;
+
+    return 0;
+}

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -34,6 +34,7 @@
 #include "tun.h"
 #include "utils.h"
 #include "libiproute.h"
+#include "capability.h"
 
 #ifndef DEVTUN
 #define DEVTUN "/dev/net/tun"
@@ -592,4 +593,64 @@ netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const c
     }
 
     return driver;
+}
+
+static int make_bypass_socket(const struct addrinfo *ai, bool blocking)
+{
+    int blockmode = blocking ? 0 : SOCK_NONBLOCK;
+    int sd;
+
+    sd = socket(ai->ai_family, ai->ai_socktype|SOCK_CLOEXEC|blockmode,
+        ai->ai_protocol);
+    if (sd < 0) {
+        int uv_err = uv_translate_sys_error(errno);
+
+        ZITI_LOG(ERROR, "Failed to create socket: %d/%s", uv_err, uv_strerror(uv_err));
+        return uv_err;
+    }
+
+    int mark = ZET_BYPASS_MARK;
+    int sys_rc;
+
+    ziti_cap_assert(ZITI_CAP_NETADMIN);
+    sys_rc = setsockopt(sd, SOL_SOCKET, SO_MARK, &mark, sizeof mark);
+    ziti_cap_restore();
+
+    if (sys_rc < 0) {
+        int uv_err = uv_translate_sys_error(errno);
+
+        ZITI_LOG(ERROR, "Failed to configure SO_MARK on socket: %d/%s",
+            uv_err, uv_strerror(uv_err));
+        (void) close(sd);
+        return uv_err;
+    }
+
+    return sd;
+}
+
+/**
+ * Override tlsuv's socket factory. This factory is used to create
+ * the sockets used for the controller and edge router communication.
+ */
+uv_os_sock_t tlsuv_socket(const struct addrinfo *ai, bool blocking)
+{
+    int blockopt = blocking ? 0 : SOCK_NONBLOCK;
+    uv_os_sock_t /* int */ sd;
+
+    sd = socket(ai->ai_family, ai->ai_socktype|SOCK_CLOEXEC|blockopt, ai->ai_protocol);
+    if (sd < 0) {
+        int uv_err = uv_translate_sys_error(errno);
+
+        ZITI_LOG(ERROR, "socket: %d/%s", uv_err, uv_strerror(uv_err));
+        return -1;
+    }
+
+    int mark = ZET_BYPASS_MARK;
+    if (setsockopt(sd, SOL_SOCKET, SO_MARK, &mark, sizeof mark) < 0) {
+        int uv_err = uv_translate_sys_error(errno);
+
+        ZITI_LOG(WARN, "setsockopt(SO_MARK): %d/%s", uv_err, uv_strerror(uv_err));
+    }
+
+    return sd;
 }

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -33,10 +33,35 @@
 #include "resolvers.h"
 #include "tun.h"
 #include "utils.h"
+#include "libiproute.h"
 
 #ifndef DEVTUN
 #define DEVTUN "/dev/net/tun"
 #endif
+
+/**
+ * Let's keep the ZET_RT_TABLE in 0..255:
+ * - busybox routing tables ids are restricted to 0..1023.
+ * - iproute2 stores table ids 0..255 in rtmsg.rtm_table; otherwise rtattr RTA_TABLE is used
+ */
+#ifndef ZET_RT_TABLE
+#define ZET_RT_TABLE ((unsigned char)'Z')
+#endif
+
+/**
+ * ZET_POLICY_PREF_BASE in 0..32767
+ * 0: local
+ * 32766: main
+ * 32767: default
+ *
+ * 'Ze' = 0x5A65 = 23141
+ */
+#ifndef ZET_POLICY_PREF_BASE
+#define ZET_POLICY_PREF_BASE (((unsigned char)'Z')<<8|'e')
+#endif
+
+#define ZET_BYPASS_MARK 0xC000000
+#define ZET_BYPASS_MASK 0xC000000
 
 /*
  * ip link set tun0 up
@@ -50,6 +75,9 @@
 #endif
 
 #define CHECK_UV(op) do{ int rc = op; if (rc < 0) ZITI_LOG(ERROR, "uv_err: %d/%s", rc, uv_strerror(rc)); } while(0)
+
+
+static int ZET__is_rt_table_main(struct netif_handle_s *tun);
 
 extern void dns_set_miss_status(int code);
 
@@ -127,7 +155,8 @@ static void route_updates_done(uv_work_t *wr, int status) {
 }
 
 static void process_routes_updates(uv_work_t *wr) {
-    struct rt_process_cmd *cmd = wr->data;
+    struct rt_process_cmd *const cmd = wr->data;
+    struct netif_handle_s *const tun = cmd->tun;
 
     uv_fs_t tmp_req = {0};
     uv_file routes_file = uv_fs_mkstemp(wr->loop, &tmp_req, "/tmp/ziti-tunnel-routes.XXXXXX", NULL);
@@ -142,6 +171,10 @@ static void process_routes_updates(uv_work_t *wr) {
         "delete",
         "add",
     };
+    static const char *const formats[2] = {
+        "route %s %s dev %s table %d\n",
+        "route %s %s dev %s"
+    };
     char buf[1024];
     for (size_t i = 0; i < sizeof verbs/sizeof verbs[0]; i++) {
         const char *const verb = verbs[i];
@@ -153,7 +186,10 @@ static void process_routes_updates(uv_work_t *wr) {
             // action == 1: add
             unsigned action = (uintptr_t) value;
             if (action == i) {
-                int len = snprintf(buf, sizeof(buf), "route %s %s dev %s\n", verb, prefix, cmd->tun->name);
+
+                int len = snprintf(buf, sizeof(buf),
+                    formats[!!ZET__is_rt_table_main(tun)],
+                    verb, prefix, tun->name, tun->route_table);
                 if (len < 0 || (size_t) len >= sizeof buf) {
                     if (len > 0) errno = ENOMEM;
                     ZITI_LOG(ERROR, "route updates failed %d/%s", -errno, strerror(errno));
@@ -397,6 +433,60 @@ static int tun_exclude_rt(netif_handle dev, uv_loop_t *l, const char *addr) {
     return run_command("ip route replace %s %s", addr, route);
 }
 
+static int tun_exclude_rt_noop(netif_handle dev, uv_loop_t *l, const char *addr) {
+  /**
+   * When the isolated routing table feature is active, communication between the controller and edge router does not need to be explicitly defined.
+   * These sockets are marked with SO_MARK, allowing them to bypass the Ziti-dedicated routing table, which contains the Ziti-specific routes, and use
+   * the routes available in the `main` routing table.
+   */
+    (void) dev;
+    (void) l;
+    (void) addr;
+    return 0;
+}
+
+static int
+ZET__route_table(const struct netif_options *opts)
+{
+    return (opts->use_rt_main || run_command("ip -4 rule show >/dev/null") != 0)
+      ? RT_TABLE_MAIN : ZET_RT_TABLE;
+}
+
+static int
+ZET__is_rt_table_main(struct netif_handle_s *tun)
+{
+  return tun->route_table == RT_TABLE_MAIN;
+}
+
+static void
+ZET__rpdb_init(struct netif_handle_s *tun)
+{
+    rtnetlink h;
+    int err;
+
+    if (ZET__is_rt_table_main(tun))
+        return;
+
+    if ((err = rtnetlink_new(&h)) < 0) {
+          ZITI_LOG(ERROR, "failed to open netlink socket: %d/%s", errno, strerror(errno));
+          return;
+    }
+
+    err = zt_iprule_modify(h, IPRULE_ADD,
+        "not from 0.0.0.0/0 fwmark 0x%x/0x%x pref %d lookup %d",
+        ZET_BYPASS_MARK, ZET_BYPASS_MASK, ZET_POLICY_PREF_BASE, tun->route_table);
+    if (err < 0 && err != -EEXIST)
+        ZITI_LOG(ERROR, "error(s) encountered while updating ipv4 routing policy database.");
+
+    err = zt_iprule_modify(h, IPRULE_ADD,
+        "not from ::/0 fwmark 0x%x/0x%x pref %d lookup %d",
+        ZET_BYPASS_MARK, ZET_BYPASS_MASK, ZET_POLICY_PREF_BASE, tun->route_table);
+    if (err < 0 && err != -EEXIST && err != -EAFNOSUPPORT)
+        ZITI_LOG(ERROR, "error(s) encountered while updating ipv6 routing policy database.");
+
+    rtnetlink_free(h);
+}
+
 static void cleanup_sock(const int *fd) {
     if (fd && *fd != -1) {
         close(*fd);
@@ -442,7 +532,7 @@ netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const c
 
     strncpy(tun->name, ifr.ifr_name, sizeof(tun->name));
 
-    tun->rt_table = ZET__select_routing_table(opts);
+    tun->route_table = ZET__route_table(opts);
 
     struct netif_driver_s *driver = calloc(1, sizeof(struct netif_driver_s));
     if (driver == NULL) {
@@ -460,7 +550,7 @@ netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const c
     driver->add_route    = tun_add_route;
     driver->delete_route = tun_delete_route;
     driver->close        = tun_close;
-    driver->exclude_rt   = tun_exclude_rt;
+    driver->exclude_rt   = ZET__is_rt_table_main(tun) ? tun_exclude_rt : tun_exclude_rt_noop;
     driver->commit_routes = tun_commit_routes;
     driver->get_name = get_tun_name;
 
@@ -490,12 +580,15 @@ netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const c
         return NULL;
     }
 
+    ZET__rpdb_init(tun);
+
     if (dns_ip) {
         init_dns_maintainer(loop, tun->name, dns_ip);
     }
 
     if (dns_block) {
-        run_command("ip route add %s dev %s", dns_block, tun->name);
+        run_command("ip route add %s dev %s table %d",
+            dns_block, tun->name, tun->route_table);
     }
 
     return driver;

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -27,6 +27,10 @@
 #include <unistd.h>
 #include <stdarg.h>
 
+#include <sysexits.h>
+
+#include <uv.h>
+
 #include <ziti/ziti_log.h>
 #include <ziti/ziti_dns.h>
 
@@ -634,22 +638,18 @@ static int make_bypass_socket(const struct addrinfo *ai, bool blocking)
  */
 uv_os_sock_t tlsuv_socket(const struct addrinfo *ai, bool blocking)
 {
-    int blockopt = blocking ? 0 : SOCK_NONBLOCK;
     uv_os_sock_t /* int */ sd;
 
-    sd = socket(ai->ai_family, ai->ai_socktype|SOCK_CLOEXEC|blockopt, ai->ai_protocol);
-    if (sd < 0) {
+    sd = make_bypass_socket(ai, blocking);
+    if (sd < 0)
+        exit(EX_OSERR);
+
+    int nodelay = 1;
+    if (setsockopt(sd, SOL_TCP, TCP_NODELAY, &nodelay, sizeof nodelay) < 0
+        && errno != ENOPROTOOPT) {
         int uv_err = uv_translate_sys_error(errno);
 
-        ZITI_LOG(ERROR, "socket: %d/%s", uv_err, uv_strerror(uv_err));
-        return -1;
-    }
-
-    int mark = ZET_BYPASS_MARK;
-    if (setsockopt(sd, SOL_SOCKET, SO_MARK, &mark, sizeof mark) < 0) {
-        int uv_err = uv_translate_sys_error(errno);
-
-        ZITI_LOG(WARN, "setsockopt(SO_MARK): %d/%s", uv_err, uv_strerror(uv_err));
+        ZITI_LOG(WARN, "Failed to set TCP_NODELAY on socket: %d/%s", uv_err, uv_strerror(uv_err));
     }
 
     return sd;

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.h
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.h
@@ -29,7 +29,7 @@ struct netif_handle_s {
     int  fd;
     char name[IFNAMSIZ];
 
-    int rt_table;
+    int route_table;
 
     model_map *route_updates;
 };

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.h
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.h
@@ -21,13 +21,19 @@
 #include <net/if.h>
 #include "ziti/netif_driver.h"
 
+struct netif_options {
+    bool use_rt_main;
+};
+
 struct netif_handle_s {
     int  fd;
     char name[IFNAMSIZ];
 
+    int rt_table;
+
     model_map *route_updates;
 };
 
-extern netif_driver tun_open(struct uv_loop_s *loop, uint32_t tun_ip, uint32_t dns_ip, const char *cidr, char *error, size_t error_len);
+extern netif_driver tun_open(struct uv_loop_s *loop, uint32_t tun_ip, uint32_t dns_ip, const char *cidr, char *error, size_t error_len, const struct netif_options *opts);
 
 #endif //ZITI_TUNNELER_SDK_TUN_H


### PR DESCRIPTION
Linux has the capability to support multiple routing tables. So let's manage ZET routes in a dedicated routing table, distinct from main and default. The routing policy database is configured to prefer the routes managed in the ZET table over those stored in the main and default routing tables. This approach provides isolation, and thus additional security for ZET routes.

This serves two purposes:
- It acts as a safeguard against TunnelVision (CVE-2024-3661). For more information, visit: https://www.tunnelvisionbug.com/
- It simplifies application of multipathing and MPTCP
- Improves support for jumping between networks


