### PR TITLE
start adding pkcs11 libs to zet image

### DIFF
--- a/docker/ziti-edge-tunnel.Dockerfile
+++ b/docker/ziti-edge-tunnel.Dockerfile
@@ -1,4 +1,78 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM almalinux:9 AS opensc
+
+ARG OPENSC_VERSION=0.26.1
+
+ENV OPENSC_VERSION=${OPENSC_VERSION} \
+    OPENSC_SOURCES=/tmp/opensc
+
+RUN dnf install -y dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf update -y
+RUN dnf install -y \
+        readline-devel \
+        openssl-devel \
+        libxslt \
+        docbook-style-xsl \
+        pcsc-lite-devel \
+        automake \
+        autoconf \
+        libtool \
+        git \
+        gcc \
+        make \
+        which
+
+RUN git clone https://github.com/OpenSC/OpenSC.git ${OPENSC_SOURCES}
+WORKDIR ${OPENSC_SOURCES}
+
+RUN git checkout ${OPENSC_VERSION} -b ${OPENSC_VERSION} \
+    && ./bootstrap \
+    && ./configure --prefix=/usr/local --sysconfdir=/etc/opensc \
+    && make \
+    && make install
+
+FROM almalinux:9 AS yubikey
+
+ARG YUBIKEY_VERSION=yubico-piv-tool-2.7.1
+
+ENV YUBIKEY_VERSION=${YUBIKEY_VERSION} \
+    YUBIKEY_SOURCES=/tmp/yubikey
+
+RUN dnf install -y dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf update -y
+RUN dnf install -y \
+    cmake \
+    libtool \
+    openssl-devel \
+    pkg-config \
+    check \
+    check-devel \
+    pcsc-lite-devel \
+    help2man \
+    git \
+    gcc \
+    gcc-c++ \
+    gengetopt \
+    make \
+    which \
+    zlib-devel \
+    cmake3
+
+RUN git clone https://github.com/Yubico/yubico-piv-tool.git ${YUBIKEY_SOURCES}
+WORKDIR ${YUBIKEY_SOURCES}
+
+RUN git checkout ${YUBIKEY_VERSION} -b ${YUBIKEY_VERSION} \
+    && mkdir -p build && cd build \
+    && cmake3 .. \
+    && make \
+    && make install
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS runner
+
+COPY --from=opensc /usr/local /usr/local
+COPY --from=yubikey /usr/local /usr/local
 
 ARG ARTIFACTS_DIR=./build
 ARG DOCKER_BUILD_DIR=.
@@ -22,7 +96,7 @@ COPY ${DOCKER_BUILD_DIR}/LICENSE-Apache /licenses/apache.txt
 
 ### Add necessary Red Hat repos and packages
 # installing util-linux adds 20MB to the image size and doesn't seem worthwhile just for the mountpoint command...
-RUN INSTALL_PKGS="iproute procps shadow-utils jq" \
+RUN INSTALL_PKGS="iproute procps shadow-utils jq openssl-pkcs11" \
     && microdnf -y update --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
     && microdnf -y install --setopt=install_weak_deps=0 --setopt=tsflags=nodocs ${INSTALL_PKGS}
 


### PR DESCRIPTION
Install PKCS#11 libraries for popular hardware keys, e.g., TPM 2.0, YubiKey.

```bash
ziti-tunnel-sdk-c docker-tpm-pkcs11*​​≡5s 
❯ docker image ls openziti/ziti-edge-tunnel:1.6.0
REPOSITORY                  TAG       IMAGE ID       CREATED       SIZE
openziti/ziti-edge-tunnel   1.6.0     c46b5682a6c6   2 weeks ago   157MB

ziti-tunnel-sdk-c docker-tpm-pkcs11*​​≡
❯ docker image ls ziti-edge-tunnel:v1.6.0-3-gd6c0a5d                  
REPOSITORY         TAG                 IMAGE ID       CREATED         SIZE
ziti-edge-tunnel   v1.6.0-3-gd6c0a5d   74709dc8ac08   4 minutes ago   189MB
```