### PR TITLE
base container images on rhel9 to keep supporting truenas, etc. with x86-64-v2 microarchitecture; resolves #1221

### DIFF
--- a/docker/ziti-edge-tunnel.Dockerfile
+++ b/docker/ziti-edge-tunnel.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 ARG ARTIFACTS_DIR=./build
 ARG DOCKER_BUILD_DIR=.


### PR DESCRIPTION
resolves #1221