### PR TITLE
support both IPv4/6 DNS upstreams

### DIFF
--- a/lib/ziti-tunnel-cbs/ziti_hosting.c
+++ b/lib/ziti-tunnel-cbs/ziti_hosting.c
@@ -916,7 +916,7 @@ host_ctx_t *ziti_sdk_c_host(void *ziti_ctx, uv_loop_t *loop, const char *service
             host_ctx->forward_address = false;
             host_ctx->addr_u.address = server_v1_cfg->hostname;
 
-            snprintf(display_port, sizeof(display_port), "%d", server_v1_cfg->port);
+            snprintf(display_port, sizeof(display_port), "%d", (int)server_v1_cfg->port);
             host_ctx->forward_port = false;
             host_ctx->port_u.port = server_v1_cfg->port;
         }

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
@@ -261,7 +261,7 @@ static void dial_opts_from_intercept_cfg_v1(ziti_dial_opts *opts, const ziti_int
     tag *t = (tag *) model_map_get(&(config->dial_options), "identity");
     if (t != NULL) {
         if (t->type == tag_string) {
-            opts->identity = t->string_value;
+            opts->identity = (char*)t->string_value;
         } else {
             ZITI_LOG(WARN, "dial_options.identity has non-string type %d", t->type);
         }
@@ -270,7 +270,7 @@ static void dial_opts_from_intercept_cfg_v1(ziti_dial_opts *opts, const ziti_int
     t = (tag *)model_map_get(&(config->dial_options), "connect_timeout_seconds");
     if (t != NULL) {
         if (t->type == tag_number) {
-            opts->connect_timeout_seconds = t->num_value;
+            opts->connect_timeout_seconds = (int)t->num_value;
         } else {
             ZITI_LOG(WARN, "dial_options.connect_timeout_seconds has non-numeric type %d", t->type);
         }
@@ -466,7 +466,6 @@ intercept_ctx_t *new_intercept_ctx(tunneler_context tnlr_ctx, ziti_intercept_t *
     intercept_ctx_t *i_ctx = intercept_ctx_new(tnlr_ctx, zi_ctx->service_name, zi_ctx);
     intercept_ctx_set_match_addr(i_ctx, intercept_match_addr);
 
-    int i;
     const ziti_address *intercept_addr;
     switch (zi_ctx->cfg_desc->cfgtype) {
         case CLIENT_CFG_V1:

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1579,18 +1579,7 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
     ip_addr_t dns_ip4 = IPADDR4_INIT(dns_ip);
     ziti_dns_setup(tunneler, ipaddr_ntoa(&dns_ip4), ip_range);
     if (dns_upstream) {
-        char *col = strchr(dns_upstream, ':');
-        if (col) {
-            char host[HOST_NAME_MAX];
-            snprintf(host, sizeof(host), "%.*s", (int)(col - dns_upstream), dns_upstream);
-            int port = atoi(col + 1);
-            if (port < 0 || port > UINT16_MAX) {
-                ZITI_LOG(ERROR, "invalid upstream DNS server port: %d", port);
-            }
-            ziti_dns_set_upstream(ziti_loop, host, port);
-        } else {
-            ziti_dns_set_upstream(ziti_loop, dns_upstream, 0);
-        }
+        ziti_dns_set_upstream(ziti_loop, dns_upstream, 0);
     }
     run_tunneler_loop(ziti_loop);
     if (tun->close) {


### PR DESCRIPTION
- always try to bind upstream socket to IPv6
- map IPv4 upstream address to IPv6

mobile clients may change upstream DNS as they switch networks