### PR TITLE
update vcpkg@2025.10.17

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -28,5 +28,5 @@
       ]
     }
   },
-  "builtin-baseline": "4334d8b4c8916018600212ab4dd4bbdc343065d1"
+  "builtin-baseline": "74e6536215718009aae747d86d84b78376bf9e09"
 }


### PR DESCRIPTION
| dependency | vcpkg@2025.08.27 version | vcpkg 2025.10.17 version (if changed) |
|-------------|-----------------------------|--------------------------|
| catch2 | 3.10.0 | 3.11.0 |
| json-c | 0.18-20240915 | |
| libsodium | 1.0.20#3 | |
| libuv | 1.51.0 | |
| llhttp | 9.2.1 | |
| openssl | 3.5.2 | 3.6.0#2 |
| protobuf | 5.29.5#1 | 5.29.5#2 |
| protobuf-c | 1.5.2 | |
| zlib |1.3.1 |
