### PR TITLE
get lwip ports from lwip project instead of abandoned lwip-contrib project

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -19,17 +19,8 @@ endif()
 FetchContent_Declare(lwip
         GIT_REPOSITORY https://github.com/lwip-tcpip/lwip.git
         GIT_TAG STABLE-2_2_0_RELEASE
+        # lwip's CMakeLists.txt does a lot of stuff that we don't need, so prevent FetchContent_MakeAvailable from loading it.
+        # we include ${LWIP_DIR}/src/Filelists.cmake instead.
+        SOURCE_SUBDIR dont/load/lwip/cmakelists
         )
-FetchContent_GetProperties(lwip)
-if(NOT lwip_POPULATED)
-    FetchContent_Populate(lwip)
-endif()
-
-FetchContent_Declare(lwip-contrib
-        GIT_REPOSITORY https://github.com/netfoundry/lwip-contrib.git
-        GIT_TAG STABLE-2_1_0_RELEASE
-        )
-FetchContent_GetProperties(lwip-contrib)
-if(NOT lwip-contrib_POPULATED)
-    FetchContent_Populate(lwip-contrib)
-endif()
+FetchContent_MakeAvailable(lwip)

--- a/lib/ziti-tunnel/CMakeLists.txt
+++ b/lib/ziti-tunnel/CMakeLists.txt
@@ -13,8 +13,7 @@ target_compile_definitions(ziti-tunnel-sdk-c
 
 FetchContent_GetProperties(lwip)
 set (LWIP_DIR "${lwip_SOURCE_DIR}")
-FetchContent_GetProperties(lwip-contrib)
-set (LWIP_CONTRIB_DIR "${lwip-contrib_SOURCE_DIR}")
+set (LWIP_CONTRIB_DIR "${lwip_SOURCE_DIR}/contrib")
 
 if(WIN32)
     set(LWIP_CONTRIB_INCLUDE "${LWIP_CONTRIB_DIR}/ports/win32/include")

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -4,10 +4,7 @@ if (NOT TARGET subcommand)
             GIT_REPOSITORY https://github.com/openziti/subcommands.c.git
             GIT_TAG main
     )
-    FetchContent_GetProperties(subcommand)
-    if (NOT subcommand_POPULATED)
-        FetchContent_Populate(subcommand)
-    endif ()
+    FetchContent_MakeAvailable(subcommand)
     add_library(subcommand INTERFACE)
     target_include_directories(subcommand INTERFACE ${subcommand_SOURCE_DIR})
 endif ()


### PR DESCRIPTION
also use FetchContent_MakeAvailable to avoid deprecation warnings