### PR TITLE
Rc add zfw calls

### DIFF
--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -419,9 +419,7 @@ tunnel_service *get_tunnel_service(tunnel_identity* id, ziti_service* zs) {
     svc->Permissions.Dial = ziti_service_has_permission(zs, ziti_session_type_Dial);
     setTunnelPostureDataTimeout(svc, zs);
     setTunnelServiceAddress(svc, zs);
-    if(svc->Permissions.Bind){
-        setTunnelAllowedSourceAddress(svc, zs);
-    }
+    setTunnelAllowedSourceAddress(svc, zs);
     return svc;
 }
 

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2696,7 +2696,7 @@ void setup_xdp(char *tun_name){
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter xdp tunnel redirect not set on dev %s\n","ziti0");
+                printf("diverter xdp tunnel redirect not set on dev %s\n", tun_name);
             }
         }
     }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -148,7 +148,7 @@ static char *configured_cidr = NULL;
 static char *configured_log_level = NULL;
 static char *configured_proxy = NULL;
 static char *config_dir = NULL;
-static char *diverterIf = NULL;
+static char *diverter_if = NULL;
 static bool diverter = false;
 static bool firewall = false; 
 
@@ -1697,15 +1697,15 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
 #endif
 #if __linux__
     if(!diverter && !firewall){
-        diverterIf = getenv("ZITI_DIVERTER");
-        if(diverterIf && strlen(diverterIf)){
+        diverter_if = getenv("ZITI_DIVERTER");
+        if(diverter_if && strlen(diverter_if)){
             diverter = true;
         }
         char *zifi_firewall = getenv("ZITI_FIREWALL");
         if(zifi_firewall && strlen(zifi_firewall)){
             diverter = true;
             firewall = true;
-            diverterIf = getenv("ZITI_FIREWALL");
+            diverter_if = getenv("ZITI_FIREWALL");
         }
     }
     char zfw_path[PATH_MAX];
@@ -1722,7 +1722,7 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
         if(getenv)
         if (access(diverter_path, F_OK) == 0){
             int count = 0;
-            char *interface = strtok(diverterIf,",");
+            char *interface = strtok(diverter_if,",");
             while(interface != NULL){
                 uint32_t idx = if_nametoindex(interface);
                 if (!idx)
@@ -1959,7 +1959,7 @@ static struct option run_options[] = {
         { "dns-upstream", required_argument, NULL, 'u'},
         { "proxy", required_argument, NULL, 'x' },
         { "diverter", required_argument, NULL, 'D' },
-        { "diverterFw", required_argument, NULL, 'f' },
+        { "diverter-fw", required_argument, NULL, 'f' },
 };
 
 static struct option run_host_options[] = {
@@ -2031,12 +2031,12 @@ static int run_opts(int argc, char *argv[]) {
         switch (c) {
             case 'D':
                 diverter = true;
-                diverterIf = optarg;
+                diverter_if = optarg;
                 break;
             case 'f':
                 diverter = true;
                 firewall = true;
-                diverterIf = optarg;
+                diverter_if = optarg;
                 break;
             case 'i': {
                 struct cfg_instance_s *inst = calloc(1, sizeof(struct cfg_instance_s));
@@ -3932,7 +3932,7 @@ static CommandLine enroll_cmd = make_command("enroll", "enroll Ziti identity",
         "\t-n|--name\tidentity name\n",
         parse_enroll_opts, enroll);
 static CommandLine run_cmd = make_command("run", "run Ziti tunnel (required superuser access)",
-                                          "-i <id.file> [-r N] [-v N] [-d|--dns-ip-range N.N.N.N/n] [-D|--diverter <interface list>] [-f|--diverterFw <interface list>]",
+                                          "-i <id.file> [-r N] [-v N] [-d|--dns-ip-range N.N.N.N/n] [-D|--diverter <interface list>] [-f|--diverter-fw <interface list>]",
                                           "\t-i|--identity <identity>\trun with provided identity file (required)\n"
                                           "\t-I|--identity-dir <dir>\tload identities from provided directory\n"
                                           "\t-x|--proxy type://[username[:password]@]hostname_or_ip:port\tproxy to use when"
@@ -3942,7 +3942,7 @@ static CommandLine run_cmd = make_command("run", "run Ziti tunnel (required supe
                                           "\t-d|--dns-ip-range <ip range>\tspecify CIDR block in which service DNS names"
                                           " are assigned in N.N.N.N/n format (default " DEFAULT_DNS_CIDR ")\n"
                                           "\t-D|--diverter <interface>\tset diverter mode to true on <interface>\n"
-                                          "\t-f|--diverterFw <interface>\tset diverter to true in firewall mode on <interface>)\n",
+                                          "\t-f|--diverter-fw <interface>\tset diverter to true in firewall mode on <interface>)\n",
         run_opts, run);
 static CommandLine run_host_cmd = make_command("run-host", "run Ziti tunnel to host services",
                                           "-i <id.file> [-r N] [-v N]",

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -4186,7 +4186,6 @@ static void move_config_from_previous_windows_backup(uv_loop_t *loop) {
 
 #if __linux__ 
 void INThandler(int sig){
-    
     if(diverter && !firewall){
         diverter_binding_flush();
         diverter_quit();

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2572,7 +2572,7 @@ void pass_dns_range(){
         close(fd);
         char *protocols[2] = {"tcp", "udp"};
         for(int x = 0; x < 2; x++){
-            char *const parmList[] = {diverter_path, "-I", "-c", prefix, "-m", prefix_len, "-l", "1" , "-h", "65535", "-t", "0", "-p", protocols[x], NULL};
+            char *const parmList[] = {diverter_path, "-I", "-c", prefix, "-m", prefix_len, "-l", "1" , "-h", "65535", "-t", "65535", "-p", protocols[x], NULL};
             if ((pid = fork()) == -1)
             {
                 ZITI_LOG(DEBUG,"fork error: can't spawn bind");

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1701,54 +1701,60 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
             ziti_dns_set_upstream(ziti_loop, dns_upstream, 0);
         }
     }
-    #if __linux__
-        if(!diverter && !firewall){
-            diverterIf = getenv("ZITI_DIVERTER");
-            if(diverterIf){
-                diverter = true;
-            }
-            char *zifi_firewall = getenv("ZITI_FIREWALL");
-            if(zifi_firewall){
-                diverter = true;
-                firewall = true;
-                diverterIf = getenv("ZITI_FIREWALL");
-            }
+#if _WIN32
+    if(diverter){
+        ZITI_LOG(INFO,"Diverter features not currently supported on windows");
+        exit(1);
+    }
+#endif
+#if __linux__
+    if(!diverter && !firewall){
+        diverterIf = getenv("ZITI_DIVERTER");
+        if(diverterIf){
+            diverter = true;
         }
-        if(diverter && tun){
-            ztun = tun;
-            if(!firewall){
-                diverter_quit();
-            }
-            if (access(diverter_path, F_OK) == 0){
-                int count = 0;
-                char *interface = strtok(diverterIf,",");
-                while(interface != NULL){
-                    uint32_t idx = if_nametoindex(interface);
-                    if (!idx)
-                    {
-                        ZITI_LOG(INFO,"Diverter interface not found: %s", interface);
-                        interface = strtok(NULL,",");
-                        continue;
-                    }
-                    if(if_indextoname(idx, check_alt)){
-                        interface = check_alt;
-                    }
-                    init_diverter_interface(interface);
+        char *zifi_firewall = getenv("ZITI_FIREWALL");
+        if(zifi_firewall){
+            diverter = true;
+            firewall = true;
+            diverterIf = getenv("ZITI_FIREWALL");
+        }
+    }
+    if(diverter && tun){
+        ztun = tun;
+        if(!firewall){
+            diverter_quit();
+        }
+        if (access(diverter_path, F_OK) == 0){
+            int count = 0;
+            char *interface = strtok(diverterIf,",");
+            while(interface != NULL){
+                uint32_t idx = if_nametoindex(interface);
+                if (!idx)
+                {
+                    ZITI_LOG(INFO,"Diverter interface not found: %s", interface);
                     interface = strtok(NULL,",");
-                    count++;
+                    continue;
                 }
-                if(count){
-                    set_diverter(dns_subnet_in->s_addr, dns_subnet_zaddr.addr.cidr.bits, tun->handle->name);
-                }else{
-                   ZITI_LOG(INFO,"No valid diverter interfaces found");
-                   exit(1);  
+                if(if_indextoname(idx, check_alt)){
+                    interface = check_alt;
                 }
-            }else{
-                ZITI_LOG(INFO, "Diverter binary not found");
-                exit(1);
+                init_diverter_interface(interface);
+                interface = strtok(NULL,",");
+                count++;
             }
+            if(count){
+                set_diverter(dns_subnet_in->s_addr, dns_subnet_zaddr.addr.cidr.bits, tun->handle->name);
+            }else{
+                ZITI_LOG(INFO,"No valid diverter interfaces found");
+                exit(1);  
+            }
+        }else{
+            ZITI_LOG(INFO, "Diverter binary not found");
+            exit(1);
         }
-    #endif
+    }
+#endif
     run_tunneler_loop(ziti_loop);
     if (tun->close) {
         tun->close(tun->handle);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1304,6 +1304,8 @@ static void on_event(const base_event *ev) {
                                             if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
                                                 diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-D");
                                                 bind_route(svc->Addresses[x]->IP, svc->Addresses[x]->Prefix, ztun->handle->name);
+                                            }else if(firewall){
+                                                diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-D");
                                             }
                                         }
                                     }
@@ -1359,6 +1361,8 @@ static void on_event(const base_event *ev) {
                                             if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
                                                 diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-I");
                                                 unbind_route(svc->Addresses[x]->IP, svc->Addresses[x]->Prefix, ztun->handle->name);
+                                            }else if(firewall){
+                                                diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-I");
                                             }
                                         }
                                     }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1297,11 +1297,6 @@ static void on_event(const base_event *ev) {
                                 if(!svc->Addresses[x]->IsHost){
                                     char *ip = svc->Addresses[x]->IP;
                                     char prefix_len[4];
-                                    if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
-                                        char cidr[44];
-                                        sprintf(cidr, "%s/%d", ip, svc->Addresses[x]->Prefix);
-                                        ztun->add_route(ztun->handle, cidr);
-                                    }
                                     sprintf(prefix_len, "%d", svc->Addresses[x]->Prefix);
                                     for(int i =  0; (svc->Ports != NULL) && (svc->Ports[i] != NULL); i++){
                                         char low_port[6];
@@ -1351,20 +1346,11 @@ static void on_event(const base_event *ev) {
 #if __linux__
                     if(svc && diverter){
                         if(svc->Permissions.Dial){
-                            if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
-                                ztun->commit_routes(ztun->handle, global_loop_ref);
-                                sleep(1);
-                            }
                             for(int x = 0; svc->Addresses && (svc->Addresses[x] != NULL); x++){
                                 if(!svc->Addresses[x]->IsHost){
                                     char *ip = svc->Addresses[x]->IP;
                                     char prefix_len[4];
                                     sprintf(prefix_len, "%d", svc->Addresses[x]->Prefix);
-                                    if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
-                                        char cidr[44];
-                                        sprintf(cidr, "%s/%d", ip, svc->Addresses[x]->Prefix);
-                                        ztun->delete_route(ztun->handle, cidr);
-                                    }
                                     for(int i =  0; (svc->Ports != NULL) && (svc->Ports[i] != NULL); i++){
                                         char low_port[6];
                                         char high_port[6];

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2149,18 +2149,13 @@ static void interrupt_handler(int sig) {
 #endif
 
 void diverter_update(char *ip, char *mask, char *lowport, char *highport, char *protocol, char *service_id, char *action){
+    bool state = true;
     unsigned short random_port = 0;
     unsigned char count = 0;
     random_port = htons(1024 + rand() % (65535 - 1023));
     char tproxy_port[6];
     sprintf(tproxy_port, "%u", random_port);
-    if (access(diverter_path, F_OK) != 0)
-    {
-        ZITI_LOG(INFO,"diverter not installed: Cannot find /opt/openziti/bin/zfw");
-        return;
-    }
     pid_t pid;
-    ZITI_LOG(INFO,"%s -c %s -m %s -l %s -h %s -t %s -p %s -s %s", action,ip, mask, lowport, highport, tproxy_port, protocol,service_id);
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
     int fd = open("/dev/null", O_WRONLY);
@@ -2173,15 +2168,14 @@ void diverter_update(char *ip, char *mask, char *lowport, char *highport, char *
     char *const parmList[17] = {diverter_path, action, "-c", ip, "-m", mask, "-l",
      lowport, "-h", highport, "-t", tproxy_port, "-p", protocol, "-s", service_id, NULL};
     if ((pid = fork()) == -1){
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }else if (pid == 0) {
        execv(diverter_path, parmList);
-       ZITI_LOG(DEBUG, "execv error: unknown error binding");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) > 0)){
             if(WIFEXITED(status) && !WEXITSTATUS(status)){
-                ZITI_LOG(DEBUG,"waitpid error: diverter %s action for : %s set", action,  ip);
+                state = false;
             }
         }
     }
@@ -2189,13 +2183,18 @@ void diverter_update(char *ip, char *mask, char *lowport, char *highport, char *
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err);
+    if(state){
+        ZITI_LOG(INFO,"%s -c %s -m %s -l %s -h %s -t %s -p %s -s %s", action,ip, mask, lowport, highport, tproxy_port, protocol,service_id);
+    }else{
+        ZITI_LOG(DEBUG,"Failed insert: %s -c %s -m %s -l %s -h %s -t %s -p %s -s %s", action,ip, mask, lowport, highport, tproxy_port, protocol,service_id);
+    }
 }
 
 void bind_route(char* ip, int prefix_len, char *dev)
 {
+    bool state = true;
     char *cidr_block[19];
     sprintf(cidr_block, "%s/%d", ip, prefix_len);
-    ZITI_LOG(INFO,"restoring route to %s via dev %s", cidr_block, dev);
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2214,12 +2213,12 @@ void bind_route(char* ip, int prefix_len, char *dev)
     else if (pid == 0)
     {
         execv("/usr/sbin/ip", parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error rebinding route\n");
+        state = false;
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) > 0)){
             if(WIFEXITED(status) && !WEXITSTATUS(status)){
-                ZITI_LOG(DEBUG,"waitpid error: binding %s to dev %s", cidr_block, dev);
+                state = false;
             }
         }
     }
@@ -2227,13 +2226,18 @@ void bind_route(char* ip, int prefix_len, char *dev)
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"Diverter restoring route to %s via dev %s", cidr_block, dev);
+    }else{
+        ZITI_LOG(DEBUG,"Diverter failed restoring route to %s via dev %s", cidr_block, dev);
+    }
 }
 
 void unbind_route(char* ip, int prefix_len, char *dev)
 {
+    bool state = true;
     char *cidr_block[19];
     sprintf(cidr_block, "%s/%d", ip, prefix_len);
-    ZITI_LOG(INFO,"unbinding route to %s via dev %s for transparency support", cidr_block, dev);
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2247,17 +2251,16 @@ void unbind_route(char* ip, int prefix_len, char *dev)
     char *const parmList[] = {"/usr/sbin/ip", "route", "delete", cidr_block, "dev", dev, "scope", "link", NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn unbind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv("/usr/sbin/ip", parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error unbinding route");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) > 0)){
             if(WIFEXITED(status) && !WEXITSTATUS(status)){
-                ZITI_LOG(DEBUG,"waitpid error: unbinding %s from dev %s", cidr_block, dev);
+                state = false;
             }
         }
     }
@@ -2265,9 +2268,15 @@ void unbind_route(char* ip, int prefix_len, char *dev)
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(INFO,"Diverter unbinding route to %s via dev %s for transparency support", cidr_block, dev);
+    }else{
+        ZITI_LOG(INFO,"Diverter failed unbinding route to %s via dev %s for transparency support", cidr_block, dev);
+    }
 }
 
 void diverter_quit(){
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2281,28 +2290,32 @@ void diverter_quit(){
     char *const parmList[] = {diverter_path, "-Q", NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error removing diverter");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: Unable to remove diverter from: %s", diverterIf);
+                state = false;
             }
         }
     }
     dup2(o_std_out, STDOUT_FILENO);
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
-    close(o_std_err); 
+    close(o_std_err);
+    if(state){
+        ZITI_LOG(DEBUG,"Successfully removed diverter");
+    }else{
+        ZITI_LOG(DEBUG,"Remove diverter failed");
+    }
 }
 
 void init_diverter_interface(char * interface){
-    ZITI_LOG(INFO,"diverter tc enabled on %s", interface);
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2316,18 +2329,17 @@ void init_diverter_interface(char * interface){
     char *const parmList[] = {diverter_path, "-H", interface, NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error adding diverter ingress filters");
     }else{
         int status =0;
 
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: zfw not set on dev %s", interface);
+                state = false;
             }
         }
     }
@@ -2340,12 +2352,17 @@ void init_diverter_interface(char * interface){
         enable_ipv6(interface);
         pass_non_tuple(interface);
     }
+    if(state){
+        ZITI_LOG(INFO,"diverter tc enabled on %s", interface);
+    }else{
+        ZITI_LOG(INFO,"diverter tc not enabled on %s", interface);
+    }
 }
 
 void bind_diverter_route(char *ip, int prefix_len){
+    bool state = true;
     char mask[4];
     sprintf(mask, "%d", prefix_len);
-    ZITI_LOG(INFO,"binding transparency route to %s/%s on lo", ip, mask);
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2359,17 +2376,16 @@ void bind_diverter_route(char *ip, int prefix_len){
     char *const parmList[] = {diverter_path, "-B", ip, "-m", mask, NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG, "fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG,"error binding %s/%s to lo", ip, mask);
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: error binding %s/%s to lo", ip, mask);
+                state = false;
             }
         }
     }
@@ -2377,12 +2393,17 @@ void bind_diverter_route(char *ip, int prefix_len){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(INFO,"binding transparency route to %s/%s on lo", ip, mask);
+    }else{
+        ZITI_LOG(DEBUG,"Failed to bind transparency route %s/%s to lo", ip, mask);
+    }
 }
 
 void unbind_diverter_route(char *ip, int prefix_len){
+    bool state = true;
     char mask[4];
     sprintf(mask, "%d", prefix_len);
-    ZITI_LOG(INFO,"unbinding transparency route %s/%s from lo", ip, mask);
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2396,17 +2417,16 @@ void unbind_diverter_route(char *ip, int prefix_len){
     char *const parmList[] = {diverter_path, "-J", ip, "-m", mask, NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG, "fork error: can't spawn unbind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG,"error unbinding %s/%s from lo", ip, mask);
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: error unbinding %s/%s from lo", ip, mask);
+                state = false;
             }
         }
     }
@@ -2414,10 +2434,15 @@ void unbind_diverter_route(char *ip, int prefix_len){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(INFO,"unbinding transparency route %s/%s from lo", ip, mask);
+    }else{
+        ZITI_LOG(DEBUG,"Failed to unbind transparency route %s/%s from lo", ip, mask);
+    }
 }
 
 void diverter_binding_flush(){
-    ZITI_LOG(INFO,"unbinding transparency routes from lo");
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2431,17 +2456,16 @@ void diverter_binding_flush(){
     char *const parmList[] = {diverter_path, "-F", "-j", NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG, "fork error: can't spawn unbind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG,"error flushing diverter routes from lo\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: error flushing diverter routes");
+                state = false;
             }
         }
     }
@@ -2449,10 +2473,15 @@ void diverter_binding_flush(){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(INFO,"unbinding transparency routes from lo");
+    }else{
+        ZITI_LOG(DEBUG,"Failed to unbind transparency routes from lo");
+    }
 }
 
 void diverter_ingress_flush(){
-    ZITI_LOG(INFO,"flushing diverter intercepts");
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2466,17 +2495,16 @@ void diverter_ingress_flush(){
     char *const parmList[] = {diverter_path, "-F", "-z", "ingress", NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG, "fork error: can't spawn unbind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG,"error flushing diverter ingress intercepts\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: error flushing diverter ingress intercepts");
+                state = false;
             }
         }
     }
@@ -2484,9 +2512,15 @@ void diverter_ingress_flush(){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(INFO,"flushing diverter intercepts");
+    }else{
+        ZITI_LOG(DEBUG,"Failed to flush diverter intercepts");
+    }
 }
 
 void pass_non_tuple(char *interface){
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2500,17 +2534,16 @@ void pass_non_tuple(char *interface){
     char *const parmList[] = {diverter_path, "-q", interface, NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error removing non-tuple filters\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter non-tuple firewall not disabled on dev %s\n", interface);
+                state = false;
             }
         }
     }
@@ -2518,9 +2551,15 @@ void pass_non_tuple(char *interface){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(INFO,"Diverter permit non tuple");
+    }else{
+        ZITI_LOG(DEBUG,"Diverter permit non tuple failed");
+    }
 }
 
 void enable_ipv6(char *interface){
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2534,17 +2573,16 @@ void enable_ipv6(char *interface){
     char *const parmList[] = {diverter_path, "-6", interface, NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error enabling ipv6 filters");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter IPv6 not enabled on dev %s", interface);
+                state = false;
             }
         }
     }
@@ -2552,9 +2590,15 @@ void enable_ipv6(char *interface){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"Diverter enable ipv6");
+    }else{
+        ZITI_LOG(DEBUG,"Diverter enable ipv6 failed");
+    }
 }
 
 void pass_tcp_ipv4(){
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2568,17 +2612,16 @@ void pass_tcp_ipv4(){
     char *const parmList[] = {diverter_path, "-I", "-c", "0.0.0.0", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "tcp", NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error binding ipv4 tcp filters\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter IPv4 TCP firewall not disabled on dev %s", diverterIf);
+                state = false;
             }
         }
     }
@@ -2586,9 +2629,15 @@ void pass_tcp_ipv4(){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"Diverter permit IPv4 TCP traffic");
+    }else{
+        ZITI_LOG(DEBUG,"Diverter permit IPv4 TCP traffic failed");
+    }
 }
 
 void pass_dns_range(uint32_t dns_prefix, unsigned char dns_prefix_range){
+    bool state = true;
     pid_t pid;
     char prefix[INET_ADDRSTRLEN];
     char prefix_len[4];
@@ -2608,17 +2657,16 @@ void pass_dns_range(uint32_t dns_prefix, unsigned char dns_prefix_range){
         char *const parmList[] = {diverter_path, "-I", "-c", prefix, "-m", prefix_len, "-l", "1" , "-h", "65535", "-t", "65535", "-p", protocols[x], NULL};
         if ((pid = fork()) == -1)
         {
-            ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+            state = false;
         }
         else if (pid == 0)
         {
             execv(diverter_path, parmList);
-            ZITI_LOG(DEBUG, "execv error: unknown error binding ipv4 tcp filters\n");
         }else{
             int status =0;
             if(!(waitpid(pid, &status, 0) < 0)){
                 if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                    ZITI_LOG(DEBUG,"waitpid error: diverter IPv4 TCP firewall not disabled on dev %s", diverterIf);
+                    state = false;
                 }
             }
         }
@@ -2627,9 +2675,15 @@ void pass_dns_range(uint32_t dns_prefix, unsigned char dns_prefix_range){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"DNS Range added to diverter firewall");
+    }else{
+        ZITI_LOG(DEBUG,"Diverter unable to add DNS Range to firewall");
+    }
 }
 
 void pass_udp_ipv4(){
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2643,17 +2697,16 @@ void pass_udp_ipv4(){
     char *const parmList[] = {diverter_path, "-I", "-c", "0.0.0.0", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "udp", NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error binding ipv4 udp filters");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter IPv4 UDP firewall not disabled on dev %s\n", diverterIf);
+                state = false;
             }
         }
     }
@@ -2661,9 +2714,15 @@ void pass_udp_ipv4(){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"Diverter permit IPv4 UDP traffic");
+    }else{
+        ZITI_LOG(DEBUG,"Diverter permit IPv4 UDP traffic failed");
+    }
 }
 
 void pass_tcp_ipv6(){
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2677,17 +2736,16 @@ void pass_tcp_ipv6(){
     char *const parmList[] = {diverter_path, "-I", "-c", "::", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "tcp", NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error binding ipv6 tcp filters\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter IPv6 TCP firewall not disabled on dev %s\n", diverterIf);
+                state = false;
             }
         }
     }
@@ -2695,10 +2753,15 @@ void pass_tcp_ipv6(){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"Diverter permit IPv6 TCP traffic");
+    }else{
+        ZITI_LOG(DEBUG,"Diverter permit IPv6 TCP traffic failed");
+    }
 }
 
 void set_tun_mode(char *interface){
-    ZITI_LOG(INFO,"setting diverter interface %s to run in tun mode", interface);
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2712,17 +2775,16 @@ void set_tun_mode(char *interface){
     char *const parmList[] = {diverter_path, "-T", interface, NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+       state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error setting tunnel mode\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter tunnel mode intercept not set on dev %s\n", interface);
+               state = false;
             }
         }
     }
@@ -2730,10 +2792,15 @@ void set_tun_mode(char *interface){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"Diverter set tun mode forwarding on %s", interface);
+    }else{
+        ZITI_LOG(DEBUG,"Failed to set diverter tun mode forwarding on %s", interface);
+    }
 }
 
 void setup_xdp(char *tun_name){
-    ZITI_LOG(INFO,"adding diverter xdp to %s", tun_name);
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2747,17 +2814,16 @@ void setup_xdp(char *tun_name){
     char *const parmList[] = {diverter_path, "-Z", tun_name, NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error binding xdp to %s", tun_name);
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter xdp not set on dev %s\n", tun_name);
+                state = false;
             }
         }
     }
@@ -2765,9 +2831,15 @@ void setup_xdp(char *tun_name){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"Adding diverter xdp to %s", tun_name);
+    }else{
+        ZITI_LOG(DEBUG,"Failed adding diverter xdp to %s", tun_name);
+    }
 }
 
 void pass_udp_ipv6(){
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2781,17 +2853,16 @@ void pass_udp_ipv6(){
     char *const parmList[] = {diverter_path, "-I", "-c", "::", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "udp", NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error binding ipv6 udp filters\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter IPv6 UDP firewall not disabled on dev %s", diverterIf);
+                state = false;
             }
         }
     }
@@ -2799,9 +2870,15 @@ void pass_udp_ipv6(){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"Diverter permit IPv6 UDP traffic");
+    }else{
+        ZITI_LOG(DEBUG,"Diverter permit IPv6 UDP traffic failed");
+    }
 }
 
 void add_user_rules(){
+    bool state = true;
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2815,17 +2892,16 @@ void add_user_rules(){
     char *const parmList[] = {diverter_path, "-A",NULL};
     if ((pid = fork()) == -1)
     {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+        state = false;
     }
     else if (pid == 0)
     {
         execv("/opt/openziti/bin/user/user_rules.sh", parmList);
-        ZITI_LOG(DEBUG, "execv error: unknown error adding user defined rules\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: error adding user defined rules\n");
+                state = false;
             }
         }
     }
@@ -2833,6 +2909,11 @@ void add_user_rules(){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    if(state){
+        ZITI_LOG(DEBUG,"Diverter importing user rules");
+    }else{
+        ZITI_LOG(DEBUG,"Diverter unable to import user rules");
+    }
 }
 
 void disable_firewall(){
@@ -2844,7 +2925,11 @@ void disable_firewall(){
 
 void set_diverter(uint32_t dns_prefix, unsigned char dns_prefix_range, char *tun_name)
 {
-    ZITI_LOG(INFO,"starting ziti-edge-tunnel in diverter mode");
+    if(!firewall){
+        ZITI_LOG(INFO,"Starting ziti-edge-tunnel in diverter mode");
+    }else{
+        ZITI_LOG(INFO,"Starting ziti-edge-tunnel in diverter firewall mode");
+    }
     if(!firewall){
         disable_firewall();
     }else{

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -85,14 +85,15 @@ static void unbind_route(char* ip, int prefix, char *dev);
 void bind_route(char* ip, int prefix_len, char *dev);
 void bind_diverter_route(char *ip, int prefix_len);
 void unbind_diverter_route(char *ip, int prefix_len);
+void enable_ipv6(char *interface);
+void set_tun_mode(char *interface);
+void pass_non_tuple(char *interface);
 void diverter_binding_flush();
 char check_alt[IF_NAMESIZE];
 char *diverter_path = "/opt/openziti/bin/zfw";
 static tunneler_context initialize_tunneler(netif_driver tun, uv_loop_t* ziti_loop);
 static void diverter_update(char *ip, char *mask, char *lowport, char *highport, char *protocol, char *service_id, char *action);
 static netif_driver ztun;
-uint32_t dns_prefix = 0;
-unsigned char dns_prefix_range = 0;
 #if _WIN32
 static void move_config_from_previous_windows_backup(uv_loop_t *loop);
 #define LAST_CHAR_IPC_CMD '\n'
@@ -1298,6 +1299,9 @@ static void on_event(const base_event *ev) {
                                 if(!svc->Addresses[x]->IsHost){
                                     char *ip = svc->Addresses[x]->IP;
                                     char prefix_len[4];
+                                    if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
+                                        bind_route(svc->Addresses[x]->IP, svc->Addresses[x]->Prefix, ztun->handle->name);
+                                    }
                                     sprintf(prefix_len, "%d", svc->Addresses[x]->Prefix);
                                     for(int i =  0; (svc->Ports != NULL) && (svc->Ports[i] != NULL); i++){
                                         char low_port[6];
@@ -1305,10 +1309,7 @@ static void on_event(const base_event *ev) {
                                         sprintf(low_port, "%d", svc->Ports[i]->Low);
                                         sprintf(high_port,"%d", svc->Ports[i]->High);
                                         for(int j =  0; (svc->Protocols != NULL) && (svc->Protocols[j] != NULL); j++){
-                                            if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
-                                                diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-D");
-                                                bind_route(svc->Addresses[x]->IP, svc->Addresses[x]->Prefix, ztun->handle->name);
-                                            }else if(firewall){
+                                            if((svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL) || firewall){
                                                 diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-D");
                                             }
                                         }
@@ -1368,9 +1369,7 @@ static void on_event(const base_event *ev) {
                                         sprintf(low_port, "%d", svc->Ports[i]->Low);
                                         sprintf(high_port,"%d", svc->Ports[i]->High);
                                         for(int j =  0; (svc->Protocols != NULL) && (svc->Protocols[j] != NULL); j++){
-                                            if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
-                                                diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-I");
-                                            }else if(firewall){
+                                            if((svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL) || firewall){
                                                 diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-I");
                                             }
                                         }
@@ -1703,19 +1702,47 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
         }
     }
     #if __linux__
+        if(!diverter && !firewall){
+            diverterIf = getenv("ZITI_DIVERTER");
+            if(diverterIf){
+                diverter = true;
+            }
+            char *zifi_firewall = getenv("ZITI_FIREWALL");
+            if(zifi_firewall){
+                diverter = true;
+                firewall = true;
+                diverterIf = getenv("ZITI_FIREWALL");
+            }
+        }
         if(diverter && tun){
             ztun = tun;
+            if(!firewall){
+                diverter_quit();
+            }
             if (access(diverter_path, F_OK) == 0){
-                uint32_t idx = if_nametoindex(diverterIf);
-                if (!idx)
-                {
-                    printf("Diverter interface not found: %s\n", diverterIf);
-                    exit(1);
+                int count = 0;
+                char *interface = strtok(diverterIf,",");
+                while(interface != NULL){
+                    uint32_t idx = if_nametoindex(interface);
+                    if (!idx)
+                    {
+                        ZITI_LOG(INFO,"Diverter interface not found: %s", interface);
+                        interface = strtok(NULL,",");
+                        continue;
+                    }
+                    if(if_indextoname(idx, check_alt)){
+                        interface = check_alt;
+                    }
+                    init_diverter_interface(interface);
+                    interface = strtok(NULL,",");
+                    count++;
                 }
-                if(if_indextoname(idx, check_alt)){
-                   diverterIf = check_alt;
+                if(count){
+                    set_diverter(dns_subnet_in->s_addr, dns_subnet_zaddr.addr.cidr.bits, tun->handle->name);
+                }else{
+                   ZITI_LOG(INFO,"No valid diverter interfaces found");
+                   exit(1);  
                 }
-                set_diverter(tun->handle->name);
             }else{
                 ZITI_LOG(INFO, "Diverter binary not found");
                 exit(1);
@@ -2274,8 +2301,8 @@ void diverter_quit(){
     close(o_std_err); 
 }
 
-void init_diverter(){
-    ZITI_LOG(INFO,"diverter tc enabled on %s", diverterIf);
+void init_diverter_interface(char * interface){
+    ZITI_LOG(INFO,"diverter tc enabled on %s", interface);
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2286,7 +2313,7 @@ void init_diverter(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {diverter_path, "-H", diverterIf, NULL};
+    char *const parmList[] = {diverter_path, "-H", interface, NULL};
     if ((pid = fork()) == -1)
     {
         ZITI_LOG(DEBUG,"fork error: can't spawn bind");
@@ -2300,7 +2327,7 @@ void init_diverter(){
 
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: zfw not set on dev %s", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: zfw not set on dev %s", interface);
             }
         }
     }
@@ -2308,6 +2335,11 @@ void init_diverter(){
     dup2(o_std_err, STDERR_FILENO);
     close(o_std_out);
     close(o_std_err); 
+    set_tun_mode(interface);
+    if(!firewall){
+        enable_ipv6(interface);
+        pass_non_tuple(interface);
+    }
 }
 
 void bind_diverter_route(char *ip, int prefix_len){
@@ -2454,7 +2486,7 @@ void diverter_ingress_flush(){
     close(o_std_err); 
 }
 
-void pass_non_tuple(){
+void pass_non_tuple(char *interface){
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2465,7 +2497,7 @@ void pass_non_tuple(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {diverter_path, "-q", diverterIf, NULL};
+    char *const parmList[] = {diverter_path, "-q", interface, NULL};
     if ((pid = fork()) == -1)
     {
         ZITI_LOG(DEBUG,"fork error: can't spawn bind");
@@ -2478,7 +2510,7 @@ void pass_non_tuple(){
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter non-tuple firewall not disabled on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter non-tuple firewall not disabled on dev %s\n", interface);
             }
         }
     }
@@ -2488,7 +2520,7 @@ void pass_non_tuple(){
     close(o_std_err); 
 }
 
-void enable_ipv6(){
+void enable_ipv6(char *interface){
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2499,7 +2531,7 @@ void enable_ipv6(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {diverter_path, "-6", diverterIf, NULL};
+    char *const parmList[] = {diverter_path, "-6", interface, NULL};
     if ((pid = fork()) == -1)
     {
         ZITI_LOG(DEBUG,"fork error: can't spawn bind");
@@ -2512,7 +2544,7 @@ void enable_ipv6(){
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter IPv6 not enabled on dev %s", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter IPv6 not enabled on dev %s", interface);
             }
         }
     }
@@ -2556,49 +2588,45 @@ void pass_tcp_ipv4(){
     close(o_std_err); 
 }
 
-void pass_dns_range(){
+void pass_dns_range(uint32_t dns_prefix, unsigned char dns_prefix_range){
     pid_t pid;
     char prefix[INET_ADDRSTRLEN];
     char prefix_len[4];
-    if(dns_prefix && dns_prefix_range){
-        sprintf(prefix_len, "%u", dns_prefix_range);
-        inet_ntop(AF_INET, &dns_prefix, prefix, INET_ADDRSTRLEN);
-        int o_std_out = dup(STDOUT_FILENO);
-        int o_std_err = dup(STDERR_FILENO);
-        int fd = open("/dev/null", O_WRONLY);
-        if (fd == -1){
-            return; 
+    sprintf(prefix_len, "%u", dns_prefix_range);
+    inet_ntop(AF_INET, &dns_prefix, prefix, INET_ADDRSTRLEN);
+    int o_std_out = dup(STDOUT_FILENO);
+    int o_std_err = dup(STDERR_FILENO);
+    int fd = open("/dev/null", O_WRONLY);
+    if (fd == -1){
+        return; 
+    }
+    dup2(fd, STDOUT_FILENO);
+    dup2(fd, STDERR_FILENO);
+    close(fd);
+    char *protocols[2] = {"tcp", "udp"};
+    for(int x = 0; x < 2; x++){
+        char *const parmList[] = {diverter_path, "-I", "-c", prefix, "-m", prefix_len, "-l", "1" , "-h", "65535", "-t", "65535", "-p", protocols[x], NULL};
+        if ((pid = fork()) == -1)
+        {
+            ZITI_LOG(DEBUG,"fork error: can't spawn bind");
         }
-        dup2(fd, STDOUT_FILENO);
-        dup2(fd, STDERR_FILENO);
-        close(fd);
-        char *protocols[2] = {"tcp", "udp"};
-        for(int x = 0; x < 2; x++){
-            char *const parmList[] = {diverter_path, "-I", "-c", prefix, "-m", prefix_len, "-l", "1" , "-h", "65535", "-t", "65535", "-p", protocols[x], NULL};
-            if ((pid = fork()) == -1)
-            {
-                ZITI_LOG(DEBUG,"fork error: can't spawn bind");
-            }
-            else if (pid == 0)
-            {
-                execv(diverter_path, parmList);
-                ZITI_LOG(DEBUG, "execv error: unknown error binding ipv4 tcp filters\n");
-            }else{
-                int status =0;
-                if(!(waitpid(pid, &status, 0) < 0)){
-                    if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                        ZITI_LOG(DEBUG,"waitpid error: diverter IPv4 TCP firewall not disabled on dev %s", diverterIf);
-                    }
+        else if (pid == 0)
+        {
+            execv(diverter_path, parmList);
+            ZITI_LOG(DEBUG, "execv error: unknown error binding ipv4 tcp filters\n");
+        }else{
+            int status =0;
+            if(!(waitpid(pid, &status, 0) < 0)){
+                if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
+                    ZITI_LOG(DEBUG,"waitpid error: diverter IPv4 TCP firewall not disabled on dev %s", diverterIf);
                 }
             }
         }
-        dup2(o_std_out, STDOUT_FILENO);
-        dup2(o_std_err, STDERR_FILENO);
-        close(o_std_out);
-        close(o_std_err); 
-    }else{
-        ZITI_LOG(INFO,"Invalid dns prefix range");
     }
+    dup2(o_std_out, STDOUT_FILENO);
+    dup2(o_std_err, STDERR_FILENO);
+    close(o_std_out);
+    close(o_std_err); 
 }
 
 void pass_udp_ipv4(){
@@ -2669,8 +2697,8 @@ void pass_tcp_ipv6(){
     close(o_std_err); 
 }
 
-void set_tun_mode(){
-    ZITI_LOG(INFO,"setting diverter to run in tun mode");
+void set_tun_mode(char *interface){
+    ZITI_LOG(INFO,"setting diverter interface %s to run in tun mode", interface);
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2681,7 +2709,7 @@ void set_tun_mode(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {diverter_path, "-T", diverterIf, NULL};
+    char *const parmList[] = {diverter_path, "-T", interface, NULL};
     if ((pid = fork()) == -1)
     {
         ZITI_LOG(DEBUG,"fork error: can't spawn bind");
@@ -2694,7 +2722,7 @@ void set_tun_mode(){
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"waitpid error: diverter tunnel mode intercept not set on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter tunnel mode intercept not set on dev %s\n", interface);
             }
         }
     }
@@ -2810,17 +2838,13 @@ void add_user_rules(){
 void disable_firewall(){
     pass_tcp_ipv4();
     pass_udp_ipv4();
-    enable_ipv6();
     pass_tcp_ipv6();
     pass_udp_ipv6();
-    pass_non_tuple();
 }
 
-void set_diverter(char *tun_name)
+void set_diverter(uint32_t dns_prefix, unsigned char dns_prefix_range, char *tun_name)
 {
     ZITI_LOG(INFO,"starting ziti-edge-tunnel in diverter mode");
-    init_diverter();
-    set_tun_mode();
     if(!firewall){
         disable_firewall();
     }else{
@@ -2830,7 +2854,7 @@ void set_diverter(char *tun_name)
         }else{
             ZITI_LOG(DEBUG, "Diverter user defined FW rules not found");
         }
-        pass_dns_range();
+        pass_dns_range(dns_prefix, dns_prefix_range);
     }
     setup_xdp(tun_name);
 }
@@ -2892,12 +2916,6 @@ static void run(int argc, char *argv[]) {
 
         tun_ip = htonl(mask);
         dns_ip = htonl(mask + 1);
-#if __linux__
-        if(firewall){
-            dns_prefix = ntohl(htonl(tun_ip)-1);
-            dns_prefix_range = (unsigned char)bits;
-        }
-#endif
 
         // set ip info into instance
         set_ip_info(dns_ip, tun_ip, bits);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1710,11 +1710,11 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
 #if __linux__
     if(!diverter && !firewall){
         diverterIf = getenv("ZITI_DIVERTER");
-        if(diverterIf){
+        if(diverterIf && strlen(diverterIf)){
             diverter = true;
         }
         char *zifi_firewall = getenv("ZITI_FIREWALL");
-        if(zifi_firewall){
+        if(zifi_firewall && strlen(zifi_firewall)){
             diverter = true;
             firewall = true;
             diverterIf = getenv("ZITI_FIREWALL");

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -4022,7 +4022,7 @@ static CommandLine enroll_cmd = make_command("enroll", "enroll Ziti identity",
         "\t-n|--name\tidentity name\n",
         parse_enroll_opts, enroll);
 static CommandLine run_cmd = make_command("run", "run Ziti tunnel (required superuser access)",
-                                          "-i <id.file> [-r N] [-v N] [-d|--dns-ip-range N.N.N.N/n] [-D|--diverter <interface>] [-f|--diverterFw <interface>]",
+                                          "-i <id.file> [-r N] [-v N] [-d|--dns-ip-range N.N.N.N/n] [-D|--diverter <interface list>] [-f|--diverterFw <interface list>]",
                                           "\t-i|--identity <identity>\trun with provided identity file (required)\n"
                                           "\t-I|--identity-dir <dir>\tload identities from provided directory\n"
                                           "\t-x|--proxy type://[username[:password]@]hostname_or_ip:port\tproxy to use when"

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1359,6 +1359,9 @@ static void on_event(const base_event *ev) {
                                     char *ip = svc->Addresses[x]->IP;
                                     char prefix_len[4];
                                     sprintf(prefix_len, "%d", svc->Addresses[x]->Prefix);
+                                    if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
+                                        unbind_route(svc->Addresses[x]->IP, svc->Addresses[x]->Prefix, ztun->handle->name);
+                                    }
                                     for(int i =  0; (svc->Ports != NULL) && (svc->Ports[i] != NULL); i++){
                                         char low_port[6];
                                         char high_port[6];
@@ -1367,7 +1370,6 @@ static void on_event(const base_event *ev) {
                                         for(int j =  0; (svc->Protocols != NULL) && (svc->Protocols[j] != NULL); j++){
                                             if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
                                                 diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-I");
-                                                unbind_route(svc->Addresses[x]->IP, svc->Addresses[x]->Prefix, ztun->handle->name);
                                             }else if(firewall){
                                                 diverter_update(ip, prefix_len,  low_port, high_port, svc->Protocols[j], svc->Id, "-I");
                                             }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2129,15 +2129,15 @@ void diverter_update(char *ip, char *mask, char *lowport, char *highport, char *
     char *const parmList[17] = {diverter_path, action, "-c", ip, "-m", mask, "-l",
      lowport, "-h", highport, "-t", tproxy_port, "-p", protocol, "-s", service_id, NULL};
     if ((pid = fork()) == -1){
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }else if (pid == 0) {
        execv(diverter_path, parmList);
-       printf("execv error: unknown error binding\n");
+       ZITI_LOG(DEBUG, "execv error: unknown error binding");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) > 0)){
             if(WIFEXITED(status) && !WEXITSTATUS(status)){
-                printf("diverter %s action for : %s set\n", action,  ip);
+                ZITI_LOG(DEBUG,"waitpid error: diverter %s action for : %s set", action,  ip);
             }
         }
     }
@@ -2165,17 +2165,17 @@ void bind_route(char* ip, int prefix_len, char *dev)
     char *const parmList[] = {"/usr/sbin/ip", "route", "add", cidr_block, "dev", dev, "scope", "link", NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv("/usr/sbin/ip", parmList);
-        printf("execv error: unknown error rebinding route");
+        ZITI_LOG(DEBUG, "execv error: unknown error rebinding route\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) > 0)){
             if(WIFEXITED(status) && !WEXITSTATUS(status)){
-                printf("bound %s to dev %s\n", cidr_block, dev);
+                ZITI_LOG(DEBUG,"waitpid error: binding %s to dev %s", cidr_block, dev);
             }
         }
     }
@@ -2203,17 +2203,17 @@ void unbind_route(char* ip, int prefix_len, char *dev)
     char *const parmList[] = {"/usr/sbin/ip", "route", "delete", cidr_block, "dev", dev, "scope", "link", NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn unbind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn unbind");
     }
     else if (pid == 0)
     {
         execv("/usr/sbin/ip", parmList);
-        printf("execv error: unknown error unbinding route");
+        ZITI_LOG(DEBUG, "execv error: unknown error unbinding route");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) > 0)){
             if(WIFEXITED(status) && !WEXITSTATUS(status)){
-                printf("unbound %s from dev %s\n", cidr_block, dev);
+                ZITI_LOG(DEBUG,"waitpid error: unbinding %s from dev %s", cidr_block, dev);
             }
         }
     }
@@ -2237,17 +2237,17 @@ void diverter_quit(){
     char *const parmList[] = {diverter_path, "-Q", NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error removing diverter");
+        ZITI_LOG(DEBUG, "execv error: unknown error removing diverter");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("Unable to remove diverter from: %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: Unable to remove diverter from: %s", diverterIf);
             }
         }
     }
@@ -2272,18 +2272,18 @@ void init_diverter(){
     char *const parmList[] = {diverter_path, "-V", diverterIf, NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error adding diverter ingress filters");
+        ZITI_LOG(DEBUG, "execv error: unknown error adding diverter ingress filters");
     }else{
         int status =0;
 
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("zfw not set on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: zfw not set on dev %s", diverterIf);
             }
         }
     }
@@ -2315,12 +2315,12 @@ void bind_diverter_route(char *ip, int prefix_len){
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG,"error binding %s/%s to lo\n", ip, mask);
+        ZITI_LOG(DEBUG,"error binding %s/%s to lo", ip, mask);
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"error binding %s/%s to lo\n", ip, mask);
+                ZITI_LOG(DEBUG,"waitpid error: error binding %s/%s to lo", ip, mask);
             }
         }
     }
@@ -2352,12 +2352,12 @@ void unbind_diverter_route(char *ip, int prefix_len){
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        ZITI_LOG(DEBUG,"error unbinding %s/%s from lo\n", ip, mask);
+        ZITI_LOG(DEBUG,"error unbinding %s/%s from lo", ip, mask);
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"error unbinding %s/%s from lo\n", ip, mask);
+                ZITI_LOG(DEBUG,"waitpid error: error unbinding %s/%s from lo", ip, mask);
             }
         }
     }
@@ -2392,7 +2392,7 @@ void diverter_binding_flush(){
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"error flushing diverter routes");
+                ZITI_LOG(DEBUG,"waitpid error: error flushing diverter routes");
             }
         }
     }
@@ -2427,7 +2427,7 @@ void diverter_ingress_flush(){
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                ZITI_LOG(DEBUG,"error flushing diverter ingress intercepts");
+                ZITI_LOG(DEBUG,"waitpid error: error flushing diverter ingress intercepts");
             }
         }
     }
@@ -2451,17 +2451,17 @@ void pass_non_tuple(){
     char *const parmList[] = {diverter_path, "-q", diverterIf, NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error removing non-tuple filters");
+        ZITI_LOG(DEBUG, "execv error: unknown error removing non-tuple filters\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter non-tuple firewall not disabled on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter non-tuple firewall not disabled on dev %s\n", diverterIf);
             }
         }
     }
@@ -2485,17 +2485,17 @@ void enable_ipv6(){
     char *const parmList[] = {diverter_path, "-6", diverterIf, NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error enabling ipv6 filters");
+        ZITI_LOG(DEBUG, "execv error: unknown error enabling ipv6 filters");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter IPv6 not enabled on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter IPv6 not enabled on dev %s", diverterIf);
             }
         }
     }
@@ -2519,17 +2519,17 @@ void pass_tcp_ipv4(){
     char *const parmList[] = {diverter_path, "-I", "-c", "0.0.0.0", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "tcp", NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error binding ipv4 tcp filters");
+        ZITI_LOG(DEBUG, "execv error: unknown error binding ipv4 tcp filters\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter IPv4 TCP firewall not disabled on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter IPv4 TCP firewall not disabled on dev %s", diverterIf);
             }
         }
     }
@@ -2553,17 +2553,17 @@ void pass_udp_ipv4(){
     char *const parmList[] = {diverter_path, "-I", "-c", "0.0.0.0", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "udp", NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error binding ipv4 udp filters");
+        ZITI_LOG(DEBUG, "execv error: unknown error binding ipv4 udp filters");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter IPv4 UDP firewall not disabled on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter IPv4 UDP firewall not disabled on dev %s\n", diverterIf);
             }
         }
     }
@@ -2587,17 +2587,17 @@ void pass_tcp_ipv6(){
     char *const parmList[] = {diverter_path, "-I", "-c", "::", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "tcp", NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error binding ipv6 tcp filters");
+        ZITI_LOG(DEBUG, "execv error: unknown error binding ipv6 tcp filters\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter IPv6 TCP firewall not disabled on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter IPv6 TCP firewall not disabled on dev %s\n", diverterIf);
             }
         }
     }
@@ -2622,17 +2622,17 @@ void set_tun_mode(){
     char *const parmList[] = {diverter_path, "-T", diverterIf, NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error setting tunnel mode");
+        ZITI_LOG(DEBUG, "execv error: unknown error setting tunnel mode\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter tunnel mode intercept not set on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter tunnel mode intercept not set on dev %s\n", diverterIf);
             }
         }
     }
@@ -2657,17 +2657,17 @@ void setup_xdp(char *tun_name){
     char *const parmList[] = {diverter_path, "-Z", tun_name, NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error binding xdp to %s", tun_name);
+        ZITI_LOG(DEBUG, "execv error: unknown error binding xdp to %s", tun_name);
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter xdp not set on dev %s\n", tun_name);
+                ZITI_LOG(DEBUG,"waitpid error: diverter xdp not set on dev %s\n", tun_name);
             }
         }
     }
@@ -2691,17 +2691,51 @@ void pass_udp_ipv6(){
     char *const parmList[] = {diverter_path, "-I", "-c", "::", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "udp", NULL};
     if ((pid = fork()) == -1)
     {
-        perror("fork error: can't spawn bind");
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
         execv(diverter_path, parmList);
-        printf("execv error: unknown error binding ipv6 udp filters");
+        ZITI_LOG(DEBUG, "execv error: unknown error binding ipv6 udp filters\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter IPv6 UDP firewall not disabled on dev %s\n", diverterIf);
+                ZITI_LOG(DEBUG,"waitpid error: diverter IPv6 UDP firewall not disabled on dev %s", diverterIf);
+            }
+        }
+    }
+    dup2(o_std_out, STDOUT_FILENO);
+    dup2(o_std_err, STDERR_FILENO);
+    close(o_std_out);
+    close(o_std_err); 
+}
+
+void add_user_rules(){
+    pid_t pid;
+    int o_std_out = dup(STDOUT_FILENO);
+    int o_std_err = dup(STDERR_FILENO);
+    int fd = open("/dev/null", O_WRONLY);
+    if (fd == -1){
+        return; 
+    }
+    dup2(fd, STDOUT_FILENO);
+    dup2(fd, STDERR_FILENO);
+    close(fd);
+    char *const parmList[] = {diverter_path, "-A",NULL};
+    if ((pid = fork()) == -1)
+    {
+        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
+    }
+    else if (pid == 0)
+    {
+        execv("/opt/openziti/bin/user/user_rules.sh", parmList);
+        ZITI_LOG(DEBUG, "execv error: unknown error adding user defined rules\n");
+    }else{
+        int status =0;
+        if(!(waitpid(pid, &status, 0) < 0)){
+            if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
+                ZITI_LOG(DEBUG,"waitpid error: error adding user defined rules\n");
             }
         }
     }
@@ -2727,6 +2761,13 @@ void set_diverter(char *tun_name)
     set_tun_mode();
     if(!firewall){
         disable_firewall();
+    }else{
+        if (access("/opt/openziti/bin/user/user_rules.sh", F_OK) == 0){
+            ZITI_LOG(INFO,"loading user defined FW rules");
+            add_user_rules();
+        }else{
+            ZITI_LOG(DEBUG, "Diverter user defined FW rules not found");
+        }
     }
     setup_xdp(tun_name);
 }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2269,7 +2269,7 @@ void init_diverter(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {diverter_path, "-V", diverterIf, NULL};
+    char *const parmList[] = {diverter_path, "-H", diverterIf, NULL};
     if ((pid = fork()) == -1)
     {
         ZITI_LOG(DEBUG,"fork error: can't spawn bind");

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1720,11 +1720,18 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
             diverterIf = getenv("ZITI_FIREWALL");
         }
     }
+    char zfw_path[PATH_MAX];
+    char *dpath = getenv("ZFW_OBJECT_PATH");
+    if(dpath && strlen(dpath)){
+        sprintf(zfw_path, "%s/%s", dpath, "zfw");
+        diverter_path = zfw_path;
+    } 
     if(diverter && tun){
         ztun = tun;
         if(!firewall){
             diverter_quit();
         }
+        if(getenv)
         if (access(diverter_path, F_OK) == 0){
             int count = 0;
             char *interface = strtok(diverterIf,",");
@@ -2354,8 +2361,8 @@ void init_diverter_interface(char * interface){
     close(o_std_out);
     close(o_std_err); 
     set_tun_mode(interface);
+    enable_ipv6(interface);
     if(!firewall){
-        enable_ipv6(interface);
         pass_non_tuple(interface);
     }
     if(state){

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1347,7 +1347,10 @@ static void on_event(const base_event *ev) {
 #if __linux__
                     if(svc && diverter){
                         if(svc->Permissions.Dial){
-                            ztun->commit_routes(ztun->handle, global_loop_ref);
+                            if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
+                                ztun->commit_routes(ztun->handle, global_loop_ref);
+                                sleep(1);
+                            }
                             for(int x = 0; svc->Addresses && (svc->Addresses[x] != NULL); x++){
                                 if(!svc->Addresses[x]->IsHost){
                                     char *ip = svc->Addresses[x]->IP;

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -81,8 +81,6 @@ static void scm_service_stop_event(uv_loop_t *loop, void *arg);
 static void stop_tunnel_and_cleanup();
 static bool is_host_only();
 static void run_tunneler_loop(uv_loop_t* ziti_loop);
-static void unbind_route(char* ip, int prefix, char *dev);
-void bind_route(char* ip, int prefix_len, char *dev);
 void bind_diverter_route(char *ip, int prefix_len);
 void unbind_diverter_route(char *ip, int prefix_len);
 void enable_ipv6(char *interface);
@@ -1300,7 +1298,9 @@ static void on_event(const base_event *ev) {
                                     char *ip = svc->Addresses[x]->IP;
                                     char prefix_len[4];
                                     if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
-                                        bind_route(svc->Addresses[x]->IP, svc->Addresses[x]->Prefix, ztun->handle->name);
+                                        char cidr[44];
+                                        sprintf(cidr, "%s/%d", ip, svc->Addresses[x]->Prefix);
+                                        ztun->add_route(ztun->handle, cidr);
                                     }
                                     sprintf(prefix_len, "%d", svc->Addresses[x]->Prefix);
                                     for(int i =  0; (svc->Ports != NULL) && (svc->Ports[i] != NULL); i++){
@@ -1361,7 +1361,9 @@ static void on_event(const base_event *ev) {
                                     char prefix_len[4];
                                     sprintf(prefix_len, "%d", svc->Addresses[x]->Prefix);
                                     if(svc->AllowedSourceAddresses && svc->AllowedSourceAddresses[0] != NULL){
-                                        unbind_route(svc->Addresses[x]->IP, svc->Addresses[x]->Prefix, ztun->handle->name);
+                                        char cidr[44];
+                                        sprintf(cidr, "%s/%d", ip, svc->Addresses[x]->Prefix);
+                                        ztun->delete_route(ztun->handle, cidr);
                                     }
                                     for(int i =  0; (svc->Ports != NULL) && (svc->Ports[i] != NULL); i++){
                                         char low_port[6];
@@ -2200,91 +2202,6 @@ void diverter_update(char *ip, char *mask, char *lowport, char *highport, char *
         ZITI_LOG(INFO,"%s -c %s -m %s -l %s -h %s -t %s -p %s -s %s", action,ip, mask, lowport, highport, tproxy_port, protocol,service_id);
     }else{
         ZITI_LOG(DEBUG,"Failed insert: %s -c %s -m %s -l %s -h %s -t %s -p %s -s %s", action,ip, mask, lowport, highport, tproxy_port, protocol,service_id);
-    }
-}
-
-void bind_route(char* ip, int prefix_len, char *dev)
-{
-    bool state = true;
-    char *cidr_block[19];
-    sprintf(cidr_block, "%s/%d", ip, prefix_len);
-    pid_t pid;
-    int o_std_out = dup(STDOUT_FILENO);
-    int o_std_err = dup(STDERR_FILENO);
-    int fd = open("/dev/null", O_WRONLY);
-    if (fd == -1){
-        return; 
-    }
-    dup2(fd, STDOUT_FILENO);
-    dup2(fd, STDERR_FILENO);
-    close(fd);
-    char *const parmList[] = {"/usr/sbin/ip", "route", "add", cidr_block, "dev", dev, "scope", "link", NULL};
-    if ((pid = fork()) == -1)
-    {
-        ZITI_LOG(DEBUG,"fork error: can't spawn bind");
-    }
-    else if (pid == 0)
-    {
-        execv("/usr/sbin/ip", parmList);
-        state = false;
-    }else{
-        int status =0;
-        if(!(waitpid(pid, &status, 0) > 0)){
-            if(WIFEXITED(status) && !WEXITSTATUS(status)){
-                state = false;
-            }
-        }
-    }
-    dup2(o_std_out, STDOUT_FILENO);
-    dup2(o_std_err, STDERR_FILENO);
-    close(o_std_out);
-    close(o_std_err); 
-    if(state){
-        ZITI_LOG(DEBUG,"Diverter restoring route to %s via dev %s", cidr_block, dev);
-    }else{
-        ZITI_LOG(DEBUG,"Diverter failed restoring route to %s via dev %s", cidr_block, dev);
-    }
-}
-
-void unbind_route(char* ip, int prefix_len, char *dev)
-{
-    bool state = true;
-    char *cidr_block[19];
-    sprintf(cidr_block, "%s/%d", ip, prefix_len);
-    pid_t pid;
-    int o_std_out = dup(STDOUT_FILENO);
-    int o_std_err = dup(STDERR_FILENO);
-    int fd = open("/dev/null", O_WRONLY);
-    if (fd == -1){
-        return; 
-    }
-    dup2(fd, STDOUT_FILENO);
-    dup2(fd, STDERR_FILENO);
-    close(fd);
-    char *const parmList[] = {"/usr/sbin/ip", "route", "delete", cidr_block, "dev", dev, "scope", "link", NULL};
-    if ((pid = fork()) == -1)
-    {
-        state = false;
-    }
-    else if (pid == 0)
-    {
-        execv("/usr/sbin/ip", parmList);
-    }else{
-        int status =0;
-        if(!(waitpid(pid, &status, 0) > 0)){
-            if(WIFEXITED(status) && !WEXITSTATUS(status)){
-                state = false;
-            }
-        }
-    }
-    dup2(o_std_out, STDOUT_FILENO);
-    dup2(o_std_err, STDERR_FILENO);
-    close(o_std_out);
-    close(o_std_err); 
-    if(state){
-        ZITI_LOG(INFO,"Diverter unbinding route to %s via dev %s for transparency support", cidr_block, dev);
-    }else{
-        ZITI_LOG(INFO,"Diverter failed unbinding route to %s via dev %s for transparency support", cidr_block, dev);
     }
 }
 

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -86,6 +86,7 @@ void bind_route(char* ip, int prefix_len, char *dev);
 void bind_diverter_route(char *ip, int prefix_len);
 void unbind_diverter_route(char *ip, int prefix_len);
 void diverter_binding_flush();
+char *diverter_path = "/opt/openziti/bin/zfw";
 static tunneler_context initialize_tunneler(netif_driver tun, uv_loop_t* ziti_loop);
 static void diverter_update(char *ip, char *mask, char *lowport, char *highport, char *protocol, char *service_id, char *action);
 static netif_driver ztun;
@@ -1696,7 +1697,12 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
     #if __linux__
         if(diverter && tun){
             ztun = tun;
-            set_diverter(tun->handle->name);
+            if (access(diverter_path, F_OK) == 0){
+                set_diverter(tun->handle->name);
+            }else{
+                ZITI_LOG(INFO, "Diverter binary not found");
+                exit(1);
+            }
         }
     #endif
     run_tunneler_loop(ziti_loop);
@@ -2104,9 +2110,9 @@ void diverter_update(char *ip, char *mask, char *lowport, char *highport, char *
     random_port = htons(1024 + rand() % (65535 - 1023));
     char tproxy_port[6];
     sprintf(tproxy_port, "%u", random_port);
-    if (access("/usr/sbin/zfw", F_OK) != 0)
+    if (access(diverter_path, F_OK) != 0)
     {
-        ZITI_LOG(INFO,"diverter not installed: Cannot find /usr/sbin/zfw");
+        ZITI_LOG(INFO,"diverter not installed: Cannot find /opt/openziti/bin/zfw");
         return;
     }
     pid_t pid;
@@ -2120,12 +2126,12 @@ void diverter_update(char *ip, char *mask, char *lowport, char *highport, char *
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[17] = {"/usr/sbin/zfw", action, "-c", ip, "-m", mask, "-l",
+    char *const parmList[17] = {diverter_path, action, "-c", ip, "-m", mask, "-l",
      lowport, "-h", highport, "-t", tproxy_port, "-p", protocol, "-s", service_id, NULL};
     if ((pid = fork()) == -1){
         perror("fork error: can't spawn bind");
     }else if (pid == 0) {
-       execv("/usr/sbin/zfw", parmList);
+       execv(diverter_path, parmList);
        printf("execv error: unknown error binding\n");
     }else{
         int status =0;
@@ -2228,14 +2234,14 @@ void diverter_quit(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-Q", NULL};
+    char *const parmList[] = {diverter_path, "-Q", NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error removing diverter");
     }else{
         int status =0;
@@ -2251,8 +2257,8 @@ void diverter_quit(){
     close(o_std_err); 
 }
 
-void set_diverter_in(){
-    ZITI_LOG(INFO,"diverter tc inbound enabled on %s", diverterIf);
+void init_diverter(){
+    ZITI_LOG(INFO,"diverter tc enabled on %s", diverterIf);
     pid_t pid;
     int o_std_out = dup(STDOUT_FILENO);
     int o_std_err = dup(STDERR_FILENO);
@@ -2263,21 +2269,21 @@ void set_diverter_in(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-X", diverterIf, "-O",  "/opt/openziti/bin/zfw_tc_ingress.o", "-z", "ingress", NULL};
+    char *const parmList[] = {diverter_path, "-V", diverterIf, NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error adding diverter ingress filters");
     }else{
         int status =0;
 
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("zfw not set inbound on dev %s\n", diverterIf);
+                printf("zfw not set on dev %s\n", diverterIf);
             }
         }
     }
@@ -2301,14 +2307,14 @@ void bind_diverter_route(char *ip, int prefix_len){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-B", ip, "-m", mask, NULL};
+    char *const parmList[] = {diverter_path, "-B", ip, "-m", mask, NULL};
     if ((pid = fork()) == -1)
     {
         ZITI_LOG(DEBUG, "fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         ZITI_LOG(DEBUG,"error binding %s/%s to lo\n", ip, mask);
     }else{
         int status =0;
@@ -2338,14 +2344,14 @@ void unbind_diverter_route(char *ip, int prefix_len){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-J", ip, "-m", mask, NULL};
+    char *const parmList[] = {diverter_path, "-J", ip, "-m", mask, NULL};
     if ((pid = fork()) == -1)
     {
         ZITI_LOG(DEBUG, "fork error: can't spawn unbind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         ZITI_LOG(DEBUG,"error unbinding %s/%s from lo\n", ip, mask);
     }else{
         int status =0;
@@ -2373,14 +2379,14 @@ void diverter_binding_flush(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-F", "-j", NULL};
+    char *const parmList[] = {diverter_path, "-F", "-j", NULL};
     if ((pid = fork()) == -1)
     {
         ZITI_LOG(DEBUG, "fork error: can't spawn unbind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         ZITI_LOG(DEBUG,"error flushing diverter routes from lo\n");
     }else{
         int status =0;
@@ -2408,55 +2414,20 @@ void diverter_ingress_flush(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-F", "-z", "ingress", NULL};
+    char *const parmList[] = {diverter_path, "-F", "-z", "ingress", NULL};
     if ((pid = fork()) == -1)
     {
         ZITI_LOG(DEBUG, "fork error: can't spawn unbind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         ZITI_LOG(DEBUG,"error flushing diverter ingress intercepts\n");
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
                 ZITI_LOG(DEBUG,"error flushing diverter ingress intercepts");
-            }
-        }
-    }
-    dup2(o_std_out, STDOUT_FILENO);
-    dup2(o_std_err, STDERR_FILENO);
-    close(o_std_out);
-    close(o_std_err); 
-}
-
-void set_diverter_out(){
-    ZITI_LOG(INFO,"diverter tc outbound enabled on %s", diverterIf);
-    pid_t pid;
-    int o_std_out = dup(STDOUT_FILENO);
-    int o_std_err = dup(STDERR_FILENO);
-    int fd = open("/dev/null", O_WRONLY);
-    if (fd == -1){
-        return; 
-    }
-    dup2(fd, STDOUT_FILENO);
-    dup2(fd, STDERR_FILENO);
-    close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-X", diverterIf, "-O",  "/opt/openziti/bin/zfw_tc_outbound_track.o", "-z", "egress", NULL};
-    if ((pid = fork()) == -1)
-    {
-        perror("fork error: can't spawn bind");
-    }
-    else if (pid == 0)
-    {
-        execv("/usr/sbin/zfw", parmList);
-        printf("execv error: unknown error adding diverter egress filters");
-    }else{
-        int status =0;
-        if(!(waitpid(pid, &status, 0) < 0)){
-            if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter not set outbound on dev %s\n", diverterIf);
             }
         }
     }
@@ -2477,14 +2448,14 @@ void pass_non_tuple(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-q", diverterIf, NULL};
+    char *const parmList[] = {diverter_path, "-q", diverterIf, NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error removing non-tuple filters");
     }else{
         int status =0;
@@ -2511,14 +2482,14 @@ void enable_ipv6(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-6", diverterIf, NULL};
+    char *const parmList[] = {diverter_path, "-6", diverterIf, NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error enabling ipv6 filters");
     }else{
         int status =0;
@@ -2545,14 +2516,14 @@ void pass_tcp_ipv4(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-I", "-c", "0.0.0.0", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "tcp", NULL};
+    char *const parmList[] = {diverter_path, "-I", "-c", "0.0.0.0", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "tcp", NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error binding ipv4 tcp filters");
     }else{
         int status =0;
@@ -2579,14 +2550,14 @@ void pass_udp_ipv4(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-I", "-c", "0.0.0.0", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "udp", NULL};
+    char *const parmList[] = {diverter_path, "-I", "-c", "0.0.0.0", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "udp", NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error binding ipv4 udp filters");
     }else{
         int status =0;
@@ -2613,14 +2584,14 @@ void pass_tcp_ipv6(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-I", "-c", "::", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "tcp", NULL};
+    char *const parmList[] = {diverter_path, "-I", "-c", "::", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "tcp", NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error binding ipv6 tcp filters");
     }else{
         int status =0;
@@ -2648,14 +2619,14 @@ void set_tun_mode(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-T", diverterIf, NULL};
+    char *const parmList[] = {diverter_path, "-T", diverterIf, NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error setting tunnel mode");
     }else{
         int status =0;
@@ -2683,20 +2654,20 @@ void setup_xdp(char *tun_name){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/ip", "link", "set", tun_name, "xdpgeneric", "obj", "/opt/openziti/bin/zfw_xdp_tun_ingress.o", "sec", "xdp_redirect", NULL};
+    char *const parmList[] = {diverter_path, "-Z", tun_name, NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/ip", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error binding xdp to %s", tun_name);
     }else{
         int status =0;
         if(!(waitpid(pid, &status, 0) < 0)){
             if(!(WIFEXITED(status) && !WEXITSTATUS(status))){
-                printf("diverter xdp tunnel redirect not set on dev %s\n", tun_name);
+                printf("diverter xdp not set on dev %s\n", tun_name);
             }
         }
     }
@@ -2717,14 +2688,14 @@ void pass_udp_ipv6(){
     dup2(fd, STDOUT_FILENO);
     dup2(fd, STDERR_FILENO);
     close(fd);
-    char *const parmList[] = {"/usr/sbin/zfw", "-I", "-c", "::", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "udp", NULL};
+    char *const parmList[] = {diverter_path, "-I", "-c", "::", "-m", "0", "-l", "1" , "-h", "65535", "-t", "0", "-p", "udp", NULL};
     if ((pid = fork()) == -1)
     {
         perror("fork error: can't spawn bind");
     }
     else if (pid == 0)
     {
-        execv("/usr/sbin/zfw", parmList);
+        execv(diverter_path, parmList);
         printf("execv error: unknown error binding ipv6 udp filters");
     }else{
         int status =0;
@@ -2752,8 +2723,7 @@ void disable_firewall(){
 void set_diverter(char *tun_name)
 {
     ZITI_LOG(INFO,"starting ziti-edge-tunnel in diverter mode");
-    set_diverter_in();
-    set_diverter_out();
+    init_diverter();
     set_tun_mode();
     if(!firewall){
         disable_firewall();


### PR DESCRIPTION
This pull request adds system calls to zfw for the purpose allowing bi-directional transparency.   I allows user to specify diverter function either via command line argument or environmental variable with command line taking precedence.  ```-D, diverter <comma separated interface list> or ZITI_DIVERTER =<comma separated interface list>.   I also added a more restrictive option which in addition to transparency support also provides full firewall filtering -f, --diverter-fw <interface list> | DIVERTER_FIREWALL=<interface list>.  It assumes zfw binaries/ebpf objects are in /opt/openziti/bin by default but can be modified via environmental variable ZFW_OBJECT_PATH=<path>.  