### PR TITLE
update ziti-sdk@1.3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 
 set(ZITI_SDK_DIR "" CACHE FILEPATH "developer option: use local ziti-sdk-c checkout")
-set(ZITI_SDK_VERSION "1.3.4" CACHE STRING "ziti-sdk-c version or branch to use")
+set(ZITI_SDK_VERSION "1.3.5" CACHE STRING "ziti-sdk-c version or branch to use")
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)


### PR DESCRIPTION
## Changes
- fix HA enrollment: alternate controllers cannot be used for enrollment (openziti/ziti-sdk-c#804)
- Avoid bind crypto errors (openziti/ziti-sdk-c#803)
- extend dump information (openziti/ziti-sdk-c#801)