### PR TITLE
set tcp error callback sooner so tcp errors that happen while waiting for ziti_dial can be handled

### DIFF
--- a/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_cbs.c
@@ -603,6 +603,7 @@ static void ziti_conn_close_cb(ziti_connection zc) {
     }
     if (io->ziti_io) {
         free(io->ziti_io);
+        io->ziti_io = NULL;
     }
     ziti_tunneler_close(io->tnlr_io);
     free(io);


### PR DESCRIPTION
cherry picked from release-1.x.
fixes #961