### PR TITLE
remember enabled/disabled state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ compile_commands.json
 /docker/*.jwt
 /docker/*.json
 /docker/*.json.orig
+
+.run

--- a/lib/ziti-tunnel-cbs/include/ziti/ziti_tunnel_cbs.h
+++ b/lib/ziti-tunnel-cbs/include/ziti/ziti_tunnel_cbs.h
@@ -302,7 +302,7 @@ typedef void (*event_cb)(const base_event* event);
 typedef void (*command_cb)(const tunnel_result *, void *ctx);
 typedef struct {
     int (*process)(const tunnel_command *cmd, command_cb cb, void *ctx);
-    int (*load_identity)(const char *identifier, const char *path, int api_page_size, command_cb, void *ctx);
+    int (*load_identity)(const char *identifier, const char *path, bool disabled, int api_page_size, command_cb cb, void *ctx);
     // do not use, temporary accessor
     ziti_context (*get_ziti)(const char *identifier);
 } ziti_tunnel_ctrl;

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
@@ -601,7 +601,7 @@ static int process_cmd(const tunnel_command *cmd, command_cb cb, void *ctx) {
             }
 
             if (ziti_get_identity(inst->ztx)) {
-                ziti_set_enabled(inst->ztx, false);
+                disconnect_identity(inst->ztx, CMD_CTX.tunnel_ctx);
             }
             model_map_remove(&instances, delete_id.identifier);
             result.success = true;

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
@@ -52,11 +52,11 @@ static const char * cfg_types[] = { "ziti-tunneler-client.v1", "intercept.v1", "
 static long refresh_interval = 10;
 
 static int process_cmd(const tunnel_command *cmd, void (*cb)(const tunnel_result *, void *ctx), void *ctx);
-static int load_identity_cfg(const char *identifier, const ziti_config *cfg,
+static int load_identity_cfg(const char *identifier, const ziti_config *cfg, bool disabled,
                              int api_page_size, command_cb cb, void *ctx);
-static int load_identity(const char *identifier, const char *path, int api_page_size, command_cb cb, void *ctx);
+static int load_identity(const char *identifier, const char *path, bool disabled, int api_page_size, command_cb cb, void *ctx);
 static void get_transfer_rates(const char *identifier, command_cb cb, void *ctx);
-static void load_ziti_async(uv_loop_t *loop, void *arg);
+static void load_ziti_async(uv_loop_t *loop, struct ziti_instance_s *inst);
 static void on_sigdump(uv_signal_t *sig, int signum);
 static void enable_mfa(ziti_context ztx, void *ctx);
 static void verify_mfa(ziti_context ztx, char *code, void *ctx);
@@ -225,10 +225,10 @@ static int process_cmd(const tunnel_command *cmd, command_cb cb, void *ctx) {
                     result.error = "identifier is required when loading with config";
                     break;
                 }
-                rc = load_identity_cfg(load.identifier, load.config, load.apiPageSize, cb, ctx);
+                rc = load_identity_cfg(load.identifier, load.config, false, load.apiPageSize, cb, ctx);
             } else if (load.path != NULL) {
                 const char *id = load.identifier ? load.identifier : load.path;
-                rc = load_identity(id, load.path, load.apiPageSize, cb, ctx);
+                rc = load_identity(id, load.path, false, load.apiPageSize, cb, ctx);
             }
 
             if (rc == ZITI_OK) {
@@ -601,7 +601,7 @@ static int process_cmd(const tunnel_command *cmd, command_cb cb, void *ctx) {
             }
 
             if (ziti_get_identity(inst->ztx)) {
-                disconnect_identity(inst->ztx, CMD_CTX.tunnel_ctx);
+                ziti_set_enabled(inst->ztx, false);
             }
             model_map_remove(&instances, delete_id.identifier);
             result.success = true;
@@ -717,24 +717,25 @@ static int process_cmd(const tunnel_command *cmd, command_cb cb, void *ctx) {
     return 0;
 }
 
-static int load_identity(const char *identifier, const char *path, int api_page_size, command_cb cb, void *ctx) {
+static int load_identity(const char *identifier, const char *path, bool disabled, int api_page_size, command_cb cb, void *ctx) {
     ziti_config cfg = {0};
     int rc = ziti_load_config(&cfg, path);
     if (rc == ZITI_OK) {
         if (identifier == NULL) {
             identifier = path;
         }
-        rc = load_identity_cfg(identifier, &cfg, api_page_size, cb, ctx);
+        rc = load_identity_cfg(identifier, &cfg, disabled, api_page_size, cb, ctx);
     }
 
     free_ziti_config(&cfg);
     return rc;
 }
 
-static int load_identity_cfg(const char *identifier, const ziti_config *cfg, int api_page_size, command_cb cb, void *ctx) {
+static int load_identity_cfg(const char *identifier, const ziti_config *cfg, bool disabled, int api_page_size, command_cb cb, void *ctx) {
     struct ziti_instance_s *inst = new_ziti_instance(identifier ? identifier : cfg->cfg_source);
     ziti_options opts = {
             .api_page_size = api_page_size > 0 ? api_page_size : 0,
+            .disabled = disabled,
     };
     int rc = init_ziti_instance(inst, cfg, &opts);
     if (rc != ZITI_OK) {
@@ -1027,9 +1028,7 @@ static void on_ziti_event(ziti_context ztx, const ziti_event_t *event) {
     }
 }
 
-static void load_ziti_async(uv_loop_t *loop, void *arg) {
-    struct ziti_instance_s *inst = arg;
-
+static void load_ziti_async(uv_loop_t *loop, struct ziti_instance_s *inst) {
     tunnel_result result = {
             .success = true,
             .error = NULL,

--- a/programs/ziti-edge-tunnel/include/model/dtos.h
+++ b/programs/ziti-edge-tunnel/include/model/dtos.h
@@ -39,7 +39,6 @@ XX(Active, bool, none, Active, __VA_ARGS__) \
 XX(Loaded, bool, none, Loaded, __VA_ARGS__) \
 XX(Config, tunnel_config, ptr, Config, __VA_ARGS__) \
 XX(ControllerVersion, string, none, ControllerVersion, __VA_ARGS__) \
-XX(IdFileStatus, bool, none, IdFileStatus, __VA_ARGS__) \
 XX(NeedsExtAuth, bool, none, NeedsExtAuth, __VA_ARGS__) \
 XX(MfaEnabled, bool, none, MfaEnabled, __VA_ARGS__) \
 XX(MfaNeeded, bool, none, MfaNeeded, __VA_ARGS__) \
@@ -93,7 +92,6 @@ XX(TimeoutRemaining, int, none, TimeoutRemaining, __VA_ARGS__) \
 XX(Permissions, tunnel_service_permissions , none, Permissions, __VA_ARGS__)
 
 #define TUNNEL_STATUS(XX, ...) \
-XX(Active, bool, none, Active, __VA_ARGS__) \
 XX(Duration, int, none, Duration, __VA_ARGS__) \
 XX(StartTime, timestamp, none, StartTime, __VA_ARGS__) \
 XX(Identities, tunnel_identity, array, Identities, __VA_ARGS__) \

--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -56,9 +56,6 @@ tunnel_identity *create_or_get_tunnel_identity(const char* identifier, char* fil
     tunnel_identity *id = find_tunnel_identity(identifier);
 
     if (id != NULL) {
-        if (filename != NULL) {
-            id->IdFileStatus = true;
-        }
         return id;
     } else {
         tunnel_identity *tnl_id = calloc(1, sizeof(struct tunnel_identity_s));
@@ -81,7 +78,6 @@ tunnel_identity *create_or_get_tunnel_identity(const char* identifier, char* fil
             tnl_id->Name = calloc(length + 1, sizeof(char));
             snprintf(tnl_id->Name, length+1, "%s", fingerprint);
 
-            tnl_id->IdFileStatus = true;
             tnl_id->Active = true;
         }
         model_map_set(&tnl_identity_map, identifier, tnl_id);
@@ -438,9 +434,7 @@ tunnel_identity_array get_tunnel_identities() {
 
     int idx = 0;
     MODEL_MAP_FOREACH(id, tnl_id, &tnl_identity_map) {
-        if (tnl_id->IdFileStatus) {
-            tnl_id_arr[idx++] = tnl_id;
-        }
+        tnl_id_arr[idx++] = tnl_id;
     }
 
     return tnl_id_arr;
@@ -464,7 +458,6 @@ tunnel_identity_array get_tunnel_identities_for_metrics() {
         id_new->Active = id->Active;
         id_new->Loaded = id->Loaded;
         id_new->Metrics = id->Metrics;
-        id_new->IdFileStatus = id->IdFileStatus;
         tnl_id_arr[i] = id_new;
     }
     free(arr);
@@ -594,7 +587,6 @@ void set_identifier_from_identities() {
         }
         if (tnl_id->Identifier != NULL) {
             // set this field to false during initialization
-            tnl_id->IdFileStatus = false;
             normalize_identifier(tnl_id->Identifier);
             model_map_set(&tnl_identity_map, tnl_id->Identifier, tnl_id);
         }
@@ -605,7 +597,6 @@ void set_identifier_from_identities() {
 }
 
 void initialize_tunnel_status() {
-    tnl_status.Active = true;
     tnl_status.Duration = 0;
     uv_timeval64_t now;
     uv_gettimeofday(&now);
@@ -673,7 +664,6 @@ tunnel_status *get_tunnel_status() {
 char *get_tunnel_config(size_t *json_len) {
     tunnel_status tnl_config = {0};
     tunnel_status *tnl_sts = get_tunnel_status();
-    tnl_config.Active = tnl_sts->Active;
     tnl_config.Duration = tnl_sts->Duration;
     tnl_config.StartTime = tnl_sts->StartTime;
 

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1328,7 +1328,7 @@ static void on_event(const base_event *ev) {
                     }
                 }
             }
-            ZITI_LOG(ERROR, "id->Active: %d", id->Active);
+            
             if (id->Active && model_map_size(&hostnamesToEdit) > 0 && !is_host_only()) {
                 remove_and_add_nrpt_rules(global_loop_ref, &hostnamesToEdit, get_dns_ip());
             }


### PR DESCRIPTION
closes #630 

remember the state of the tunneler whether identities are enabled or disabled.
clean up fields that don't seem to be used (famous last words)