### PR TITLE
Handle failed tcp conns before ziti dial

### DIFF
--- a/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
@@ -599,6 +599,7 @@ static void ziti_conn_close_cb(ziti_connection zc) {
     }
     if (io->ziti_io) {
         free(io->ziti_io);
+        io->ziti_io = NULL;
     }
     ziti_tunneler_close(io->tnlr_io);
     free(io);


### PR DESCRIPTION
This avoids double closing tcp handles, which leads to circular tcp connection list.