### PR TITLE
feat: add static builds presets

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -37,12 +37,17 @@ runs:
         # use 2024.07.12 vcpkg baseline,
         # see https://learn.microsoft.com/en-us/vcpkg/users/examples/versioning.getting-started#builtin-baseline
         vcpkgGitCommitId: '1de2026f28ead93ff1773e6e680387643e914ea1'
-
+      
     - uses: lukka/run-cmake@v10.6 # pin version to avoid failed glibc dependency on ubuntu 20 runners. go back to @latest when ubuntu 22+ is adopted for runner os.
       name: Configure CMake
       with:
         configurePreset: ci-${{ inputs.preset }}
         configurePresetAdditionalArgs: "[ `-B`, `./build` ]"
+        
+    - name: hack force libpthread.a for static builds
+      if: contains(inputs.preset, 'static')
+      shell: bash
+      run: "grep -rl  ./build | xargs sed -i 's/libpthread.so/libpthread.a/g'"
 
     - name: build ziti-edge-tunnel
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,17 +43,17 @@ jobs:
           - os: ubuntu-20.04
             container: openziti/ziti-builder:v2
             name: Linux x86_64
-            preset: linux-x64-static-libssl
+            preset: linux-x64-static
 
           - os: ubuntu-20.04
             container: openziti/ziti-builder:v2
             name: Linux arm
-            preset: linux-arm-static-libssl
+            preset: linux-arm-static
 
           - os: ubuntu-20.04
             container: openziti/ziti-builder:v2
             name: Linux arm64
-            preset: linux-arm64-static-libssl
+            preset: linux-arm64-static
 
     steps:
       - name: Debug action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
           # token: defaults to github.token
           fail_on_unmatched_files: true
           files: |
-            ${{ runner.workspace }}/downloads/linux-x64-static-libssl/ziti-edge-tunnel-Linux_x86_64.zip
-            ${{ runner.workspace }}/downloads/linux-arm-static-libssl/ziti-edge-tunnel-Linux_arm.zip
+            ${{ runner.workspace }}/downloads/linux-x64-static/ziti-edge-tunnel-Linux_x86_64.zip
+            ${{ runner.workspace }}/downloads/linux-arm-static/ziti-edge-tunnel-Linux_arm.zip
             ${{ runner.workspace }}/downloads/macOS-x64/ziti-edge-tunnel-Darwin_x86_64.zip
             ${{ runner.workspace }}/downloads/macOS-arm64/ziti-edge-tunnel-Darwin_arm64.zip
 
@@ -51,7 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ${{ runner.workspace }}/downloads/linux-arm64-static-libssl/ziti-edge-tunnel-Linux_aarch64.zip
+          asset_path: ${{ runner.workspace }}/downloads/linux-arm64-static/ziti-edge-tunnel-Linux_aarch64.zip
           asset_name: ziti-edge-tunnel-Linux_arm64.zip
           asset_content_type: application/octet-stream
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -225,6 +225,31 @@
       "inherits": [ "ci-linux-static-libssl", "ci-linux-arm" ]
     },
     {
+      "name": "ci-linux-static",
+      "description": "preset to link executable against static libs",
+      "cacheVariables": {
+        "CMAKE_EXE_LINKER_FLAGS": "-static",
+        "BUILD_SHARED_LIBS": "OFF",
+        "ZLIB_USE_STATIC_LIBS": "ON",
+        "OPENSSL_USE_STATIC_LIBS": "ON",
+        "CMAKE_SUPPRESS_REGENERATION": "ON",
+        "CMAKE_FIND_LIBRARY_SUFFIXES": ".a"
+      },
+      "hidden": true
+    },
+    {
+      "name": "ci-linux-x64-static",
+      "inherits": [ "ci-linux-static", "ci-linux-static-libssl", "ci-linux-x64" ]
+    },
+    {
+      "name": "ci-linux-arm64-static",
+      "inherits": [ "ci-linux-static", "ci-linux-static-libssl", "ci-linux-arm64" ]
+    },
+    {
+      "name": "ci-linux-arm-static",
+      "inherits": [ "ci-linux-static", "ci-linux-static-libssl", "ci-linux-arm" ]
+    },
+    {
       "name": "ci-windows-x64",
       "inherits": "ci-windows-x64-vs2022"
     },


### PR DESCRIPTION
Closes #938 

I finally made it, took a lot of experimentation. Used Act but I couldn't reproduce an issue where CMAKE tries to regenerate the build folder after forcing libpthread.a to be linked.
Also yeah, I could not normally force libpthread.a to be linked, so this ugly hack of using sed had to be issued. Also I couldn't reproduce this behaviour on 22.04 jammy when building manually.