### PR TITLE
update vcpkg@2025.01.13

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -28,5 +28,5 @@
       ]
     }
   },
-  "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
+  "builtin-baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -28,5 +28,5 @@
       ]
     }
   },
-  "builtin-baseline": "3508985146f1b1d248c67ead13f8f54be5b4f5da"
+  "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -28,5 +28,5 @@
       ]
     }
   },
-  "builtin-baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836"
+  "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
 }


### PR DESCRIPTION
Newer baselines introduce build failures on our current toolchains.

Try re-running bootstrap-vcpkg.sh/cmd (in your vcpkg checkout) if vcpkg install fails because "vcpkgTools.xml" isn't found.