### PR TITLE
wait longer for test service to become available

### DIFF
--- a/docker/docker.test.bash
+++ b/docker/docker.test.bash
@@ -192,7 +192,7 @@ docker compose up ziti-host --detach
 ZITI_ENROLL_TOKEN="$(docker compose exec quickstart cat /tmp/httpbin-client.ott.jwt)" \
 docker  compose up ziti-tun --detach
 
-ATTEMPTS=3
+ATTEMPTS=5
 DELAY=3
 
 curl_cmd="curl --fail --connect-timeout 1 --silent --show-error --request POST --header 'Content-Type: application/json' --data '{\"ziti\": \"works\"}' http://${ZITI_TEST_INTERCEPT}/post"


### PR DESCRIPTION
This test failed at least once in GH Actions because the tunneler was only running for 4 seconds before the last attempt to cURL the Ziti service address, and hadn't yet acquired the service config.