### PR TITLE
Support using pre-built dependencies

### DIFF
--- a/vcpkg-overlays/full-distro/fedora-40/catch2/portfile.cmake
+++ b/vcpkg-overlays/full-distro/fedora-40/catch2/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/fedora-40/catch2/vcpkg.json
+++ b/vcpkg-overlays/full-distro/fedora-40/catch2/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "catch2",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/fedora-40/json-c/portfile.cmake
+++ b/vcpkg-overlays/full-distro/fedora-40/json-c/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/fedora-40/json-c/vcpkg.json
+++ b/vcpkg-overlays/full-distro/fedora-40/json-c/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "json-c",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/fedora-40/libsodium/portfile.cmake
+++ b/vcpkg-overlays/full-distro/fedora-40/libsodium/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/fedora-40/libsodium/vcpkg.json
+++ b/vcpkg-overlays/full-distro/fedora-40/libsodium/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "libsodium",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/fedora-40/openssl/portfile.cmake
+++ b/vcpkg-overlays/full-distro/fedora-40/openssl/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/fedora-40/openssl/vcpkg.json
+++ b/vcpkg-overlays/full-distro/fedora-40/openssl/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "openssl",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/fedora-40/protobuf-c/portfile.cmake
+++ b/vcpkg-overlays/full-distro/fedora-40/protobuf-c/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/fedora-40/protobuf-c/vcpkg.json
+++ b/vcpkg-overlays/full-distro/fedora-40/protobuf-c/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "protobuf-c",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/fedora-40/zlib/portfile.cmake
+++ b/vcpkg-overlays/full-distro/fedora-40/zlib/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/fedora-40/zlib/vcpkg.json
+++ b/vcpkg-overlays/full-distro/fedora-40/zlib/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "zlib",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/macOS-15/json-c/portfile.cmake
+++ b/vcpkg-overlays/full-distro/macOS-15/json-c/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/macOS-15/json-c/vcpkg.json
+++ b/vcpkg-overlays/full-distro/macOS-15/json-c/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "json-c",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/macOS-15/libsodium/portfile.cmake
+++ b/vcpkg-overlays/full-distro/macOS-15/libsodium/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/macOS-15/libsodium/vcpkg.json
+++ b/vcpkg-overlays/full-distro/macOS-15/libsodium/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "libsodium",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/macOS-15/openssl/portfile.cmake
+++ b/vcpkg-overlays/full-distro/macOS-15/openssl/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/macOS-15/openssl/vcpkg.json
+++ b/vcpkg-overlays/full-distro/macOS-15/openssl/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "openssl",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/macOS-15/protobuf-c/portfile.cmake
+++ b/vcpkg-overlays/full-distro/macOS-15/protobuf-c/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/macOS-15/protobuf-c/vcpkg.json
+++ b/vcpkg-overlays/full-distro/macOS-15/protobuf-c/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "protobuf-c",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/windows-11/README.md
+++ b/vcpkg-overlays/full-distro/windows-11/README.md
@@ -1,8 +1,8 @@
 # How to Avoid Building All Dependencies with vcpkg
 
-vcpkg supports a trick that lets toy get a dependency from an external source  (like a package manager) instead of
-building it. The only explanation of the trick that I've seen is a [blog post from microsoft], but I've put it to
-use it on Linux (with apt/dnf dependencies), macOS (homebrew), and Windows (msys2).
+vcpkg supports a trick that lets you get a dependency from an external source (like a package manager) instead of
+building it. The only explanation of the trick that I've seen is a [blog post from microsoft](https://devblogs.microsoft.com/cppblog/using-system-package-manager-dependencies-with-vcpkg/),
+but I've put it to use it on Linux (with apt/dnf dependencies), macOS (homebrew), and Windows (msys2).
 
 You can probably get away with using a different package manager, as long as the packages that it installs are
 registered with the pkg-config that your build uses. I've been getting pkg-config from msys2 on Windows, so I

--- a/vcpkg-overlays/full-distro/windows-11/README.md
+++ b/vcpkg-overlays/full-distro/windows-11/README.md
@@ -1,0 +1,34 @@
+# How to Avoid Building All Dependencies with vcpkg
+
+vcpkg supports a trick that lets toy get a dependency from an external source  (like a package manager) instead of
+building it. The only explanation of the trick that I've seen is a [blog post from microsoft], but I've put it to
+use it on Linux (with apt/dnf dependencies), macOS (homebrew), and Windows (msys2).
+
+You can probably get away with using a different package manager, as long as the packages that it installs are
+registered with the pkg-config that your build uses. I've been getting pkg-config from msys2 on Windows, so I
+stayed with msys2 for the dependency packages as well. I imagine chocolatey would work too if that's your thing.
+
+Anyway, here's what worked for me:
+
+1. Install [msys2](https://www.msys2.org)
+
+2. Install pkg-config and ziti-tunnel-sdk-c dependencies from an `msys2` prompt:
+
+       pacman -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-json-c mingw-w64-x86_64-libuv \
+           mingw-w64-x86_64-libsodium mingw-w64-x86_64-openssl 
+
+3. Add `c:\msys64\mingw64\bin` to your PATH.
+
+4. Add the following to your cmake preset:
+
+       "cacheVariables": {
+          "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-overlays/full-distro/windows-11"
+       },
+       "environment": {
+          "OPENSSL_ROOT_DIR": "c:/msys64/mingw64"
+       },
+
+   The openssl variable was needed because [cmake's FindOpenSSL module](https://cmake.org/cmake/help/latest/module/FindOpenSSL.html)
+   does not consult `pkg-config` on Windows.
+
+5. Remove your build directory, and re-run cmake.

--- a/vcpkg-overlays/full-distro/windows-11/README.md
+++ b/vcpkg-overlays/full-distro/windows-11/README.md
@@ -17,18 +17,18 @@ Anyway, here's what worked for me:
        pacman -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-json-c mingw-w64-x86_64-libuv \
            mingw-w64-x86_64-libsodium mingw-w64-x86_64-openssl 
 
-3. Add `c:\msys64\mingw64\bin` to your PATH.
-
-4. Add the following to your cmake preset:
+3. Add the following to your cmake preset:
 
        "cacheVariables": {
+          "PKG_CONFIG_EXECUTABLE": "c:/msys64/mingw64/bin/pkg-config.exe",
           "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-overlays/full-distro/windows-11"
        },
        "environment": {
           "OPENSSL_ROOT_DIR": "c:/msys64/mingw64"
        },
 
-   The openssl variable was needed because [cmake's FindOpenSSL module](https://cmake.org/cmake/help/latest/module/FindOpenSSL.html)
-   does not consult `pkg-config` on Windows.
+   - Note that the `PKG_CONFIG_EXECUTABLE` setting depends on where you installed `msys2`.
+   - The openssl variable was needed because [cmake's FindOpenSSL module](https://cmake.org/cmake/help/latest/module/FindOpenSSL.html)
+     does not consult `pkg-config` on Windows.
 
 5. Remove your build directory, and re-run cmake.

--- a/vcpkg-overlays/full-distro/windows-11/json-c/portfile.cmake
+++ b/vcpkg-overlays/full-distro/windows-11/json-c/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/windows-11/json-c/vcpkg.json
+++ b/vcpkg-overlays/full-distro/windows-11/json-c/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "json-c",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/windows-11/libsodium/portfile.cmake
+++ b/vcpkg-overlays/full-distro/windows-11/libsodium/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/windows-11/libsodium/vcpkg.json
+++ b/vcpkg-overlays/full-distro/windows-11/libsodium/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "libsodium",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/windows-11/libuv/portfile.cmake
+++ b/vcpkg-overlays/full-distro/windows-11/libuv/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/windows-11/libuv/vcpkg.json
+++ b/vcpkg-overlays/full-distro/windows-11/libuv/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "libuv",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/windows-11/openssl/portfile.cmake
+++ b/vcpkg-overlays/full-distro/windows-11/openssl/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/windows-11/openssl/vcpkg.json
+++ b/vcpkg-overlays/full-distro/windows-11/openssl/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "openssl",
+  "version": "0"
+}

--- a/vcpkg-overlays/full-distro/windows-11/protobuf-c/portfile.cmake
+++ b/vcpkg-overlays/full-distro/windows-11/protobuf-c/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/vcpkg-overlays/full-distro/windows-11/protobuf-c/vcpkg.json
+++ b/vcpkg-overlays/full-distro/windows-11/protobuf-c/vcpkg.json
@@ -1,0 +1,4 @@
+{
+  "name": "protobuf-c",
+  "version": "0"
+}


### PR DESCRIPTION
Add vcpkg port overlays for developers who want to use pre-built dependencies from their OS package manager instead of building them via vcpkg. Using these overlays requires adding "${sourceDir}/vcpkg-overlays/full-distro/OS_NAME" to the `VCPKG_OVERLAY_PORTS` cmake cache variable, which would probably be done in CMakeUserPresets.json (see example for windows-11).

Note we don't want to use this trick for release builds unless we can be certain that the libraries installed by the package manager are static. For now it's just intended for developers who want to avoid rebuilding vcpkg dependencies for no apparent reason.