### PR TITLE
fix artifact filenames for container images

### DIFF
--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -43,8 +43,8 @@ jobs:
           set -x
           ls -horRAS ./downloads
           mkdir -p ./build/{arm64,amd64}/linux/
-          unzip -d ./build/arm64/linux/ ./downloads/linux-arm64/ziti-edge-tunnel-Linux_arm64.zip
-          unzip -d ./build/amd64/linux/ ./downloads/linux-x64/ziti-edge-tunnel-Linux_x86_64.zip
+          unzip -d ./build/arm64/linux/ ./downloads/linux-arm64-static-libssl/ziti-edge-tunnel-Linux_aarch64.zip
+          unzip -d ./build/amd64/linux/ ./downloads/linux-x64-static-libssl/ziti-edge-tunnel-Linux_x86_64.zip
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
I meant to include this commit in https://github.com/openziti/ziti-tunnel-sdk-c/pull/964