### PR TITLE
null ziti io context ref before closing tunneler side

### DIFF
--- a/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
@@ -601,13 +601,14 @@ static void ziti_conn_close_cb(ziti_connection zc) {
         ZITI_LOG(WARN, "null io. underlay connection possibly leaked. ziti_conn[%p]", zc);
         return;
     }
+    ziti_conn_set_data(zc, NULL);
+    ZITI_LOG(VERBOSE, "nulled data for ziti_conn[%p]", zc);
     if (io->ziti_io) {
         free(io->ziti_io);
+        io->ziti_io = NULL;
     }
     ziti_tunneler_close(io->tnlr_io);
     free(io);
-    ziti_conn_set_data(zc, NULL);
-    ZITI_LOG(VERBOSE, "nulled data for ziti_conn[%p]", zc);
 }
 
 #define RESOLVE_APP_DATA "{\"connType\":\"resolver\"}"

--- a/lib/ziti-tunnel/tunnel_tcp.c
+++ b/lib/ziti-tunnel/tunnel_tcp.c
@@ -254,6 +254,7 @@ int tunneler_tcp_close(struct tcp_pcb *pcb) {
     }
     tcp_arg(pcb, NULL);
     tcp_recv(pcb, NULL);
+    tcp_err(pcb, NULL);
     if (pcb->state < ESTABLISHED) {
         TNL_LOG(DEBUG, "closing connection before handshake complete. sending RST to client");
         tcp_abandon(pcb, 1);


### PR DESCRIPTION
Also clear err callback on tcp close.