### PR TITLE
allow ZITI_DEBUG to be defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
     add_compile_definitions(PATH_SEP='/')
 endif()
 
-if(DEFINED ENV{ZITI_DEBUG})
+if(ZITI_DEBUG)
     add_compile_definitions(ZITI_DEBUG)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ else()
     add_compile_definitions(PATH_SEP='/')
 endif()
 
+if(DEFINED ENV{ZITI_DEBUG})
+    add_compile_definitions(ZITI_DEBUG)
+endif()
+
 find_package(Git)
 if(NOT GIT_VERSION AND GIT_FOUND)
     message("Found Git executable \"${GIT_EXECUTABLE}\".")


### PR DESCRIPTION
if ZITI_DEBUG is declared, define a symbol to trigger debuggier logging in the c sdk

depends on https://github.com/openziti/ziti-sdk-c/pull/811/files