### PR TITLE
improve vcpkg cache hits

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,9 +24,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install autoconf autoconf-archive automake pkg-config
-        # get md5sum
-        echo /sbin >> $GITHUB_PATH
+        brew install autoconf autoconf-archive automake pkg-config md5sha1sum
 
     - name: simple build
       run: echo "preset = ${{ inputs.preset }}"

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,7 +26,7 @@ runs:
       run: brew install autoconf autoconf-archive automake pkg-config
 
     - name: simple build
-      run: echo "preset = ${{ inputs.preset }}"
+      run: echo "preset = ${{ inputs.preset }}"; env
       shell: bash
 
     - name: install contemporary cmake

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,7 +23,10 @@ runs:
     - name: macOS tools
       if: runner.os == 'macOS'
       shell: bash
-      run: brew install autoconf autoconf-archive automake pkg-config
+      run: |
+        brew install autoconf autoconf-archive automake pkg-config
+        # get md5sum
+        echo /sbin >> $GITHUB_PATH
 
     - name: simple build
       run: echo "preset = ${{ inputs.preset }}"
@@ -46,13 +49,13 @@ runs:
         DISTRO_LABEL: ${{ format('{0}-{1}', matrix.distro.name, matrix.distro.version) }}
         KEY_PREFIX: vcpkg_cache-cmake-${{ inputs.preset }}
       run: |
-        common_key="${KEY_PREFIX}-vcpkg_json_md5=$(md5sum --quiet ./vcpkg.json)"
+        common_key="${KEY_PREFIX}-vcpkg_json_md5=$(md5sum ./vcpkg.json | awk '{ print $1 }')"
         if [ "${RUNNER_OS}" != "Linux" ]; then
           echo "key=${common_key}-ImageVersion=${ImageVersion}" | tee -a $GITHUB_OUTPUT      
         else
           # ImageVersion is irrelevant since the build action runs in a container
           # Express the vcpkg overlays, dockerfile, and entry point that the action will use as a single hash
-          build_action_hash="$(find ./.github/actions/openziti-tunnel-build-action/gh-release -type f -print | xargs md5sum --quiet | sort | md5sum --quiet)"
+          build_action_hash="$(find ./.github/actions/openziti-tunnel-build-action/gh-release -type f -print | xargs md5sum | awk '{ print $1 }' | sort | md5sum | awk '{ print $1 }')"
           echo "key=${common_key}-build_action_md5=${build_action_hash}" | tee -a $GITHUB_OUTPUT
         fi
 

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -48,7 +48,7 @@ runs:
     - uses: actions/cache@v4
       if: runner.os == 'Linux'
       with:
-        key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json', '.github/actions/openziti-tunnel-build-action/gh-release/vcpkg-overlays/**/vcpkg.json') }}-ImageVersion=${{ env.ImageVersion }}
+        key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json', '.github/actions/openziti-tunnel-build-action/gh-release/vcpkg-overlays/**/vcpkg.json') }}-ImageVersion=${{ env.IMAGE_VERSION }}
         path: ./vcpkg_cache
 
     - uses: lukka/run-cmake@v10.6 # pin version to avoid failed glibc dependency on ubuntu 20 runners. go back to @latest when ubuntu 22+ is adopted for runner os.

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -42,13 +42,13 @@ runs:
     - uses: actions/cache@v4
       if: runner.os != 'Linux'
       with:
-        key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json') }}
+        key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json') }}-ImageVersion=$env:ImageVersion
         path: ./vcpkg_cache
 
     - uses: actions/cache@v4
       if: runner.os == 'Linux'
       with:
-        key: deps=${{ inputs.preset }}-${{ hashFiles('./vcpkg.json', '.github/actions/openziti-tunnel-build-action/gh-release/vcpkg-overlays/**/vcpkg.json') }}
+        key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json', '.github/actions/openziti-tunnel-build-action/gh-release/vcpkg-overlays/**/vcpkg.json') }}-ImageVersion=${{ env.ImageVersion }}
         path: ./vcpkg_cache
 
     - uses: lukka/run-cmake@v10.6 # pin version to avoid failed glibc dependency on ubuntu 20 runners. go back to @latest when ubuntu 22+ is adopted for runner os.

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,7 +26,7 @@ runs:
       run: brew install autoconf autoconf-archive automake pkg-config
 
     - name: simple build
-      run: echo "preset = ${{ inputs.preset }}"; env
+      run: echo "preset = ${{ inputs.preset }}"
       shell: bash
 
     - name: install contemporary cmake
@@ -39,16 +39,26 @@ runs:
         # get baseline from vcpkg
         vcpkgJsonGlob: './vcpkg.json'
 
-    - uses: actions/cache@v4
-      if: runner.os != 'Linux'
-      with:
-        key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json') }}-ImageVersion=$env:ImageVersion
-        path: ./vcpkg_cache
+    - name: get vcpkg cache key
+      id: get_vcpkg_cache_key
+      shell: bash
+      env:
+        DISTRO_LABEL: ${{ format('{0}-{1}', matrix.distro.name, matrix.distro.version) }}
+        KEY_PREFIX: vcpkg_cache-cmake-${{ inputs.preset }}
+      run: |
+        common_key="${KEY_PREFIX}-vcpkg_json_md5=$(md5sum --quiet ./vcpkg.json)"
+        if [ "${RUNNER_OS}" != "Linux" ]; then
+          echo "key=${common_key}-ImageVersion=${ImageVersion}" | tee -a $GITHUB_OUTPUT      
+        else
+          # ImageVersion is irrelevant since the build action runs in a container
+          # Express the vcpkg overlays, dockerfile, and entry point that the action will use as a single hash
+          build_action_hash="$(find ./.github/actions/openziti-tunnel-build-action/gh-release -type f -print | xargs md5sum --quiet | sort | md5sum --quiet)"
+          echo "key=${common_key}-build_action_md5=${build_action_hash}" | tee -a $GITHUB_OUTPUT
+        fi
 
     - uses: actions/cache@v4
-      if: runner.os == 'Linux'
       with:
-        key: deps-${{ inputs.preset }}-${{ hashFiles('./vcpkg.json', '.github/actions/openziti-tunnel-build-action/gh-release/vcpkg-overlays/**/vcpkg.json') }}-ImageVersion=${{ env.IMAGE_VERSION }}
+        key: ${{ steps.get_vcpkg_cache_key.outputs.key }}
         path: ./vcpkg_cache
 
     - uses: lukka/run-cmake@v10.6 # pin version to avoid failed glibc dependency on ubuntu 20 runners. go back to @latest when ubuntu 22+ is adopted for runner os.

--- a/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
@@ -16,6 +16,7 @@ ENV TZ=UTC
 RUN dnf install -y \
         "@Development Tools" \
         dnf-plugins-core \
+        findutils \
         gcc-toolset-10 \
         gcc-toolset-10-libatomic-devel \
         iproute \

--- a/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
@@ -16,7 +16,6 @@ ENV TZ=UTC
 RUN dnf install -y \
         "@Development Tools" \
         dnf-plugins-core \
-        findutils \
         gcc-toolset-10 \
         gcc-toolset-10-libatomic-devel \
         iproute \

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -93,9 +93,21 @@ jobs:
         run: |
           cp -vr ./.github/actions/openziti-tunnel-build-action/${DISTRO_LABEL}/* ./.github/actions/openziti-tunnel-build-action/
 
+      - name: get vcpkg cache key
+        id: get_vcpkg_cache_key
+        shell: bash
+        env:
+          DISTRO_LABEL: ${{ format('{0}-{1}', matrix.distro.name, matrix.distro.version) }}
+          KEY_PREFIX: vcpkg_cache-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}
+        run: |
+          key_prefix="${KEY_PREFIX}-vcpkg_json_md5=$(md5sum --quiet ./vcpkg.json)"
+          # Express the vcpkg overlays, dockerfile, and entry point that the action will use as a single hash
+          build_action_md5="$(find ./.github/actions/openziti-tunnel-build-action/${DISTRO_LABEL} -type f -print | xargs md5sum --quiet | sort | md5sum --quiet)"
+          echo "key=${key_prefix}-build_action_md5=${build_action_md5}" | tee -a $GITHUB_OUTPUT
+
       - uses: actions/cache@v4
         with:
-          key: deps-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}-${{ hashFiles('./vcpkg.json', './.github/actions/openziti-tunnel-build-action/vcpkg-overlays/**/vcpkg.json') }}-${{ env:IMAGE_VERSION }}
+          key: ${{ steps.get_vcpkg_cache_key.outputs.key }}
           path: ./vcpkg_cache
 
         # entrypoint.sh uses the value of arch to select the cmake preset

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -100,9 +100,9 @@ jobs:
           DISTRO_LABEL: ${{ format('{0}-{1}', matrix.distro.name, matrix.distro.version) }}
           KEY_PREFIX: vcpkg_cache-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}
         run: |
-          key_prefix="${KEY_PREFIX}-vcpkg_json_md5=$(md5sum --quiet ./vcpkg.json)"
+          key_prefix="${KEY_PREFIX}-vcpkg_json_md5=$(md5sum ./vcpkg.json | awk '{ print $1 }')"
           # Express the vcpkg overlays, dockerfile, and entry point that the action will use as a single hash
-          build_action_md5="$(find ./.github/actions/openziti-tunnel-build-action/${DISTRO_LABEL} -type f -print | xargs md5sum --quiet | sort | md5sum --quiet)"
+          build_action_md5="$(find ./.github/actions/openziti-tunnel-build-action/${DISTRO_LABEL} -type f -print | xargs md5sum | awk '{ print $1 }' | sort | md5sum | awk '{ print $1 }')"
           echo "key=${key_prefix}-build_action_md5=${build_action_md5}" | tee -a $GITHUB_OUTPUT
 
       - uses: actions/cache@v4

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -95,7 +95,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: deps-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}-${{ hashFiles('./vcpkg.json', './.github/actions/openziti-tunnel-build-action/vcpkg-overlays/**/vcpkg.json') }}-$env:ImageVersion
+          key: deps-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}-${{ hashFiles('./vcpkg.json', './.github/actions/openziti-tunnel-build-action/vcpkg-overlays/**/vcpkg.json') }}-${{ env:IMAGE_VERSION }}
           path: ./vcpkg_cache
 
         # entrypoint.sh uses the value of arch to select the cmake preset

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -95,7 +95,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: deps-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}-${{ hashFiles('./vcpkg.json', './.github/actions/openziti-tunnel-build-action/vcpkg-overlays/**/vcpkg.json') }}
+          key: deps-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}-${{ hashFiles('./vcpkg.json', './.github/actions/openziti-tunnel-build-action/vcpkg-overlays/**/vcpkg.json') }}-$env:ImageVersion
           path: ./vcpkg_cache
 
         # entrypoint.sh uses the value of arch to select the cmake preset

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         run: |
           dnf -y update
-          dnf -y install git
+          dnf -y install git findutils
           git --version
 
       - name: checkout workspace


### PR DESCRIPTION
include image version in vcpkg cache keys, otherwise `actions/cache` finds a hit but vcpkg needs to rebuild everything.