### PR TITLE
free ziti_config memory after sending identity event

### DIFF
--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -798,6 +798,7 @@ static void on_event(const base_event *ev) {
             }
             id_event.Id = NULL;
             free_identity_event(&id_event);
+            free_ziti_config(&zc);
             break;
         }
         case TunnelEvent_ExtJWTEvent:


### PR DESCRIPTION
leak was added in #1089 (release [1.4.5](https://github.com/openziti/ziti-tunnel-sdk-c/releases/tag/v1.4.5))