### PR TITLE
bugfix and tidy cpack action and workflow

### DIFF
--- a/.github/actions/openziti-tunnel-build-action/action.yml
+++ b/.github/actions/openziti-tunnel-build-action/action.yml
@@ -1,16 +1,16 @@
-name: 'OpenZiti Tunneler Build Action'
-description: 'Builds ziti-edge-tunnel binary and install package for Linux'
-author: 'NetFoundry'
+name: OpenZiti Tunneler Build Action
+description: Builds ziti-edge-tunnel binary and Linux package
+author: NetFoundry
 inputs:
   arch:
-    description: 'The cmake preset used by entrypoint.sh when running cmake'
+    description: The cmake preset used by entrypoint.sh when running cmake
     required: false
   config:
-    description: 'The cmake build configuration used by entrypoint.sh when running cmake'
+    description: The cmake build configuration used by entrypoint.sh when running cmake
     required: false
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: docker
+  image: Dockerfile
   args:
     - ${{ inputs.arch }}
     - ${{ inputs.config }}

--- a/.github/actions/openziti-tunnel-build-action/gh-release/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/gh-release/Dockerfile
@@ -1,6 +1,5 @@
 # use ziti-builder:v1 (Ubuntu Bionic 18.04 LTS) for older glibc (2.27)
 FROM openziti/ziti-builder:v1
 
-COPY ./entrypoint.sh /root/
-RUN chmod +x /root/entrypoint.sh
+COPY --chmod=0755 ./entrypoint.sh /root/
 ENTRYPOINT [ "/root/entrypoint.sh" ]

--- a/.github/actions/openziti-tunnel-build-action/gh-release/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/gh-release/entrypoint.sh
@@ -44,26 +44,34 @@ fi
 for SAFE in \
     /github/workspace \
     /__w/ziti-tunnel-sdk-c/ziti-tunnel-sdk-c \
-    /mnt ; do
-        git config --global --add safe.directory ${SAFE}
+    /mnt \
+    /usr/local/vcpkg
+do
+    git config --global --add safe.directory ${SAFE}
+done
+
+for CACHE in \
+    /github/workspace/vcpkg_cache/{archives,downloads,installed}
+do
+    mkdir -p ${CACHE}
 done
 
 (
-  cd "${VCPKG_ROOT}"
-  git checkout master
-  git pull
-  ./bootstrap-vcpkg.sh -disableMetrics
+    cd "${VCPKG_ROOT}"
+    git checkout master
+    git pull
+    ./bootstrap-vcpkg.sh -disableMetrics
 )
 
 cmake -E make_directory ./build
 cmake \
-  --preset "${cmake_preset}" \
-  -DCMAKE_BUILD_TYPE="${cmake_config}" \
-  -DVCPKG_OVERLAY_PORTS=./.github/actions/openziti-tunnel-build-action/gh-release/vcpkg-overlays \
-  -S . \
-  -B ./build
+    --preset "${cmake_preset}" \
+    -DCMAKE_BUILD_TYPE="${cmake_config}" \
+    -DVCPKG_OVERLAY_PORTS=./.github/actions/openziti-tunnel-build-action/gh-release/vcpkg-overlays \
+    -S . \
+    -B ./build
 cmake \
-  --build ./build \
-  --config "${cmake_config}" \
-  --target bundle \
-  --verbose
+    --build ./build \
+    --config "${cmake_config}" \
+    --target bundle \
+    --verbose

--- a/.github/actions/openziti-tunnel-build-action/gh-release/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/gh-release/entrypoint.sh
@@ -50,11 +50,7 @@ do
     git config --global --add safe.directory ${SAFE}
 done
 
-for CACHE in \
-    /github/workspace/vcpkg_cache/{archives,downloads,installed}
-do
-    mkdir -p ${CACHE}
-done
+mkdir -p /github/workspace/vcpkg_cache
 
 (
     cd "${VCPKG_ROOT}"

--- a/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
@@ -40,6 +40,7 @@ RUN curl -sSfL https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSIO
 
 ENV VCPKG_ROOT=/usr/local/vcpkg
 # this must be set on arm. see https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_force_system_binaries
+ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
 
 RUN cd /usr/local \

--- a/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
@@ -44,7 +44,7 @@ ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
 
 RUN cd /usr/local \
     && git clone https://github.com/microsoft/vcpkg \
-    && ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+    && chmod -R ugo+rwX /usr/local/vcpkg
 
 WORKDIR /github/workspace
 COPY ./entrypoint.sh /root/

--- a/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/redhat-8/Dockerfile
@@ -40,8 +40,8 @@ RUN curl -sSfL https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSIO
 
 ENV VCPKG_ROOT=/usr/local/vcpkg
 # this must be set on arm. see https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_force_system_binaries
-ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
+ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 
 RUN cd /usr/local \
     && git clone https://github.com/microsoft/vcpkg \

--- a/.github/actions/openziti-tunnel-build-action/redhat-8/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/redhat-8/entrypoint.sh
@@ -32,15 +32,23 @@ fi
 for SAFE in \
     /github/workspace \
     /__w/ziti-tunnel-sdk-c/ziti-tunnel-sdk-c \
-    /mnt ; do
-        git config --global --add safe.directory ${SAFE}
+    /mnt \
+    /usr/local/vcpkg
+do
+    git config --global --add safe.directory ${SAFE}
+done
+
+for CACHE in \
+    /github/workspace/vcpkg_cache/{archives,downloads,installed}
+do
+    mkdir -p ${CACHE}
 done
 
 (
-  cd "${VCPKG_ROOT}"
-  git checkout master
-  git pull
-  ./bootstrap-vcpkg.sh -disableMetrics
+    cd "${VCPKG_ROOT}"
+    git checkout master
+    git pull
+    ./bootstrap-vcpkg.sh -disableMetrics
 )
 
 cmake -E make_directory ./build

--- a/.github/actions/openziti-tunnel-build-action/redhat-8/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/redhat-8/entrypoint.sh
@@ -38,11 +38,7 @@ do
     git config --global --add safe.directory ${SAFE}
 done
 
-for CACHE in \
-    /github/workspace/vcpkg_cache/{archives,downloads,installed}
-do
-    mkdir -p ${CACHE}
-done
+mkdir -p /github/workspace/vcpkg_cache
 
 (
     cd "${VCPKG_ROOT}"

--- a/.github/actions/openziti-tunnel-build-action/redhat-9/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/redhat-9/Dockerfile
@@ -1,6 +1,6 @@
 ARG CMAKE_VERSION="3.26.3"
 
-FROM rockylinux:9
+FROM quay.io/almalinuxorg/almalinux:9.6-20250611
 
 ARG CMAKE_VERSION
 
@@ -13,7 +13,8 @@ ENV PATH="/usr/local/:${PATH}"
 ENV GIT_DISCOVERY_ACROSS_FILESYSTEM=1
 ENV TZ=UTC
 
-RUN dnf install -y \
+RUN dnf update --assumeyes --nobest \
+    && dnf install --assumeyes --nobest \
         "@Development Tools" \
         dnf-plugins-core \
         iproute \
@@ -25,7 +26,7 @@ RUN dnf install -y \
         perl-FindBin perl-IPC-Cmd perl-File-Compare perl-File-Copy \
         libatomic \
     && dnf config-manager --set-enabled crb \
-    && dnf install -y \
+    && dnf install --assumeyes --nobest \
         doxygen \
         graphviz \
         git \
@@ -33,7 +34,7 @@ RUN dnf install -y \
         protobuf-c-devel \
         openssl-devel \
         ninja-build \
-    && dnf clean all 
+    && dnf clean all
 
 RUN curl -sSfL https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-linux-$(uname -m).sh -o cmake.sh \
     && (bash cmake.sh --skip-license --prefix=/usr/local) \
@@ -42,12 +43,15 @@ RUN curl -sSfL https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSIO
 ENV GIT_CONFIG_GLOBAL="/tmp/ziti-builder-gitconfig"
 
 ENV VCPKG_ROOT=/usr/local/vcpkg
+ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache/archives,readwrite"
+ENV VCPKG_DOWNLOADS=/github/workspace/vcpkg_cache/downloads
+ENV VCPKG_INSTALLED_DIR=/github/workspace/vcpkg_cache/installed
+
 # this must be set on arm. see https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_force_system_binaries
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
 
 RUN cd /usr/local \
     && git clone https://github.com/microsoft/vcpkg \
-    && ./vcpkg/bootstrap-vcpkg.sh -disableMetrics \
     && chmod -R ugo+rwX /usr/local/vcpkg
 
 WORKDIR /github/workspace

--- a/.github/actions/openziti-tunnel-build-action/redhat-9/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/redhat-9/Dockerfile
@@ -43,10 +43,9 @@ RUN curl -sSfL https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSIO
 ENV GIT_CONFIG_GLOBAL="/tmp/ziti-builder-gitconfig"
 
 ENV VCPKG_ROOT=/usr/local/vcpkg
-ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
-
 # this must be set on arm. see https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_force_system_binaries
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
+ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 
 RUN cd /usr/local \
     && git clone https://github.com/microsoft/vcpkg \

--- a/.github/actions/openziti-tunnel-build-action/redhat-9/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/redhat-9/Dockerfile
@@ -43,9 +43,7 @@ RUN curl -sSfL https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSIO
 ENV GIT_CONFIG_GLOBAL="/tmp/ziti-builder-gitconfig"
 
 ENV VCPKG_ROOT=/usr/local/vcpkg
-ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache/archives,readwrite"
-ENV VCPKG_DOWNLOADS=/github/workspace/vcpkg_cache/downloads
-ENV VCPKG_INSTALLED_DIR=/github/workspace/vcpkg_cache/installed
+ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 
 # this must be set on arm. see https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_force_system_binaries
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes

--- a/.github/actions/openziti-tunnel-build-action/redhat-9/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/redhat-9/entrypoint.sh
@@ -32,15 +32,23 @@ fi
 for SAFE in \
     /github/workspace \
     /__w/ziti-tunnel-sdk-c/ziti-tunnel-sdk-c \
-    /mnt ; do
-        git config --global --add safe.directory ${SAFE}
+    /mnt \
+    /usr/local/vcpkg
+do
+    git config --global --add safe.directory ${SAFE}
+done
+
+for CACHE in \
+    /github/workspace/vcpkg_cache/{archives,downloads,installed}
+do
+    mkdir -p ${CACHE}
 done
 
 (
-  cd "${VCPKG_ROOT}"
-  git checkout master
-  git pull
-  ./bootstrap-vcpkg.sh -disableMetrics
+    cd "${VCPKG_ROOT}"
+    git checkout master
+    git pull
+    ./bootstrap-vcpkg.sh -disableMetrics
 )
 
 (

--- a/.github/actions/openziti-tunnel-build-action/redhat-9/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/redhat-9/entrypoint.sh
@@ -38,11 +38,7 @@ do
     git config --global --add safe.directory ${SAFE}
 done
 
-for CACHE in \
-    /github/workspace/vcpkg_cache/{archives,downloads,installed}
-do
-    mkdir -p ${CACHE}
-done
+mkdir -p /github/workspace/vcpkg_cache
 
 (
     cd "${VCPKG_ROOT}"

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/Dockerfile
@@ -54,6 +54,7 @@ RUN curl -sSfL https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSIO
     && rm cmake.sh
 
 ENV VCPKG_ROOT=/usr/local/vcpkg
+ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 # this must be set on arm. see https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_force_system_binaries
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
 

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/Dockerfile
@@ -54,9 +54,9 @@ RUN curl -sSfL https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSIO
     && rm cmake.sh
 
 ENV VCPKG_ROOT=/usr/local/vcpkg
-ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 # this must be set on arm. see https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_force_system_binaries
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
+ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 
 RUN cd /usr/local \
     && git clone https://github.com/microsoft/vcpkg \

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/Dockerfile
@@ -58,9 +58,8 @@ ENV VCPKG_ROOT=/usr/local/vcpkg
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
 
 RUN cd /usr/local \
-    && git config --global advice.detachedHead false \
     && git clone https://github.com/microsoft/vcpkg \
-    && ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+    && chmod -R ugo+rwX /usr/local/vcpkg
 
 COPY ./entrypoint.sh /root/
 ENTRYPOINT [ "/root/entrypoint.sh" ]

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/entrypoint.sh
@@ -41,11 +41,7 @@ do
     git config --global --add safe.directory ${SAFE}
 done
 
-for CACHE in \
-    /github/workspace/vcpkg_cache/{archives,downloads,installed}
-do
-    mkdir -p ${CACHE}
-done
+mkdir -p /github/workspace/vcpkg_cache
 
 (
     cd "${VCPKG_ROOT}"

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-20.04/entrypoint.sh
@@ -35,15 +35,23 @@ fi
 for SAFE in \
     /github/workspace \
     /__w/ziti-tunnel-sdk-c/ziti-tunnel-sdk-c \
-    /mnt ; do
-        git config --global --add safe.directory ${SAFE}
+    /mnt \
+    /usr/local/vcpkg
+do
+    git config --global --add safe.directory ${SAFE}
+done
+
+for CACHE in \
+    /github/workspace/vcpkg_cache/{archives,downloads,installed}
+do
+    mkdir -p ${CACHE}
 done
 
 (
-  cd "${VCPKG_ROOT}"
-  git checkout master
-  git pull
-  ./bootstrap-vcpkg.sh -disableMetrics
+    cd "${VCPKG_ROOT}"
+    git checkout master
+    git pull
+    ./bootstrap-vcpkg.sh -disableMetrics
 )
 
 [[ -d ./build ]] && rm -r ./build

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/Dockerfile
@@ -63,9 +63,8 @@ ENV VCPKG_ROOT=/usr/local/vcpkg
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
 
 RUN cd /usr/local \
-    && git config --global advice.detachedHead false \
     && git clone https://github.com/microsoft/vcpkg \
-    && ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+    && chmod -R ugo+rwX /usr/local/vcpkg
 
 COPY ./entrypoint.sh /root/
 ENTRYPOINT [ "/root/entrypoint.sh" ]

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/Dockerfile
@@ -59,6 +59,7 @@ RUN curl -sSfL "https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSI
     && rm cmake.sh
 
 ENV VCPKG_ROOT=/usr/local/vcpkg
+ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 # this must be set on arm. see https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_force_system_binaries
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
 

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/Dockerfile
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/Dockerfile
@@ -59,9 +59,9 @@ RUN curl -sSfL "https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSI
     && rm cmake.sh
 
 ENV VCPKG_ROOT=/usr/local/vcpkg
-ENV VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 # this must be set on arm. see https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_force_system_binaries
 ENV VCPKG_FORCE_SYSTEM_BINARIES=yes
+ARG VCPKG_BINARY_SOURCES="clear;files,/github/workspace/vcpkg_cache,readwrite"
 
 RUN cd /usr/local \
     && git clone https://github.com/microsoft/vcpkg \

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/entrypoint.sh
@@ -41,11 +41,7 @@ do
     git config --global --add safe.directory ${SAFE}
 done
 
-for CACHE in \
-    /github/workspace/vcpkg_cache/{archives,downloads,installed}
-do
-    mkdir -p ${CACHE}
-done
+mkdir -p /github/workspace/vcpkg_cache
 
 (
     cd "${VCPKG_ROOT}"

--- a/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/entrypoint.sh
+++ b/.github/actions/openziti-tunnel-build-action/ubuntu-22.04/entrypoint.sh
@@ -35,15 +35,23 @@ fi
 for SAFE in \
     /github/workspace \
     /__w/ziti-tunnel-sdk-c/ziti-tunnel-sdk-c \
-    /mnt ; do
-        git config --global --add safe.directory ${SAFE}
+    /mnt \
+    /usr/local/vcpkg
+do
+    git config --global --add safe.directory ${SAFE}
+done
+
+for CACHE in \
+    /github/workspace/vcpkg_cache/{archives,downloads,installed}
+do
+    mkdir -p ${CACHE}
 done
 
 (
-  cd "${VCPKG_ROOT}"
-  git checkout master
-  git pull
-  ./bootstrap-vcpkg.sh -disableMetrics
+    cd "${VCPKG_ROOT}"
+    git checkout master
+    git pull
+    ./bootstrap-vcpkg.sh -disableMetrics
 )
 
 [[ -d ./build ]] && rm -r ./build

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -106,7 +106,7 @@ jobs:
         id: get_vcpkg_cache_key
         shell: bash
         env:
-          KEY_PREFIX: vcpkg_cache-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}
+          KEY_PREFIX: vcpkg_cache-cpack-${{ matrix.arch.rpm }}_${{ matrix.distro.name }}_${{ matrix.distro.version }}
           ACTION_HASH: ${{ hashFiles(format('./.github/actions/openziti-tunnel-build-action/{0}-{1}', matrix.distro.name, matrix.distro.version)) }}
           CONFIG_HASH: ${{ hashFiles('./vcpkg.json') }}
         run: |

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -58,9 +58,7 @@ jobs:
     env:
       ZITI_DEB_TEST_REPO: ${{ vars.ZITI_DEB_TEST_REPO || 'zitipax-openziti-deb-test' }}
       ZITI_RPM_TEST_REPO: ${{ vars.ZITI_RPM_TEST_REPO || 'zitipax-openziti-rpm-test' }}
-      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache/archives,readwrite
-      VCPKG_DOWNLOADS: ${{ github.workspace }}/vcpkg_cache/downloads
-      VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_cache/installed
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
     steps:
       - name: Print Environment Variables and Event JSON
         uses: hmarr/debug-action@v3
@@ -128,9 +126,7 @@ jobs:
         uses: ./.github/actions/openziti-tunnel-build-action
         env:
           # map vcpkg cache in the CPack Docker Action container to the mounted directory used by the rest of the workflow
-          VCPKG_BINARY_SOURCES: clear;files,/github/workspace/vcpkg_cache/archives,readwrite
-          VCPKG_DOWNLOADS: /github/workspace/vcpkg_cache/downloads
-          VCPKG_INSTALLED_DIR: /github/workspace/vcpkg_cache/installed
+          VCPKG_BINARY_SOURCES: clear;files,/github/workspace/vcpkg_cache,readwrite
         with:
           arch: ${{ matrix.arch.cmake }}
           config: RelWithDebInfo

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -107,7 +107,7 @@ jobs:
         shell: bash
         env:
           KEY_PREFIX: vcpkg_cache-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}
-          ACTION_HASH: ${{ hashFiles(format('./.github/actions/openziti-tunnel-build-action/{0}_{1}', matrix.distro.name, matrix.distro.version)) }}
+          ACTION_HASH: ${{ hashFiles(format('./.github/actions/openziti-tunnel-build-action/{0}-{1}', matrix.distro.name, matrix.distro.version)) }}
           CONFIG_HASH: ${{ hashFiles('./vcpkg.json') }}
         run: |
           set -o pipefail

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -112,7 +112,9 @@ jobs:
         run: |
           set -o pipefail
           set -o xtrace
-          echo "key=${KEY_PREFIX}-config_hash-${CONFIG_HASH}-action_hash-${ACTION_HASH}" | tee -a $GITHUB_OUTPUT
+          ACTION_HASH_SHORT=${ACTION_HASH:0:8}
+          CONFIG_HASH_SHORT=${CONFIG_HASH:0:8}
+          echo "key=${KEY_PREFIX}-vcpkg_json=${CONFIG_HASH_SHORT}-build_action=${ACTION_HASH_SHORT}" | tee -a $GITHUB_OUTPUT
 
       - name: Create a Vcpkg Cache with the Defined Key for this Matrix Job
         id: vcpkg_cache

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -39,6 +39,8 @@ jobs:
         id: set_matrix
         shell: bash
         run: |
+          set -o pipefail
+          set -o xtrace
           matrix="$(
             yq --output-format json .github/cpack-matrix.yml \
             | jq --compact-output '.cpack_matrix'
@@ -56,17 +58,21 @@ jobs:
     env:
       ZITI_DEB_TEST_REPO: ${{ vars.ZITI_DEB_TEST_REPO || 'zitipax-openziti-deb-test' }}
       ZITI_RPM_TEST_REPO: ${{ vars.ZITI_RPM_TEST_REPO || 'zitipax-openziti-rpm-test' }}
-      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache/archives,readwrite
+      VCPKG_DOWNLOADS: ${{ github.workspace }}/vcpkg_cache/downloads
+      VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_cache/installed
     steps:
-      - name: Debug action
+      - name: Print Environment Variables and Event JSON
         uses: hmarr/debug-action@v3
 
       # only focal-20.04 has >= 2.18, which is required by actions/checkout to clone
       # which enables cmake version discovery
-      - name: install contemporary Git in runner container if Ubuntu
+      - name: Install contemporary Git in runner container if Ubuntu
         if: ${{ matrix.distro.name == 'ubuntu' }}
         shell: bash
         run: |
+          set -o pipefail
+          set -o xtrace
           apt-get update
           apt-get install --yes software-properties-common
           add-apt-repository --yes ppa:git-core/ppa
@@ -74,113 +80,134 @@ jobs:
           apt-get install --yes git
           git --version
 
-      - name: install contemporary Git in runner container if RedHat 8 or 9
-        if: ${{ matrix.distro.name == 'redhat' && (matrix.distro.version == '8' || matrix.distro.version == '9') }}
+      - name: Install contemporary Git in runner container if RedHat
+        if: ${{ matrix.distro.name == 'redhat' }}
         shell: bash
         run: |
+          set -o pipefail
+          set -o xtrace
           dnf -y update
           dnf -y install git findutils
           git --version
 
-      - name: checkout workspace
+      - name: Checkout Workspace
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: configure build action for distro version
+      - name: Install the CPack Docker Action for this Matrix Job (name-version)
         env:
           DISTRO_LABEL: ${{ format('{0}-{1}', matrix.distro.name, matrix.distro.version) }}
         shell: bash
         run: |
+          set -o pipefail
+          set -o xtrace
           cp -vr ./.github/actions/openziti-tunnel-build-action/${DISTRO_LABEL}/* ./.github/actions/openziti-tunnel-build-action/
 
-      - name: get vcpkg cache key
+      - name: Define a Vcpkg Cache Key for the CPack Docker Action
         id: get_vcpkg_cache_key
         shell: bash
         env:
-          DISTRO_LABEL: ${{ format('{0}-{1}', matrix.distro.name, matrix.distro.version) }}
           KEY_PREFIX: vcpkg_cache-cpack-${{ matrix.arch.rpm }}-${{ matrix.distro.name }}-${{ matrix.distro.version }}
+          ACTION_HASH: ${{ hashFiles(format('./.github/actions/openziti-tunnel-build-action/{0}_{1}', matrix.distro.name, matrix.distro.version)) }}
+          CONFIG_HASH: ${{ hashFiles('./vcpkg.json') }}
         run: |
-          key_prefix="${KEY_PREFIX}-vcpkg_json_md5=$(md5sum ./vcpkg.json | awk '{ print $1 }')"
-          # Express the vcpkg overlays, dockerfile, and entry point that the action will use as a single hash
-          build_action_md5="$(find ./.github/actions/openziti-tunnel-build-action/${DISTRO_LABEL} -type f -print | xargs md5sum | awk '{ print $1 }' | sort | md5sum | awk '{ print $1 }')"
-          echo "key=${key_prefix}-build_action_md5=${build_action_md5}" | tee -a $GITHUB_OUTPUT
+          set -o pipefail
+          set -o xtrace
+          echo "key=${KEY_PREFIX}-config_hash-${CONFIG_HASH}-action_hash-${ACTION_HASH}" | tee -a $GITHUB_OUTPUT
 
-      - uses: actions/cache@v4
+      - name: Create a Vcpkg Cache with the Defined Key for this Matrix Job
+        id: vcpkg_cache
+        uses: actions/cache@v4
         with:
           key: ${{ steps.get_vcpkg_cache_key.outputs.key }}
           path: ./vcpkg_cache
 
         # entrypoint.sh uses the value of arch to select the cmake preset
-      - name: build binary and package
+      - name: Run the CPack Docker Action to Build the Binary & Linux Package
         uses: ./.github/actions/openziti-tunnel-build-action
         env:
-          # map vcpkg cache so container uses the same directory as the rest of the workflow
-          "VCPKG_BINARY_SOURCES": "clear;files,/github/workspace/vcpkg_cache,readwrite"
+          # map vcpkg cache in the CPack Docker Action container to the mounted directory used by the rest of the workflow
+          VCPKG_BINARY_SOURCES: clear;files,/github/workspace/vcpkg_cache/archives,readwrite
+          VCPKG_DOWNLOADS: /github/workspace/vcpkg_cache/downloads
+          VCPKG_INSTALLED_DIR: /github/workspace/vcpkg_cache/installed
         with:
           arch: ${{ matrix.arch.cmake }}
           config: RelWithDebInfo
 
-      - name: list artifacts
+      - name: Debug Build Environment
         shell: bash
         run: |
-          set -x
+          set -o pipefail
+          set -o xtrace
+          if [[ "${{ steps.vcpkg_cache.outputs.cache-hit }}" == "true" ]]; then
+            echo "::notice::Vcpkg Cache HIT - used cached dependencies"
+          else
+            echo "::warning::Vcpkg Cache MISS - dependencies rebuilt"
+          fi
           cat /etc/*-release
           ls -horAS ./build/*.${{ matrix.distro.type }}
           ls -horAS ./build/programs/ziti-edge-tunnel/RelWithDebInfo/ziti-edge-tunnel
 
-      - name: install package artifact in runner container if Ubuntu x86_64
+      - name: Test Installing the DEB Package
         if: ${{ matrix.arch.cmake == 'ci-linux-x64' && matrix.distro.name == 'ubuntu' }}
         env:
           DEBIAN_FRONTEND: noninteractive
         shell: bash
         run: |
-          set -x
+          set -o pipefail
+          set -o xtrace
           apt-get -y install ./build/ziti-edge-tunnel-*.deb
 
-      - name: install package artifact in runner container if RedHat
+      - name: Test Installing the RPM Package
         if: ${{ matrix.arch.cmake == 'ci-linux-x64' && matrix.distro.name == 'redhat' }}
         shell: bash
         run: |
-          set -x
+          set -o pipefail
+          set -o xtrace
           yum -y install ./build/ziti-edge-tunnel-*.rpm
 
-      - name: run binary artifact
+      - name: Test Running the Binary
         if: ${{ matrix.arch.cmake == 'ci-linux-x64' }}
         shell: bash
         run: |
-          set -x
+          set -o pipefail
+          set -o xtrace
           cat /etc/*-release
           ldd ./build/programs/ziti-edge-tunnel/RelWithDebInfo/ziti-edge-tunnel
           ./build/programs/ziti-edge-tunnel/RelWithDebInfo/ziti-edge-tunnel version --verbose
 
-      - name: Upload Package to Workflow Summary Page
+      - name: Upload the Linux Package
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.distro.name }}-${{ matrix.distro.version }}-${{ matrix.arch.rpm }}-${{ matrix.distro.type }}
           path: ./build/ziti-edge-tunnel-*.${{ matrix.distro.type }}
           if-no-files-found: error
 
-      - name: Configure jFrog CLI
-        if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') }}
+      - name: Install jFrog CLI
+        if: ${{ github.event_name == 'release' && startsWith(github.ref_name, 'v') }}
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_ENV_1: ${{ secrets.ZITI_ARTIFACTORY_CLI_CONFIG_PACKAGE_UPLOAD }}
 
-      - name: Upload RPM to Artifactory with jFrog CLI
-        if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') && matrix.distro.name == 'redhat' }}
+      - name: Upload RPM to Artifactory
+        if: ${{ github.event_name == 'release' && startsWith(github.ref_name, 'v') && matrix.distro.name == 'redhat' }}
         shell: bash
         run: >
+          set -o pipefail;
+          set -o xtrace;
           jf rt upload
           ./build/ziti-edge-tunnel-*.${{ matrix.distro.type }}
           ${{ env.ZITI_RPM_TEST_REPO }}/redhat${{ matrix.distro.version }}/${{ matrix.arch.rpm }}/
           --recursive=false
           --flat=true 
 
-      - name: Upload DEB to Artifactory with jFrog CLI
-        if: ${{ github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') && matrix.distro.name == 'ubuntu' }}
+      - name: Upload DEB to Artifactory
+        if: ${{ github.event_name == 'release' && startsWith(github.ref_name, 'v') && matrix.distro.name == 'ubuntu' }}
         shell: bash
         run: >
+          set -o pipefail;
+          set -o xtrace;
           jf rt upload
           ./build/ziti-edge-tunnel-*.${{ matrix.distro.type }}
           ${{ env.ZITI_DEB_TEST_REPO }}/pool/ziti-edge-tunnel/${{ matrix.distro.release_name }}/${{ matrix.arch.deb }}/

--- a/.github/workflows/promote-downstreams.yml
+++ b/.github/workflows/promote-downstreams.yml
@@ -41,6 +41,8 @@ jobs:
         id: parse
         shell: bash
         run: |
+          set -o pipefail
+          set -o xtrace
           if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "GITHUB_REF_NAME=${GITHUB_REF_NAME} is a semver release ref"
             echo "version=${GITHUB_REF_NAME#v}" | tee -a $GITHUB_OUTPUT
@@ -64,6 +66,8 @@ jobs:
         id: set_matrix
         shell: bash
         run: |
+          set -o pipefail
+          set -o xtrace
           matrix="$(
             yq --output-format json .github/cpack-matrix.yml \
             | jq --compact-output '.cpack_matrix'
@@ -87,6 +91,8 @@ jobs:
       - name: Tag Latest ziti-edge-tunnel 
         shell: bash
         run: >
+          set -o pipefail;
+          set -o xtrace;
           docker buildx imagetools create --tag
           ${{ env.ZITI_EDGE_TUNNEL_IMAGE }}:latest
           ${{ env.ZITI_EDGE_TUNNEL_IMAGE }}:${{ needs.parse_version.outputs.version }}
@@ -94,6 +100,8 @@ jobs:
       - name: Tag Latest ziti-host
         shell: bash
         run: >
+          set -o pipefail;
+          set -o xtrace;
           docker buildx imagetools create --tag
           ${{ env.ZITI_HOST_IMAGE }}:latest
           ${{ env.ZITI_HOST_IMAGE }}:${{ needs.parse_version.outputs.version }}
@@ -122,6 +130,8 @@ jobs:
         if: matrix.distro.type == 'rpm'
         shell: bash
         run: >
+          set -o pipefail;
+          set -o xtrace;
           jf rt copy
           --recursive=false
           --flat=true
@@ -133,6 +143,8 @@ jobs:
         if: matrix.distro.type == 'deb'
         shell: bash
         run: >
+          set -o pipefail;
+          set -o xtrace;
           jf rt copy
           --recursive=false
           --flat=true

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ compile_commands.json
 
 .run
 CMakeFiles/
+/vcpkg_cache/


### PR DESCRIPTION
the redhat9 builder encountered an issue, possibly surfaced by yesterday's github platform widespread outage, so I audited the workflow and [added a redhat10 distribution](https://github.com/openziti/ziti-tunnel-sdk-c/pull/1184).

```
36.54 Error:                                                                                                                                                                                                                                             
36.54  Problem 1: cannot install the best candidate for the job                                                                                                                                                                                          
36.54   - nothing provides glibc = 2.34-168.el9_6.19 needed by glibc-devel-2.34-168.el9_6.19.x86_64 from appstream                                                                                                                                       
36.54  Problem 2: package gcc-11.5.0-5.el9_5.x86_64 from appstream requires glibc-devel >= 2.2.90-12, but none of the providers can be installed                                                                                                        
36.54   - conflicting requests                                                                                                                                                                                                                           
36.54   - nothing provides glibc = 2.34-168.el9_6.19 needed by glibc-devel-2.34-168.el9_6.19.i686 from appstream                                                                                                                                         
36.54   - nothing provides glibc = 2.34-168.el9_6.19 needed by glibc-devel-2.34-168.el9_6.19.x86_64 from appstream                                                                                                                                       
36.54  Problem 3: package gcc-c++-11.5.0-5.el9_5.x86_64 from appstream requires gcc = 11.5.0-5.el9_5, but none of the providers can be installed                                                                                                        
36.54   - package gcc-11.5.0-5.el9_5.x86_64 from appstream requires glibc-devel >= 2.2.90-12, but none of the providers can be installed                                                                                                                 
36.54   - conflicting requests                                                                                                                                                                                                                           
36.54   - nothing provides glibc = 2.34-168.el9_6.19 needed by glibc-devel-2.34-168.el9_6.19.i686 from appstream                                                                                                                                         
36.54   - nothing provides glibc = 2.34-168.el9_6.19 needed by glibc-devel-2.34-168.el9_6.19.x86_64 from appstream                                                                                                                                       
36.54  Problem 4: package libtool-2.4.6-46.el9.x86_64 from appstream requires gcc(major) = 11, but none of the providers can be installed                                                                                                                
36.54   - package gcc-11.5.0-5.el9_5.x86_64 from appstream requires glibc-devel >= 2.2.90-12, but none of the providers can be installed                                                                                                                 
36.54   - conflicting requests                                                                                                                                                                                                                           
36.54   - nothing provides glibc = 2.34-168.el9_6.19 needed by glibc-devel-2.34-168.el9_6.19.i686 from appstream                                                                                                                                         
36.54   - nothing provides glibc = 2.34-168.el9_6.19 needed by glibc-devel-2.34-168.el9_6.19.x86_64 from appstream                                                                                                                                       
36.54  Problem 5: package systemtap-5.2-2.el9.x86_64 from appstream requires systemtap-devel = 5.2-2.el9, but none of the providers can be installed
36.54   - package systemtap-devel-5.2-2.el9.i686 from appstream requires gcc, but none of the providers can be installed
36.54   - package systemtap-devel-5.2-2.el9.x86_64 from appstream requires gcc, but none of the providers can be installed
36.54   - package gcc-11.5.0-5.el9_5.x86_64 from appstream requires glibc-devel >= 2.2.90-12, but none of the providers can be installed
36.54   - conflicting requests                 
36.54   - nothing provides glibc = 2.34-168.el9_6.19 needed by glibc-devel-2.34-168.el9_6.19.i686 from appstream
36.54   - nothing provides glibc = 2.34-168.el9_6.19 needed by glibc-devel-2.34-168.el9_6.19.x86_64 from appstream
36.54 (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```