### PR TITLE
only promote stable package version '1', not alpha|beta packages

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -1,6 +1,6 @@
 name: CI package
 
-on: 
+on:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/promote-downstreams.yml
+++ b/.github/workflows/promote-downstreams.yml
@@ -125,7 +125,7 @@ jobs:
           jf rt copy
           --recursive=false
           --flat=true
-          ${{ env.ZITI_RPM_TEST_REPO }}/redhat${{ matrix.distro.version }}/${{ matrix.arch.rpm }}/ziti-edge-tunnel-${{ needs.parse_version.outputs.version }}-*.${{ matrix.arch.rpm }}.rpm
+          ${{ env.ZITI_RPM_TEST_REPO }}/redhat${{ matrix.distro.version }}/${{ matrix.arch.rpm }}/ziti-edge-tunnel-${{ needs.parse_version.outputs.version }}-1.${{ matrix.arch.rpm }}.rpm
           ${{ env.ZITI_RPM_PROD_REPO }}/redhat${{ matrix.distro.version }}/${{ matrix.arch.rpm }}/
 
       - name: Copy DEB from testing to release Artifactory repo with jFrog CLI
@@ -135,5 +135,5 @@ jobs:
           jf rt copy
           --recursive=false
           --flat=true
-          ${{ env.ZITI_DEB_TEST_REPO }}/pool/ziti-edge-tunnel/${{ matrix.distro.release_name }}/${{ matrix.arch.deb }}/ziti-edge-tunnel-${{ needs.parse_version.outputs.version }}-*.deb
+          ${{ env.ZITI_DEB_TEST_REPO }}/pool/ziti-edge-tunnel/${{ matrix.distro.release_name }}/${{ matrix.arch.deb }}/ziti-edge-tunnel-${{ needs.parse_version.outputs.version }}-1.deb
           ${{ env.ZITI_DEB_PROD_REPO }}/pool/ziti-edge-tunnel/${{ matrix.distro.release_name }}/${{ matrix.arch.deb }}/


### PR DESCRIPTION
avoids unintentionally promoting alpha|beta like this https://github.com/openziti/ziti-tunnel-sdk-c/actions/runs/12433449820/job/34717192902