### PR TITLE
allow building with cmake 4.0

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,10 +17,8 @@
       "name": "vcpkg",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-      },
-      "environment": {
-        "VCPKG_FORCE_SYSTEM_BINARIES": "yes"
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-overlays/omit-json-c-apps"
       }
     },
     {

--- a/vcpkg-overlays/omit-json-c-apps/README.md
+++ b/vcpkg-overlays/omit-json-c-apps/README.md
@@ -1,0 +1,5 @@
+This overlay disables building apps in the json-c package. We don't need the apps, and the app build
+currently fails with cmake 4.0.
+
+Remove this overlay from ziti-tunnel-sdk-c when https://github.com/json-c/json-c/pull/888
+is merged and referenced in our vcpkg baseline - currently 2025.01.13.

--- a/vcpkg-overlays/omit-json-c-apps/json-c/fix-clang-cl.patch
+++ b/vcpkg-overlays/omit-json-c-apps/json-c/fix-clang-cl.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0aa1b64..54e7b3d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -295,7 +295,7 @@ message(STATUS "Wrote ${PROJECT_BINARY_DIR}/config.h")
+ configure_file(${PROJECT_SOURCE_DIR}/cmake/json_config.h.in   ${PROJECT_BINARY_DIR}/json_config.h)
+ message(STATUS "Wrote ${PROJECT_BINARY_DIR}/json_config.h")
+ 
+-if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
++if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" AND NOT MSVC)
+     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections")
+ 	if ("${DISABLE_WERROR}" STREQUAL "OFF")
+ 	    set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -Werror")
+@@ -316,7 +316,7 @@ if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL
+         # Remove this for 1.0 when we can bump the ABI and actually fix these warnings.
+         set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -Wno-shorten-64-to-32")
+     endif()
+-elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
++elseif (MSVC)
+     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} /DEBUG")
+     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} /wd4100")
+     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} /wd4996")

--- a/vcpkg-overlays/omit-json-c-apps/json-c/pkgconfig.patch
+++ b/vcpkg-overlays/omit-json-c-apps/json-c/pkgconfig.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ffb1db3dc..a82ed8619 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -273,7 +273,7 @@ install(
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+ )
+ 
+-if (UNIX OR MINGW OR CYGWIN)
++if (1)
+     SET(prefix ${CMAKE_INSTALL_PREFIX})
+     # exec_prefix is prefix by default and CMake does not have the
+     # concept.

--- a/vcpkg-overlays/omit-json-c-apps/json-c/portfile.cmake
+++ b/vcpkg-overlays/omit-json-c-apps/json-c/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO json-c/json-c
+    REF b4c371fa0cbc4dcbaccc359ce9e957a22988fb34
+    SHA512 1338271a6f9ffb3b8a8d4f2ec36a374ed84b3c91f789b607693c08cbeb38c4fdd813593f530ff94e841a095ff367a3ae8c5f5e7dbcb64e8f9044f6affdf24505
+    HEAD_REF master
+    PATCHES pkgconfig.patch
+            fix-clang-cl.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" JSON_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" JSON_BUILD_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_APPS=OFF
+        -DBUILD_TESTING=OFF
+        -DBUILD_STATIC_LIBS=${JSON_BUILD_STATIC}
+        -DBUILD_SHARED_LIBS=${JSON_BUILD_SHARED}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/vcpkg-overlays/omit-json-c-apps/json-c/vcpkg.json
+++ b/vcpkg-overlays/omit-json-c-apps/json-c/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "json-c",
+  "version-date": "2023-08-12",
+  "description": "A JSON implementation in C",
+  "homepage": "https://github.com/json-c/json-c",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
Disable the portion of the build that currently breaks when building with cmake 4 (json-c apps). This is preferable to controlling the cmake version used by vcpkg, as was done in https://github.com/openziti/ziti-tunnel-sdk-c/pull/1130/commits/3cac744697e720a1525a859a23bf26f83ab6727c and https://github.com/openziti/ziti-tunnel-sdk-c/pull/1134.