### PR TITLE
allow posix ziti:ziti to rewrite *.json files in identity dir

### DIFF
--- a/programs/ziti-edge-tunnel/package/deb/postinst.in
+++ b/programs/ziti-edge-tunnel/package/deb/postinst.in
@@ -45,7 +45,7 @@ if [ "$1" = "configure" ]; then
 
   chown root:ziti "@ZITI_IDENTITY_DIR@"
   chmod 0770 "@ZITI_IDENTITY_DIR@"
-  find "@ZITI_IDENTITY_DIR@" -maxdepth 1 -name "*.json" -type f -exec chown ziti:ziti "{}" + -exec chmod 0440 "{}" +
+  find "@ZITI_IDENTITY_DIR@" -maxdepth 1 -name "*.json" -type f -exec chown ziti:ziti "{}" + -exec chmod 0660 "{}" +
 
   # sort ascending the installed and max policykit versions, saving the highest version, so we
   # can ensure the installed version is less than the max version

--- a/programs/ziti-edge-tunnel/package/rpm/post.sh.in
+++ b/programs/ziti-edge-tunnel/package/rpm/post.sh.in
@@ -27,7 +27,7 @@ chmod -R u=rwX,g=rwX,o= "@ZITI_STATE_DIR@" || :
 
 chown root:ziti "@ZITI_IDENTITY_DIR@" || :
 chmod 0770 "@ZITI_IDENTITY_DIR@" || :
-find "@ZITI_IDENTITY_DIR@" -maxdepth 1 -name "*.json" -type f -exec chown ziti:ziti "{}" + -exec chmod 0440 "{}" + || :
+find "@ZITI_IDENTITY_DIR@" -maxdepth 1 -name "*.json" -type f -exec chown ziti:ziti "{}" + -exec chmod 0660 "{}" + || :
 
 # remove socket files that were created by older ziti-edge-tunnel versions
 rm -f /tmp/ziti-edge-tunnel.sock /tmp/ziti-edge-tunnel-event.sock


### PR DESCRIPTION
This is necessary for:

1. write state to config.json
2. for edge SDK to update client certs, private key, trust bundle