### PR TITLE
add CLI refresh command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 
 set(ZITI_SDK_DIR "" CACHE FILEPATH "developer option: use local ziti-sdk-c checkout")
-set(ZITI_SDK_VERSION "1.2.0" CACHE STRING "ziti-sdk-c version or branch to use")
+set(ZITI_SDK_VERSION "1.2.1" CACHE STRING "ziti-sdk-c version or branch to use")
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2311,6 +2311,17 @@ static int delete_identity_opts(int argc, char *argv[]) {
     return optind;
 }
 
+static int refresh_identity_opts(int argc, char *argv[]) {
+    tunnel_identity_id id = {
+            .identifier = get_identity_opt(argc, argv),
+    };
+    cmd.command = TunnelCommand_RefreshIdentity;
+
+    size_t json_len;
+    cmd.data = tunnel_identity_id_to_json(&id, MODEL_JSON_COMPACT, &json_len);
+
+    return optind;
+}
 
 static int add_identity_opts(int argc, char *argv[]) {
     static struct option opts[] = {
@@ -2452,6 +2463,11 @@ static CommandLine ext_auth_login = make_command(
         "\t-i|--identity\tidentity to authenticate\n",
         ext_auth_opts, send_message_to_tunnel_fn);
 
+static CommandLine refresh_cmd = make_command(
+        "refresh", "refresh identity", "[-i <identity>]",
+        "\t-i|--identity\tidentity to be refreshed\n",
+        refresh_identity_opts, send_message_to_tunnel_fn);
+
 #if _WIN32
 static CommandLine service_control_cmd = make_command("service_control", "execute service control functions for Ziti tunnel (required superuser access)",
                                           "-o|--operation <option>",
@@ -2476,6 +2492,7 @@ static CommandLine *main_cmds[] = {
         &get_mfa_codes_cmd,
         &ext_auth_login,
         &get_status_cmd,
+        &refresh_cmd,
         &delete_id_cmd,
         &add_id_cmd,
         &set_log_level_cmd,


### PR DESCRIPTION
[fixes #1038]

update ziti-sdk@1.2.1

```
$ ziti-edge-tunnel refresh -h
ziti-edge-tunnel refresh: refresh identity
usage: ziti-edge-tunnel refresh [-i <identity>]

        -i|--identity   identity to be refreshed

$ ziti-edge-tunnel refresh -i etc/mm.json                                                                             
{
  "Success":true,
  "Code":0
}
```