### PR TITLE
remove config_path. it was never set. continue to use identifier whic…

### DIFF
--- a/lib/ziti-tunnel-cbs/include/ziti/ziti_tunnel_cbs.h
+++ b/lib/ziti-tunnel-cbs/include/ziti/ziti_tunnel_cbs.h
@@ -369,7 +369,6 @@ struct add_identity_request_s {
 
 struct ziti_instance_s {
     char *identifier;
-    char *config_path;
     command_cb load_cb;
     void *load_ctx;
 

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
@@ -1098,7 +1098,7 @@ static void on_ziti_event(ziti_context ztx, const ziti_event_t *event) {
 
         case ZitiAPIEvent: {
             if (event->api.new_ctrl_address || event->api.new_ca_bundle) {
-                if (instance->config_path) {
+                if (instance->identifier) {
                     api_update_req *req = calloc(1, sizeof(api_update_req));
                     req->wr.data = req;
                     req->ztx = ztx;
@@ -1505,7 +1505,7 @@ goto DONE;               \
 static void update_config(uv_work_t *wr) {
     api_update_req *req = wr->data;
     struct ziti_instance_s *inst = ziti_app_ctx(req->ztx);
-    const char *config_file = inst->config_path;
+    const char *config_file = inst->identifier;
     size_t cfg_len;
     char *cfg_buf = NULL;
     uv_file f;


### PR DESCRIPTION
…h is the normalized path to the file