### PR TITLE
remove static linux builds from release

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -39,11 +39,6 @@ runs:
         configurePreset: ci-${{ inputs.preset }}
         configurePresetAdditionalArgs: "[ `-B`, `./build` ]"
 
-    - name: hack force libpthread.a for static builds
-      if: contains(inputs.preset, 'static')
-      shell: bash
-      run: "grep -rl  ./build | xargs sed -i 's/libpthread.so/libpthread.a/g'"
-
     - name: build ziti-edge-tunnel
       shell: bash
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -55,21 +55,6 @@ jobs:
             name: Linux arm64
             preset: linux-arm64
 
-          - os: ubuntu-22.04
-            container: openziti/ziti-builder:v2
-            name: Linux x86_64 static
-            preset: linux-x64-static
-
-          - os: ubuntu-22.04
-            container: openziti/ziti-builder:v2
-            name: Linux arm static
-            preset: linux-arm-static
-
-          - os: ubuntu-22.04
-            container: openziti/ziti-builder:v2
-            name: Linux arm64 static
-            preset: linux-arm64-static
-
     steps:
       - name: Debug action
         uses: hmarr/debug-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
           pwd
           mv linux-arm64/ziti-edge-tunnel-Linux_aarch64.zip linux-arm64/ziti-edge-tunnel-Linux_arm64.zip
           mv windows-x64-mingw/ziti-edge-tunnel-Windows_AMD64.zip windows-x64-mingw/ziti-edge-tunnel-Windows_x86_64.zip
-          mv linux-arm-static/ziti-edge-tunnel-Linux_arm.zip linux-arm-static/ziti-edge-tunnel-Linux_arm-static.zip
-          mv linux-arm64-static/ziti-edge-tunnel-Linux_aarch64.zip linux-arm64-static/ziti-edge-tunnel-Linux_arm64-static.zip
-          mv linux-x64-static/ziti-edge-tunnel-Linux_x86_64.zip linux-arm64-static/ziti-edge-tunnel-Linux_x86_64-static.zip
 
       - name: List Release Artifacts
         run: ls -horRAS ${{runner.workspace}}/downloads/


### PR DESCRIPTION
backs out the workflow changes from https://github.com/openziti/ziti-tunnel-sdk-c/pull/949 until we can figure out how to build generally usable static binaries, or perhaps make a musl c preset.