### PR TITLE
update ziti-sdk@1.7.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 
 set(ZITI_SDK_DIR "" CACHE FILEPATH "developer option: use local ziti-sdk-c checkout")
-set(ZITI_SDK_VERSION "1.7.9" CACHE STRING "ziti-sdk-c version or branch to use")
+set(ZITI_SDK_VERSION "1.7.10" CACHE STRING "ziti-sdk-c version or branch to use")
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)


### PR DESCRIPTION
tlsuv: https://github.com/openziti/tlsuv/compare/v0.37.1...v0.37.2

fixes crash for disconnect during TLS handshake