### PR TITLE
update vcpkg@2026.03.18

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -86,7 +86,8 @@
       "cacheVariables": {
         "CMAKE_C_COMPILER": "gcc",
         "CMAKE_CXX_COMPILER": "g++",
-        "CMAKE_EXE_LINKER_FLAGS": "-Wl,-Bstatic -lpthread"
+        "CMAKE_EXE_LINKER_FLAGS": "-Wl,-Bstatic -lpthread",
+        "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-overlays/libuv-fix-windows-errors"
       }
     },
 

--- a/vcpkg-overlays/libuv-fix-windows-errors/fix-build-type.patch
+++ b/vcpkg-overlays/libuv-fix-windows-errors/fix-build-type.patch
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5e8e016..b3c3f18 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -465,7 +465,7 @@ if(LIBUV_BUILD_SHARED)
+   endif()
+   target_link_libraries(uv ${uv_libraries})
+   set_target_properties(uv PROPERTIES OUTPUT_NAME "uv")
+-endif()
++else()
+ 
+ add_library(uv_a STATIC ${uv_sources})
+ target_compile_definitions(uv_a PRIVATE ${uv_defines})
+@@ -485,6 +485,7 @@ set_target_properties(uv_a PROPERTIES OUTPUT_NAME "uv")
+ if(WIN32)
+   set_target_properties(uv_a PROPERTIES PREFIX "lib")
+ endif()
++endif()
+ 
+ if(LIBUV_BUILD_TESTS)
+   # Small hack: use ${uv_test_sources} now to get the runner skeleton,
+@@ -755,10 +756,6 @@ configure_file(libuv-static.pc.in libuv-static.pc @ONLY)
+ install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+ install(FILES LICENSE-extra DESTINATION ${CMAKE_INSTALL_DOCDIR})
+-install(FILES ${PROJECT_BINARY_DIR}/libuv-static.pc
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+-install(TARGETS uv_a EXPORT libuvConfig
+-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install(EXPORT libuvConfig
+ 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv
+ 	NAMESPACE libuv::)
+@@ -775,6 +772,11 @@ if(LIBUV_BUILD_SHARED)
+           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++else()
++install(FILES ${PROJECT_BINARY_DIR}/libuv-static.pc
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
++install(TARGETS uv_a EXPORT libuvConfig
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()
+ 
+ if(MSVC)

--- a/vcpkg-overlays/libuv-fix-windows-errors/fix-windows-errors.patch
+++ b/vcpkg-overlays/libuv-fix-windows-errors/fix-windows-errors.patch
@@ -1,0 +1,38 @@
+diff --git a/src/win/util.c b/src/win/util.c
+index fec07b26..d3a3836f 100644
+--- a/src/win/util.c
++++ b/src/win/util.c
+@@ -508,8 +508,8 @@ int uv_uptime(double* uptime) {
+ unsigned int uv_available_parallelism(void) {
+   DWORD_PTR procmask;
+   DWORD_PTR sysmask;
+-  unsigned count;
+-  unsigned i;
++  int count;
++  unsigned int i;
+ 
+   /* TODO(bnoordhuis) Use GetLogicalProcessorInformationEx() to support systems
+    * with > 64 CPUs? See https://github.com/libuv/libuv/pull/3458
+@@ -627,7 +627,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
+ 
+     uv__convert_utf16_to_utf8(cpu_brand,
+                               cpu_brand_size / sizeof(WCHAR),
+-                              &(cpu_info->model));
++                              (char**) &(cpu_info->model));
+   }
+ 
+   uv__free(sppi);
+@@ -639,12 +639,8 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
+ 
+  error:
+   if (cpu_infos != NULL) {
+-    /* This is safe because the cpu_infos array is zeroed on allocation. */
+-    for (i = 0; i < cpu_count; i++)
+-      uv__free(cpu_infos[i].model);
++    uv_free_cpu_info(cpu_infos, cpu_count);
+   }
+-
+-  uv__free(cpu_infos);
+   uv__free(sppi);
+ 
+   return uv_translate_sys_error(err);

--- a/vcpkg-overlays/libuv-fix-windows-errors/portfile.cmake
+++ b/vcpkg-overlays/libuv-fix-windows-errors/portfile.cmake
@@ -1,0 +1,41 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libuv/libuv
+    REF "v${VERSION}"
+    SHA512 c23bb26f8fdcf678dbf14bcee9855830927a40b8ae64dfa287ef1e910f37ad30cb868ecdeaad6f7b2bf3f3fccca1a7282a31b22c547206b672f923d0651f5b0c
+    HEAD_REF v1.x
+    PATCHES
+        fix-build-type.patch
+        ssize_t.patch
+        fix-windows-errors.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIBUV_BUILD_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLIBUV_BUILD_TESTS=OFF
+        -DLIBUV_BUILD_BENCH=OFF
+        -DLIBUV_BUILD_SHARED=${LIBUV_BUILD_SHARED}
+        -DQEMU=OFF
+        -DASAN=OFF
+        -DTSAN=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libuv)
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/uv.h" "defined(USING_UV_SHARED)" "1")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/uv.h" "defined(USING_UV_SHARED)" "0")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-overlays/libuv-fix-windows-errors/ssize_t.patch
+++ b/vcpkg-overlays/libuv-fix-windows-errors/ssize_t.patch
@@ -1,0 +1,14 @@
+diff --git a/include/uv/win.h b/include/uv/win.h
+index 12ac53b4..6e1abd5b 100644
+--- a/include/uv/win.h
++++ b/include/uv/win.h
+@@ -24,7 +24,9 @@
+ #endif
+ 
+ #if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
++# ifndef ssize_t
+ typedef intptr_t ssize_t;
++# endif
+ # define SSIZE_MAX INTPTR_MAX
+ # define _SSIZE_T_
+ # define _SSIZE_T_DEFINED

--- a/vcpkg-overlays/libuv-fix-windows-errors/usage
+++ b/vcpkg-overlays/libuv-fix-windows-errors/usage
@@ -1,0 +1,4 @@
+libuv provides CMake targets:
+
+    find_package(libuv CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>)

--- a/vcpkg-overlays/libuv-fix-windows-errors/vcpkg.json
+++ b/vcpkg-overlays/libuv-fix-windows-errors/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libuv",
+  "version-semver": "1.52.1",
+  "description": "libuv is a multi-platform support library with a focus on asynchronous I/O.",
+  "homepage": "https://github.com/libuv/libuv",
+  "license": "BSD-3-Clause",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -36,6 +36,11 @@
       "version": "1.0.20",
       "port-version": 3,
       "$comment": "1.0.21 breaks on linux-arm64 so we're sticking with 1.0.20 until the fix is released and available in vcpkg"
+    },
+    {
+      "name": "abseil",
+      "version": "20250814.1",
+      "$comment": "20260107.1 breaks on several compilers so we're sticking with 20250814.1 until a buildable version is available in vcpkg"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -29,13 +29,13 @@
       ]
     }
   },
-  "builtin-baseline": "62159a45e18f3a9ac0548628dcaf74fcb60c6ff9",
+  "builtin-baseline": "c3867e714dd3a51c272826eea77267876517ed99",
   "overrides": [
     {
       "name": "libsodium",
       "version": "1.0.20",
       "port-version": 3,
-      "$comment": "1.0.21 breaks on linux-arm64 so we're sticking with 1.0.20 until the fix released and available in vcpkg"
+      "$comment": "1.0.21 breaks on linux-arm64 so we're sticking with 1.0.20 until the fix is released and available in vcpkg"
     }
   ]
 }


### PR DESCRIPTION
| dependency | vcpkg@2026.02.27 version | vcpkg 2026.03.18 version (if changed) |
|-------------|-----------------------------|--------------------------|
| abseil |20250814.1 | see note |
| catch2 | 3.13.0#1 |  |
| json-c | 0.18-20240915 | |
| libsodium | 1.0.21 | see note |
| libuv | 1.52.0 | 1.52.1 |
| llhttp | 9.3.1 |  |
| openssl | 3.6.1#2 | 3.6.1#3 |
| protobuf | 6.33.4#1 |  |
| protobuf-c | 1.5.2 | |
| stc | 5.0 | |
| zlib |1.3.1 |

Note vcpkg 2026.03.18 includes libsodium 1.0.21#1, but this version does not build on linux/arm64 with gcc. [A fix has been committed](https://github.com/jedisct1/libsodium/commit/6702f69bef6044163acc7715e6ac7e430890ce78) to the libsodium repository and released with [libsodium 1.0.22](https://github.com/jedisct1/libsodium/releases/tag/1.0.22-RELEASE), but it has not yet been pulled into vcpkg. So we'll pin libsodium at 1.0.20 until 1.0.22 is available in a vcpkg release.

Note vcpkg 2026.03.18 includes abseil 20260107.1, but this version does not build on several platforms. We'll pin abseil to version 2025.0814.1 until the build failures are sorted out.