### PR TITLE
only add nrpt entry when the service has dial permission

### DIFF
--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1305,7 +1305,7 @@ static void on_event(const base_event *ev) {
                         for (int i = 0; svc->Addresses[i]; i++) {
                             tunnel_address *addr = svc->Addresses[i];
                             bool has_dial = ziti_service_has_permission(svc_ev->added_services[svc_idx], ziti_session_type_Dial);
-                            if (addr->IsHost && model_map_get(&hostnamesToAdd, addr->HostName) == NULL && svc_ev->added_services && has_dial) {
+                            if (addr->IsHost && model_map_get(&hostnamesToAdd, addr->HostName) == NULL && has_dial) {
                                 if (model_map_get(&hostnamesToRemove, addr->HostName) != NULL) {
                                     model_map_set(&hostnamesToEdit, addr->HostName, "TRUE");
                                 } else {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1304,7 +1304,8 @@ static void on_event(const base_event *ev) {
                     if (svc->Addresses != NULL) {
                         for (int i = 0; svc->Addresses[i]; i++) {
                             tunnel_address *addr = svc->Addresses[i];
-                            if (addr->IsHost && model_map_get(&hostnamesToAdd, addr->HostName) == NULL) {
+                            bool has_dial = ziti_service_has_permission(svc_ev->added_services[svc_idx], ziti_session_type_Dial);
+                            if (addr->IsHost && model_map_get(&hostnamesToAdd, addr->HostName) == NULL && svc_ev->added_services && has_dial) {
                                 if (model_map_get(&hostnamesToRemove, addr->HostName) != NULL) {
                                     model_map_set(&hostnamesToEdit, addr->HostName, "TRUE");
                                 } else {


### PR DESCRIPTION
looks like ZDEW is adding NRPT rules when there's no dial permission:
https://openziti.discourse.group/t/wde-breaks-windows-dns-on-dc/3140/6