### PR TITLE
CI caching improvements

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -42,9 +42,7 @@ runs:
     - uses: actions/cache@v4
       with:
         key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json') }}
-        path: |
-          ./vcpkg/packages
-          ./build/vcpkg_installed
+        path: ./vcpkg_cache
 
     - uses: lukka/run-cmake@v10.6 # pin version to avoid failed glibc dependency on ubuntu 20 runners. go back to @latest when ubuntu 22+ is adopted for runner os.
       if: runner.os != 'Linux'
@@ -71,6 +69,9 @@ runs:
     - name: build ziti-edge-tunnel (linux)
       if: runner.os == 'Linux'
       uses: ./.github/actions/openziti-tunnel-build-action
+      env:
+        # map vcpkg cache so container uses the same directory as the rest of the workflow
+        "VCPKG_BINARY_SOURCES": "clear;files,/github/workspace/vcpkg_cache,readwrite"
       with:
         arch: ci-${{ inputs.preset }}
         config: ${{ inputs.config }}

--- a/.github/actions/openziti-tunnel-build-action/gh-release/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/gh-release/entrypoint.sh
@@ -48,25 +48,12 @@ for SAFE in \
         git config --global --add safe.directory ${SAFE}
 done
 
-export VCPKG_ROOT="${PWD}/vcpkg"
-# ${VCPKG_ROOT}/packages  will have been populated from outside of the container, by a different user. tell git it's ok.
-git config --global --add safe.directory "${VCPKG_ROOT}"
-
-if [ ! -d "${VCPKG_ROOT}/ports" ]; then
-    # the packages/ directory may have been populated from cache by now
-    # but git clone refuses to clone into a non-empty directory, so get
-    # vcpkg without using clone
-    git init "${VCPKG_ROOT}"
-    (cd "${VCPKG_ROOT}"; git remote add -f origin https://github.com/microsoft/vcpkg; git checkout master)
-    "${VCPKG_ROOT}/bootstrap-vcpkg.sh" -disableMetrics
-fi
-
-echo "======== here comes the env"
-env
-echo "======== that is all"
-echo "======== here comes the df"
-df
-echo "======== that is it"
+(
+  cd "${VCPKG_ROOT}"
+  git checkout master
+  git pull
+  ./bootstrap-vcpkg.sh -disableMetrics
+)
 
 cmake -E make_directory ./build
 cmake \

--- a/.github/actions/openziti-tunnel-build-action/gh-release/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/gh-release/entrypoint.sh
@@ -61,6 +61,13 @@ if [ ! -d "${VCPKG_ROOT}/ports" ]; then
     "${VCPKG_ROOT}/bootstrap-vcpkg.sh" -disableMetrics
 fi
 
+echo "======== here comes the env"
+env
+echo "======== that is all"
+echo "======== here comes the df"
+df
+echo "======== that is it"
+
 cmake -E make_directory ./build
 cmake \
   --preset "${cmake_preset}" \

--- a/.github/actions/openziti-tunnel-build-action/redhat-8/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/redhat-8/entrypoint.sh
@@ -36,6 +36,13 @@ for SAFE in \
         git config --global --add safe.directory ${SAFE}
 done
 
+(
+  cd "${VCPKG_ROOT}"
+  git checkout master
+  git pull
+  ./bootstrap-vcpkg.sh -disableMetrics
+)
+
 cmake -E make_directory ./build
 (
     [[ -d ./build ]] && rm -r ./build

--- a/.github/actions/openziti-tunnel-build-action/redhat-9/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/redhat-9/entrypoint.sh
@@ -37,6 +37,13 @@ for SAFE in \
 done
 
 (
+  cd "${VCPKG_ROOT}"
+  git checkout master
+  git pull
+  ./bootstrap-vcpkg.sh -disableMetrics
+)
+
+(
     [[ -d ./build ]] && rm -r ./build
     cmake -E make_directory ./build  
     # allow unset for scl_source scripts

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/entrypoint.sh
@@ -36,6 +36,13 @@ for SAFE in \
         git config --global --add safe.directory ${SAFE}
 done
 
+(
+  cd "${VCPKG_ROOT}"
+  git checkout master
+  git pull
+  ./bootstrap-vcpkg.sh -disableMetrics
+)
+
 [[ -d ./build ]] && rm -r ./build
 cmake \
     -E make_directory \

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/entrypoint.sh
@@ -36,6 +36,13 @@ for SAFE in \
         git config --global --add safe.directory ${SAFE}
 done
 
+(
+  cd "${VCPKG_ROOT}"
+  git checkout master
+  git pull
+  ./bootstrap-vcpkg.sh -disableMetrics
+)
+
 [[ -d ./build ]] && rm -r ./build
 cmake \
     -E make_directory \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,7 +20,8 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     name: build ${{ matrix.preset }}
-    env: {}
+    env:
+      "_VCPKG_BINARY_SOURCES": "clear;file,${{ github.workspace }}/vcpkg_cache,readwrite"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: build ${{ matrix.preset }}
     env:
-      "_VCPKG_BINARY_SOURCES": "clear;file,${{ github.workspace }}/vcpkg_cache,readwrite"
+      "VCPKG_BINARY_SOURCES": "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -47,6 +47,8 @@ jobs:
     needs: set_matrix
     name: ${{ matrix.arch.rpm }} ${{ matrix.distro.name }} ${{ matrix.distro.version }}
     runs-on: ubuntu-20.04
+    # build image name it from matrix values name:version unless override container is specified
+    container: ${{ matrix.distro.container || format('{0}:{1}', matrix.distro.name, matrix.distro.version) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -93,14 +93,9 @@ jobs:
         run: |
           mv -v ./.github/actions/openziti-tunnel-build-action/${DISTRO_LABEL}/* ./.github/actions/openziti-tunnel-build-action/
 
-      - name: get cache key
-        id: get_cache_key_preset
-        shell: bash
-        run: echo "preset=$(echo ${{ matrix.arch.cmake }} | sed -e 's/^ci-//')" >> $GITHUB_OUTPUT
-
       - uses: actions/cache@v4
         with:
-          key: deps-${{ steps.get_cache_key_preset.outputs.preset }}-${{ hashFiles('./vcpkg.json') }}
+          key: deps-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}-${{ hashFiles('./vcpkg.json') }}
           path: ./vcpkg_cache
 
         # entrypoint.sh uses the value of arch to select the cmake preset

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -47,14 +47,13 @@ jobs:
     needs: set_matrix
     name: ${{ matrix.arch.rpm }} ${{ matrix.distro.name }} ${{ matrix.distro.version }}
     runs-on: ubuntu-20.04
-    # build image name it from matrix values name:version unless override container is specified 
-    container: ${{ matrix.distro.container || format('{0}:{1}', matrix.distro.name, matrix.distro.version) }} 
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
     env:
       ZITI_DEB_TEST_REPO: ${{ vars.ZITI_DEB_TEST_REPO || 'zitipax-openziti-deb-test' }}
       ZITI_RPM_TEST_REPO: ${{ vars.ZITI_RPM_TEST_REPO || 'zitipax-openziti-rpm-test' }}
+      "VCPKG_BINARY_SOURCES": "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
     steps:
       - name: Debug action
         uses: hmarr/debug-action@v3
@@ -92,9 +91,17 @@ jobs:
         run: |
           mv -v ./.github/actions/openziti-tunnel-build-action/${DISTRO_LABEL}/* ./.github/actions/openziti-tunnel-build-action/
 
+      - uses: actions/cache@v4
+        with:
+          key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json') }}
+          path: ./vcpkg_cache
+
         # entrypoint.sh uses the value of arch to select the cmake preset
       - name: build binary and package
         uses: ./.github/actions/openziti-tunnel-build-action
+        env:
+          # map vcpkg cache so container uses the same directory as the rest of the workflow
+          "VCPKG_BINARY_SOURCES": "clear;files,/github/workspace/vcpkg_cache,readwrite"
         with:
           arch: ${{ matrix.arch.cmake }}
           config: RelWithDebInfo

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -93,9 +93,14 @@ jobs:
         run: |
           mv -v ./.github/actions/openziti-tunnel-build-action/${DISTRO_LABEL}/* ./.github/actions/openziti-tunnel-build-action/
 
+      - name: get cache key
+        id: get_cache_key_preset
+        shell: bash
+        run: echo "preset=$(echo ${{ matrix.arch.cmake }} | sed -e 's/^ci-//')" >> $GITHUB_OUTPUT
+
       - uses: actions/cache@v4
         with:
-          key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json') }}
+          key: deps-${{ steps.get_cache_key_preset.outputs.preset }}-${{ hashFiles('./vcpkg.json') }}
           path: ./vcpkg_cache
 
         # entrypoint.sh uses the value of arch to select the cmake preset


### PR DESCRIPTION
This PR updates the workflows to completely control vcpkg caching.

* disables the caching that was set up by `run-vcpkg`
* configures vcpkg's cache to be a directory within the GitHub workspace, so it can be accessed from build steps and containers.
* caches are used for cpack builds as well as gh releases. each intentionally has a different key.
