### PR TITLE
write a minidump if ziti-edge-tunnel crashes on windows

### DIFF
--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -40,7 +40,10 @@ if (WIN32)
             include/windows/windows-scripts.h
             windows-scripts.c
             windows/log_utils.c
-            include/service-utils.h)
+            include/service-utils.h
+            windows/minidump.c
+            windows/minidump.h
+    )
 endif ()
 if (LINUX)
     set(ZITI_INSTANCE_OS linux/diverter.c include/linux/diverter.h)

--- a/programs/ziti-edge-tunnel/windows/log_utils.c
+++ b/programs/ziti-edge-tunnel/windows/log_utils.c
@@ -67,7 +67,7 @@ static uint8_t mkdir_p(const char *path) {
     return mkdir(cur_path, NULL);
 }
 
-static char* get_log_path() {
+char* get_log_path() {
     char process_dir[PATH_MAX]; //create string buffer to hold path
     char process_full_path[PATH_MAX];
     char drive[_MAX_DRIVE];

--- a/programs/ziti-edge-tunnel/windows/minidump.c
+++ b/programs/ziti-edge-tunnel/windows/minidump.c
@@ -20,8 +20,8 @@
 
 extern char* get_log_path();
 LONG WINAPI CrashFilter(EXCEPTION_POINTERS *pExceptionInfo) {
-    char* mini_dump_path = calloc(PATH_MAX, sizeof(char));
-    snprintf(mini_dump_path, PATH_MAX, "%s%cziti-edge-tunnel.crash.dmp", get_log_path(), PATH_SEP);
+    char* mini_dump_path = calloc(MAX_PATH, sizeof(char));
+    snprintf(mini_dump_path, MAX_PATH, "%s%cziti-edge-tunnel.crash.dmp", get_log_path(), PATH_SEP);
 
     printf("minidump created at: %s", mini_dump_path);
     HANDLE hFile = CreateFile(mini_dump_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/programs/ziti-edge-tunnel/windows/minidump.c
+++ b/programs/ziti-edge-tunnel/windows/minidump.c
@@ -1,0 +1,40 @@
+/*
+ Copyright NetFoundry Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#include <windows.h>
+#include <dbghelp.h>
+#include <stdio.h>
+
+extern char* get_log_path();
+LONG WINAPI CrashFilter(EXCEPTION_POINTERS *pExceptionInfo) {
+    char* mini_dump_path = calloc(PATH_MAX, sizeof(char));
+    snprintf(mini_dump_path, PATH_MAX, "%s%cziti-edge-tunnel.crash.dmp", get_log_path(), PATH_SEP);
+
+    printf("minidump created at: %s", mini_dump_path);
+    HANDLE hFile = CreateFile(mini_dump_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile && hFile != INVALID_HANDLE_VALUE) {
+        MINIDUMP_EXCEPTION_INFORMATION mei = {
+                GetCurrentThreadId(),
+                pExceptionInfo,
+                TRUE
+        };
+        MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, MiniDumpWithThreadInfo, &mei, NULL, NULL);
+        CloseHandle(hFile);
+    }
+    free(mini_dump_path);
+    mini_dump_path = NULL;
+    return EXCEPTION_EXECUTE_HANDLER;
+}

--- a/programs/ziti-edge-tunnel/windows/minidump.h
+++ b/programs/ziti-edge-tunnel/windows/minidump.h
@@ -1,0 +1,23 @@
+/*
+ Copyright NetFoundry Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#ifndef ZITI_TUNNEL_SDK_C_MINIDUMP_H
+#define ZITI_TUNNEL_SDK_C_MINIDUMP_H
+
+#include <windows.h>
+LONG WINAPI CrashFilter(EXCEPTION_POINTERS *exceptionPointers);
+
+#endif //ZITI_TUNNEL_SDK_C_MINIDUMP_H

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -41,6 +41,7 @@
 #include "netif_driver/windows/tun.h"
 #include "windows/windows-service.h"
 #include "windows/windows-scripts.h"
+#include "windows/minidump.h"
 
 #endif
 
@@ -2749,6 +2750,11 @@ static bool is_host_only() {
 }
 
 int main(int argc, char *argv[]) {
+#if _WIN32
+    //register a crash handler for Windows
+    SetUnhandledExceptionFilter(CrashFilter);
+#endif
+
     const char *name = strrchr(argv[0], '/');
     if (name == NULL) {
         name = argv[0];


### PR DESCRIPTION
writes a mini crash dump with thread info file on unhandled exceptions