### PR TITLE
don't write inbound l2 frames back to the interface

### DIFF
--- a/lib/ziti-tunnel/tunnel_l2.c
+++ b/lib/ziti-tunnel/tunnel_l2.c
@@ -1,4 +1,4 @@
-// Copyright 2026 NetFoundry Inc.
+// Copyright NetFoundry Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,11 +14,8 @@
 
 
 #include "tunnel_l2.h"
-#include "netif_shim.h"
 #include "ziti_tunnel_priv.h"
 #include "lwip/prot/ethernet.h"
-
-#include <string.h>
 
 static model_map l2_conns = {};
 
@@ -61,19 +58,7 @@ ssize_t tunneler_l2_write(struct netif *netif, const void *data, size_t len) {
             pbuf_free(p);
             return -1;
         }
-        /* Rewrite the Ethernet source MAC to this interface's own hardware
-         * address.  Hypervisor virtual switches (e.g. Parallels, VMware) may
-         * enforce that the source MAC of every transmitted frame matches the
-         * MAC registered for the sending VM's NIC and silently drop frames
-         * with a foreign source MAC.  The original source MAC in the frame
-         * belongs to the intercepting client, which is unknown to the hosting
-         * VM's virtual switch, so those frames are dropped after
-         * pcap_sendpacket (visible in tcpdump but never transmitted).
-         * Rewriting to the hosting interface's own MAC satisfies the filter. */
-        if (netif->hwaddr_len >= 6 && len >= 14 && p->len >= 12) {
-            struct eth_hdr *eth = (struct eth_hdr *)p->payload;
-            memcpy(eth->src.addr, netif->hwaddr, 6);
-        }
+        /* acknowledge that packet has been read(); */
     } else {
         /* drop packet(); */
         if (log_pbuf_errors) {

--- a/programs/ziti-edge-tunnel/netif_driver/linux/pcap.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/pcap.c
@@ -60,6 +60,10 @@ typedef int     (*fn_pcap_sendpacket_t)(pcap_t *p, const u_char *buf, int size);
 typedef char   *(*fn_pcap_geterr_t)(pcap_t *p);
 typedef void    (*fn_pcap_close_t)(pcap_t *p);
 typedef void    (*fn_pcap_breakloop_t)(pcap_t *p);
+typedef int     (*fn_pcap_compile_t)(pcap_t *p, struct bpf_program *fp,
+                                      const char *str, int optimize, bpf_u_int32 netmask);
+typedef int     (*fn_pcap_setfilter_t)(pcap_t *p, struct bpf_program *fp);
+typedef void    (*fn_pcap_freecode_t)(struct bpf_program *fp);
 
 static fn_pcap_open_live_t   dyn_pcap_open_live;
 static fn_pcap_next_ex_t     dyn_pcap_next_ex;
@@ -67,6 +71,9 @@ static fn_pcap_sendpacket_t  dyn_pcap_sendpacket;
 static fn_pcap_geterr_t      dyn_pcap_geterr;
 static fn_pcap_close_t       dyn_pcap_close;
 static fn_pcap_breakloop_t   dyn_pcap_breakloop;
+static fn_pcap_compile_t     dyn_pcap_compile;
+static fn_pcap_setfilter_t   dyn_pcap_setfilter;
+static fn_pcap_freecode_t    dyn_pcap_freecode;
 
 /* -------------------------------------------------------------------------
  * Load libpcap.so at runtime and resolve all function pointers.
@@ -106,6 +113,9 @@ static int load_libpcap(char *error, size_t errlen)
     RESOLVE(pcap_geterr);
     RESOLVE(pcap_close);
     RESOLVE(pcap_breakloop);
+    RESOLVE(pcap_compile);
+    RESOLVE(pcap_setfilter);
+    RESOLVE(pcap_freecode);
 #undef RESOLVE
 
     return 0;
@@ -148,6 +158,22 @@ static void read_hwaddr_linux(const char *ifname, uint8_t hwaddr[6], uint8_t *hw
  * Thin wrappers that adapt the dynamically-loaded libpcap function pointers
  * to the platform-neutral pcap_ops_t interface expected by pcap_common.c.
  * ---------------------------------------------------------------------- */
+static int lnx_set_filter(void *p, const char *expr)
+{
+    struct bpf_program bpf;
+    if (dyn_pcap_compile((pcap_t *)p, &bpf, expr, 1, PCAP_NETMASK_UNKNOWN) != 0) {
+        ZITI_LOG(WARN, "pcap: pcap_compile(\"%s\") failed: %s",
+                 expr, dyn_pcap_geterr((pcap_t *)p));
+        return -1;
+    }
+    int rc = dyn_pcap_setfilter((pcap_t *)p, &bpf);
+    if (rc != 0) {
+        ZITI_LOG(WARN, "pcap: pcap_setfilter failed: %s", dyn_pcap_geterr((pcap_t *)p));
+    }
+    dyn_pcap_freecode(&bpf);
+    return rc;
+}
+
 static int lnx_next_packet(void *p, uint32_t *caplen, const unsigned char **data)
 {
     struct pcap_pkthdr *hdr = NULL;
@@ -204,6 +230,7 @@ netif_driver ziti_pcap_open(uv_loop_t *loop, const char *ifname,
         .get_error    = lnx_get_error,
         .do_breakloop = lnx_do_breakloop,
         .do_close     = lnx_do_close,
+        .set_filter   = lnx_set_filter,
     };
 
     return ziti_pcap_build_driver(ifname, &ops, hwaddr, hwaddr_len, error, error_len);

--- a/programs/ziti-edge-tunnel/netif_driver/pcap_common.c
+++ b/programs/ziti-edge-tunnel/netif_driver/pcap_common.c
@@ -212,6 +212,12 @@ netif_driver ziti_pcap_build_driver(const char     *ifname,
     strncpy(h->name, ifname, sizeof(h->name) - 1);
     h->ops = *ops;
 
+    if (h->ops.set_filter) {
+        if (h->ops.set_filter(h->ops.pcap, "inbound") != 0) {
+            ZITI_LOG(WARN, "pcap: could not apply 'inbound' capture filter on '%s'", ifname);
+        }
+    }
+
     uv_mutex_init(&h->frame_lock);
 
     struct netif_driver_s *driver = calloc(1, sizeof(*driver));

--- a/programs/ziti-edge-tunnel/netif_driver/pcap_common.h
+++ b/programs/ziti-edge-tunnel/netif_driver/pcap_common.h
@@ -72,6 +72,12 @@ typedef struct pcap_ops_s {
 
     /* Release the pcap handle.  Called after do_breakloop + thread join. */
     void  (*do_close)   (void *pcap);
+
+    /* Optional: install a BPF capture filter expression on the pcap handle.
+     * Called once by ziti_pcap_build_driver before the reader thread starts.
+     * NULL means the platform does not support BPF filter installation.
+     * Returns 0 on success, -1 on failure (non-fatal; capture continues). */
+    int   (*set_filter) (void *pcap, const char *expr);
 } pcap_ops_t;
 
 /* -------------------------------------------------------------------------

--- a/programs/ziti-edge-tunnel/netif_driver/windows/pcap.c
+++ b/programs/ziti-edge-tunnel/netif_driver/windows/pcap.c
@@ -49,6 +49,8 @@
 #define MAX_FRAME_LEN       65536u
 #define PCAP_READ_TIMEOUT_MS 500
 #define PCAP_ERRBUF_SIZE    256
+#define ETH_ALEN            6
+#define MAX_LOCAL_MACS      64
 
 /* -------------------------------------------------------------------------
  * Minimal pcap types (avoids dependency on pcap.h / Npcap SDK)
@@ -212,27 +214,81 @@ static void read_hwaddr(const char *ifname, uint8_t hwaddr[6], uint8_t *hwaddr_l
 }
 
 /* -------------------------------------------------------------------------
+ * win_pcap_ctx_t: Windows-specific context stored in ops.pcap.
+ *
+ * Tracks the source MACs of received frames so that win_next_packet can
+ * drop inbound frames whose destination MAC matches one of those entries.
+ * This discards frames addressed to virtual MACs the tunnel stack owns
+ * (i.e. frames that would loop back through the tunneler).
+ *
+ * local_macs is written and read only from the reader thread, so no locking
+ * is required.
+ * ---------------------------------------------------------------------- */
+typedef struct {
+    pcap_t  *pcap;
+    uint8_t  local_macs[MAX_LOCAL_MACS][ETH_ALEN];
+    int      n_local_macs;
+} win_pcap_ctx_t;
+
+static void win_track_local_mac(win_pcap_ctx_t *ctx, const uint8_t *mac)
+{
+    for (int i = 0; i < ctx->n_local_macs; i++) {
+        if (memcmp(ctx->local_macs[i], mac, ETH_ALEN) == 0) return;
+    }
+    if (ctx->n_local_macs >= MAX_LOCAL_MACS) {
+        ZITI_LOG(WARN, "pcap: local MAC table full, not tracking "
+                 "%02x:%02x:%02x:%02x:%02x:%02x",
+                 mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+        return;
+    }
+    memcpy(ctx->local_macs[ctx->n_local_macs++], mac, ETH_ALEN);
+    ZITI_LOG(DEBUG, "pcap: tracking local src mac %02x:%02x:%02x:%02x:%02x:%02x",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+/* -------------------------------------------------------------------------
  * pcap_ops_t wrapper functions
  *
  * Thin wrappers that adapt the dynamically-loaded Npcap function pointers
  * to the platform-neutral pcap_ops_t interface expected by pcap_common.c.
+ * The ops.pcap field carries a win_pcap_ctx_t * (not a raw pcap_t *).
  * ---------------------------------------------------------------------- */
 static int win_next_packet(void *p, uint32_t *caplen, const unsigned char **data)
 {
+    win_pcap_ctx_t *ctx = (win_pcap_ctx_t *)p;
     struct pcap_pkthdr *hdr = NULL;
-    int rc = dyn_pcap_next_ex((pcap_t *)p, &hdr, data);
-    if (rc == 1 && hdr) *caplen = hdr->caplen;
+    int rc = dyn_pcap_next_ex(ctx->pcap, &hdr, data);
+    if (rc == 1 && hdr) {
+        *caplen = hdr->caplen;
+        if (*caplen >= 12) {
+            const uint8_t *dst = *data;
+            const uint8_t *src = dst + ETH_ALEN;
+            for (int i = 0; i < ctx->n_local_macs; i++) {
+                if (memcmp(ctx->local_macs[i], dst, ETH_ALEN) == 0) {
+                    return 0; /* discard; caller treats 0 as timeout and retries */
+                }
+            }
+            // contingency for "inbound" filter not working: track src address of inbound frames.
+            // any frames that we see going to one of these addresses is not for us
+            win_track_local_mac(ctx, src);
+        }
+    }
     return rc;
 }
 
 static int win_send_packet(void *p, const unsigned char *buf, int size)
 {
-    return dyn_pcap_sendpacket((pcap_t *)p, buf, size);
+    return dyn_pcap_sendpacket(((win_pcap_ctx_t *)p)->pcap, buf, size);
 }
 
-static char *win_get_error(void *p)   { return dyn_pcap_geterr((pcap_t *)p); }
-static void  win_do_breakloop(void *p){ dyn_pcap_breakloop((pcap_t *)p); }
-static void  win_do_close(void *p)    { dyn_pcap_close((pcap_t *)p); }
+static char *win_get_error(void *p)    { return dyn_pcap_geterr(((win_pcap_ctx_t *)p)->pcap); }
+static void  win_do_breakloop(void *p) { dyn_pcap_breakloop(((win_pcap_ctx_t *)p)->pcap); }
+static void  win_do_close(void *p)
+{
+    win_pcap_ctx_t *ctx = (win_pcap_ctx_t *)p;
+    dyn_pcap_close(ctx->pcap);
+    free(ctx);
+}
 
 /* -------------------------------------------------------------------------
  * ziti_pcap_open
@@ -277,8 +333,16 @@ netif_driver ziti_pcap_open(uv_loop_t *loop, const char *ifname,
         ZITI_LOG(WARN, "pcap: could not read hwaddr for '%s' -- L2 may not work", ifname);
     }
 
+    win_pcap_ctx_t *ctx = calloc(1, sizeof(*ctx));
+    if (!ctx) {
+        snprintf(error, error_len, "pcap: out of memory allocating context");
+        dyn_pcap_close(pcap);
+        return NULL;
+    }
+    ctx->pcap = pcap;
+
     pcap_ops_t ops = {
-        .pcap         = pcap,
+        .pcap         = ctx,
         .next_packet  = win_next_packet,
         .send_packet  = win_send_packet,
         .get_error    = win_get_error,

--- a/tools/dcp/dcp_identify.c
+++ b/tools/dcp/dcp_identify.c
@@ -71,17 +71,17 @@ static int parse_ip_arg(const char *s, uint8_t ip[4], uint8_t mask[4], uint8_t g
 
 /* ---------- identify response ---------- */
 
-static void parse_ident_response(const uint8_t *buf, int len)
+static int parse_ident_response(const uint8_t *buf, int len)
 {
-    if (len < (int)(sizeof(eth_hdr_t) + sizeof(dcp_hdr_t))) return;
+    if (len < (int)(sizeof(eth_hdr_t) + sizeof(dcp_hdr_t))) return 0;
 
     const eth_hdr_t *eth = (const eth_hdr_t *)buf;
     const dcp_hdr_t *dcp = (const dcp_hdr_t *)(buf + sizeof(eth_hdr_t));
 
-    if (DCP_NTOHS(eth->ethertype) != ETH_P_PROFINET)         return;
-    if (DCP_NTOHS(dcp->frame_id)  != DCP_FRAME_ID_IDENT_RSP) return;
-    if (dcp->service_id   != DCP_SVC_IDENTIFY)                return;
-    if (dcp->service_type != DCP_SVCTYPE_RESPONSE)            return;
+    if (DCP_NTOHS(eth->ethertype) != ETH_P_PROFINET)         return 0;
+    if (DCP_NTOHS(dcp->frame_id)  != DCP_FRAME_ID_IDENT_RSP) return 0;
+    if (dcp->service_id   != DCP_SVC_IDENTIFY)                return 0;
+    if (dcp->service_type != DCP_SVCTYPE_RESPONSE)            return 0;
 
     printf("  device ");
     print_mac(eth->src);
@@ -115,6 +115,8 @@ static void parse_ident_response(const uint8_t *buf, int len)
     /* record this device for the SET phase */
     if (g_found_count < MAX_DEVICES)
         memcpy(g_found_macs[g_found_count++], eth->src, 6);
+
+    return 1;
 }
 
 /* ---------- set phase ---------- */
@@ -318,7 +320,7 @@ int main(int argc, char *argv[])
         int n = rawsock_recv(rs, buf, sizeof(buf), timeout_remaining);
         if (n == 0) break;
         if (n < 0)  break;
-        parse_ident_response(buf, n);
+        if (parse_ident_response(buf, n) > 0) break;
         timeout_remaining -= 10;
         if (timeout_remaining <= 0) break;
     }


### PR DESCRIPTION
add "inbound" bpf filter on pcap interfaces to prevent reflected frames.