### PR TITLE
disable duplocale when building for darwin

### DIFF
--- a/vcpkg-overlays/omit-json-c-apps/json-c/disable-duplocale.patch
+++ b/vcpkg-overlays/omit-json-c-apps/json-c/disable-duplocale.patch
@@ -1,0 +1,15 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -202,6 +202,12 @@
+ exec_program(${CMAKE_C_COMPILER} ARGS -dumpmachine OUTPUT_VARIABLE CMAKE_GNU_C_MACHINE)
+ if (CMAKE_GNU_C_MACHINE MATCHES "uclibc")
+ 	message(STATUS "Detected uClibc compiler, disabling locale handling")
++	set(HAVE_SETLOCALE 0)
++	set(HAVE_USELOCALE 0)
++endif()
++
++if (APPLE)
++	message(STATUS "Detected apple, disabling locale handling to avoid leaks.")
+ 	set(HAVE_SETLOCALE 0)
+ 	set(HAVE_USELOCALE 0)
+ endif()

--- a/vcpkg-overlays/omit-json-c-apps/json-c/portfile.cmake
+++ b/vcpkg-overlays/omit-json-c-apps/json-c/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES pkgconfig.patch
             fix-clang-cl.patch
+            disable-duplocale.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" JSON_BUILD_STATIC)


### PR DESCRIPTION
the build files in ziti-sdk-swift do this too