### PR TITLE
move setting ziti-edge-tunnel compile definitions (execinfo)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,13 +183,6 @@ target_compile_definitions(lwipcore
     PUBLIC MEMP_NUM_UDP_PCB=${UDP_MAX_CONNECTIONS}
 )
 
-# if EXECINFO is present set a flag for later inclusion
-include(CheckIncludeFile)
-check_include_file("execinfo.h" HAVE_EXECINFO_H)
-if(HAVE_EXECINFO_H)
-    target_compile_definitions(ziti-edge-tunnel PRIVATE $<$<BOOL:${HAVE_EXECINFO_H}>:HAVE_EXECINFO_H>)
-endif()
-
 if (ZITI_TUNNEL_BUILD_TESTS)
     add_subdirectory(tests)
     add_subdirectory(lib/tests)

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -93,6 +93,13 @@ target_compile_definitions(ziti-edge-tunnel
         PRIVATE ZITI_LOG_MODULE="ziti-edge-tunnel"
         )
 
+# if EXECINFO is present set a flag for later inclusion
+include(CheckIncludeFile)
+check_include_file("execinfo.h" HAVE_EXECINFO_H)
+if(HAVE_EXECINFO_H)
+    target_compile_definitions(ziti-edge-tunnel PRIVATE $<$<BOOL:${HAVE_EXECINFO_H}>:HAVE_EXECINFO_H>)
+endif()
+
 target_link_libraries(ziti-edge-tunnel
         PUBLIC ziti ziti-tunnel-sdk-c ziti-tunnel-cbs-c
         PUBLIC ${tun_lib}


### PR DESCRIPTION
target `ziti-edge-tunnel` may not exist