### PR TITLE
support running more than one tunneler at a time

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,11 +79,3 @@ jobs:
           name: ${{ matrix.preset }}
           path: ./build/bundle/ziti-edge-tunnel-*.zip
           if-no-files-found: error
-
-      - name: upload Windows PDB
-        if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.preset }}-pdb
-          path: ./build/programs/ziti-edge-tunnel/RelWithDebInfo/ziti-edge-tunnel.pdb
-          if-no-files-found: error

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,5 +77,13 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.preset }}
-          path: ./build/bundle/ziti-edge-tunnel-*.zip 
+          path: ./build/bundle/ziti-edge-tunnel-*.zip
+          if-no-files-found: error
+
+      - name: upload Windows PDB
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.preset }}-pdb
+          path: ./build/programs/ziti-edge-tunnel/RelWithDebInfo/ziti-edge-tunnel.pdb
           if-no-files-found: error

--- a/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
+++ b/lib/ziti-tunnel-cbs/ziti_tunnel_ctrl.c
@@ -931,6 +931,12 @@ static void get_transfer_rates(const char *identifier, command_cb cb, void *ctx)
 struct ziti_instance_s *new_ziti_instance(const char *identifier) {
     struct ziti_instance_s *inst = calloc(1, sizeof(struct ziti_instance_s));
     inst->identifier = strdup(identifier);
+#if _WIN32
+    // normalize: lowercase and convert forward slashes to backslashes
+    for (char *p = inst->identifier; *p; p++) {
+        *p = (*p == '/') ? '\\' : (char)tolower((unsigned char)*p);
+    }
+#endif
     return inst;
 }
 

--- a/lib/ziti-tunnel/intercept.c
+++ b/lib/ziti-tunnel/intercept.c
@@ -182,7 +182,8 @@ intercept_ctx_t * lookup_intercept_by_address(tunneler_context tnlr_ctx, const c
     ziti_address src_za;
     ziti_address_from_ip_addr(&src_za, src_addr);
     if (intercept != NULL) {
-        if (address_match(&src_za, &intercept->allowed_source_addresses) != NULL) {
+        bool has_src_restriction = STAILQ_FIRST(&intercept->allowed_source_addresses) != NULL;
+        if (!has_src_restriction || address_match(&src_za, &intercept->allowed_source_addresses) != NULL) {
             return intercept;
         }
     }

--- a/nix/packages/ziti-edge-tunnel.nix
+++ b/nix/packages/ziti-edge-tunnel.nix
@@ -42,7 +42,7 @@ let
     owner = "openziti";
     repo = "tlsuv";
     tag = "v0.41.1";
-    hash = "sha256-00w9xLts0lD8lZl5lc5k/9za0zhXfGesdeisbldNhZs=";
+    hash = "sha256-mT1K8OpwE+brdEc6ik8jMhEsXGuEh5nqfY3urx7IQiA=";
   };
   ziti_sdk_src = fetchFromGitHub {
     owner = "openziti";

--- a/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
+++ b/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
@@ -29,7 +29,8 @@
 #include "ziti/model_support.h"
 
 void add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip, const char* zet_id);
-void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* discriminator);
+void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* zet_id);
+void remove_orphaned_nrpt_rules(const char **running_ids, size_t count);
 void remove_all_nrpt_rules(const char* zet_id, bool exact);
 bool is_nrpt_policies_effective(const char* tns_ip, char* zet_id);
 void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip, const char* zet_id);

--- a/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
+++ b/programs/ziti-edge-tunnel/include/windows/windows-scripts.h
@@ -28,11 +28,11 @@
 
 #include "ziti/model_support.h"
 
-void add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip);
-void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames);
+void add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip, const char* zet_id);
+void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* discriminator);
 void remove_all_nrpt_rules(const char* zet_id, bool exact);
 bool is_nrpt_policies_effective(const char* tns_ip, char* zet_id);
-void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip);
+void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip, const char* zet_id);
 
 void update_interface_metric(uv_loop_t *ziti_loop, const char *tun_name, int metric);
 void update_symlink(uv_loop_t *symlink_loop, char* symlink, char* filename);

--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -939,9 +939,12 @@ const char *get_pcap_ifname() {
 char* get_zet_instance_id(const char* discriminator) {
     char *zet_instance_id = NULL;
     if (discriminator) {
+        // Put discriminator FIRST so that older ziti-edge-tunnel builds (which nuke anything
+        // starting with "Added by ziti-edge-tunnel") won't wipe rules owned by discriminated
+        // instances. Result: "<disc>.ziti-edge-tunnel".
         size_t len = strlen(DEFAULT_EXECUTABLE_NAME) + strlen(discriminator) + 2; /* separator + nul */
         zet_instance_id = calloc(len, sizeof(char));
-        snprintf(zet_instance_id, len, "%s.%s", DEFAULT_EXECUTABLE_NAME, discriminator);
+        snprintf(zet_instance_id, len, "%s.%s", discriminator, DEFAULT_EXECUTABLE_NAME);
     } else {
         zet_instance_id = strdup(DEFAULT_EXECUTABLE_NAME);
     }

--- a/programs/ziti-edge-tunnel/ipc_cmd.c
+++ b/programs/ziti-edge-tunnel/ipc_cmd.c
@@ -170,7 +170,9 @@ static void on_command_resp(const tunnel_result* result, void *ctx) {
                                 }
 
                                 if (model_map_size(&hostnamesToRemove) > 0) {
-                                    remove_nrpt_rules(global_loop_ref, &hostnamesToRemove, ipc_discriminator);
+                                    char *zet_id = get_zet_instance_id(ipc_discriminator);
+                                    remove_nrpt_rules(global_loop_ref, &hostnamesToRemove, zet_id);
+                                    free(zet_id);
                                 }
                             }
                         } else {

--- a/programs/ziti-edge-tunnel/ipc_cmd.c
+++ b/programs/ziti-edge-tunnel/ipc_cmd.c
@@ -26,6 +26,7 @@
 #include "instance-config.h"
 
 extern const ziti_tunnel_ctrl *CMD_CTRL;
+extern char *ipc_discriminator;
 
 static uv_pipe_t cmd_server;
 
@@ -169,7 +170,7 @@ static void on_command_resp(const tunnel_result* result, void *ctx) {
                                 }
 
                                 if (model_map_size(&hostnamesToRemove) > 0) {
-                                    remove_nrpt_rules(global_loop_ref, &hostnamesToRemove);
+                                    remove_nrpt_rules(global_loop_ref, &hostnamesToRemove, ipc_discriminator);
                                 }
                             }
                         } else {

--- a/programs/ziti-edge-tunnel/windows-scripts.c
+++ b/programs/ziti-edge-tunnel/windows-scripts.c
@@ -106,7 +106,7 @@ const char *normalize_hostname(char *hostname) {
     return hostname;
 }
 
-void chunked_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, const char* tun_ip, const char* zet_instance) {
+void chunked_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, const char* tun_ip, const char* zet_id) {
     char script[MAX_POWERSHELL_SCRIPT_LEN] = { 0 };
     size_t buf_len = snprintf(script, MAX_POWERSHELL_SCRIPT_LEN, "$Namespaces = @(");
     if (!is_buffer_available(buf_len, MAX_POWERSHELL_SCRIPT_LEN, script)) {
@@ -143,7 +143,7 @@ void chunked_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, co
         return;
     }
     copied += buf_len;
-    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "$Rule = @{Namespace=${ns}; NameServers=@('%s'); Comment='Added by %s'; DisplayName='%s:'+${ns}; }\n", tun_ip, zet_instance, zet_instance);
+    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "$Rule = @{Namespace=${ns}; NameServers=@('%s'); Comment='Added by %s'; DisplayName='%s:'+${ns}; }\n", tun_ip, zet_id, zet_id);
     if (!is_buffer_available(buf_len, (MAX_POWERSHELL_SCRIPT_LEN - copied), script)) {
         return;
     }
@@ -210,7 +210,7 @@ void add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_
     }
 }
 
-void chunked_remove_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, const char* discriminator) {
+void chunked_remove_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, const char* zet_id) {
     char script[MAX_POWERSHELL_SCRIPT_LEN] = { 0 };
     size_t buf_len = snprintf(script, MAX_POWERSHELL_SCRIPT_LEN, "$toRemove = @(\n");
     if (!is_buffer_available(buf_len, MAX_POWERSHELL_SCRIPT_LEN, script)) {
@@ -239,7 +239,7 @@ void chunked_remove_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames,
         return;
     }
     copied += buf_len;
-    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "Get-DnsClientNrptRule | where Namespace -eq $ns['n'] | Remove-DnsClientNrptRule -Force -ErrorAction SilentlyContinue\n");
+    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "Get-DnsClientNrptRule | where { $_.Namespace -eq $ns['n'] -and $_.Comment -eq 'Added by %s' } | Remove-DnsClientNrptRule -Force -ErrorAction SilentlyContinue\n", zet_id);
     if (!is_buffer_available(buf_len, (MAX_POWERSHELL_SCRIPT_LEN - copied), script)) {
         return;
     }
@@ -269,7 +269,7 @@ void chunked_remove_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames,
     }
 }
 
-void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* discriminator) {
+void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* zet_id) {
     ZITI_LOG(VERBOSE, "Remove nrpt rules");
 
     if (hostnames == NULL || model_map_size(hostnames) == 0) {
@@ -284,7 +284,7 @@ void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* d
     while(it != NULL) {
         const char* hostname = model_map_it_key(it);
         if (current_size > MAX_BUCKET_SIZE || rule_size > MAX_POWERSHELL_SCRIPT_LEN) {
-            chunked_remove_nrpt_rules(nrpt_loop, &host_names_list, discriminator);
+            chunked_remove_nrpt_rules(nrpt_loop, &host_names_list, zet_id);
             rule_size = MIN_BUFFER_LEN;
             current_size = 0;
         }
@@ -297,7 +297,7 @@ void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* d
         it = model_map_it_remove(it);
     }
     if (current_size > 0) {
-        chunked_remove_nrpt_rules(nrpt_loop, &host_names_list, discriminator);
+        chunked_remove_nrpt_rules(nrpt_loop, &host_names_list, zet_id);
     }
 }
 
@@ -317,6 +317,28 @@ char* get_nrpt_comment(const char* zet_id, bool exact) {
     nrpt_filter = calloc(tot_chars + 1, sizeof(char));
     snprintf(nrpt_filter, tot_chars, format, name);
     return nrpt_filter;
+}
+
+void remove_orphaned_nrpt_rules(const char **running_ids, size_t count) {
+    // Build a PowerShell array of running instance IDs, then remove any ZET NRPT
+    // rules whose owner (Comment) is not in that list (orphaned from a dead process).
+    char cmd[MAX_POWERSHELL_COMMAND_LEN] = { 0 };
+    size_t copied = snprintf(cmd, MAX_POWERSHELL_COMMAND_LEN,
+                             "powershell -Command \"$r=@(");
+    for (size_t i = 0; i < count; i++) {
+        copied += snprintf(cmd + copied, MAX_POWERSHELL_COMMAND_LEN - copied,
+                           "%s'%s'", i > 0 ? "," : "", running_ids[i]);
+    }
+    copied += snprintf(cmd + copied, MAX_POWERSHELL_COMMAND_LEN - copied,
+        "); Get-DnsClientNrptRule | where { $_.Comment.StartsWith('Added by %s')"
+        " -and ($r -notcontains ($_.Comment -replace '^Added by ','')) }"
+        " | Remove-DnsClientNrptRule -Force -ErrorAction SilentlyContinue\"",
+        DEFAULT_EXECUTABLE_NAME);
+    ZITI_LOG(DEBUG, "Removing orphaned NRPT rules. cmd size: %zd", copied);
+    int rc = system(cmd);
+    if (rc != 0) {
+        ZITI_LOG(WARN, "Remove orphaned NRPT script: %d(err=%lu)", rc, GetLastError());
+    }
 }
 
 void remove_all_nrpt_rules(const char* zet_id, bool exact) {
@@ -367,7 +389,7 @@ void chunked_remove_and_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *ho
         return;
     }
     copied += buf_len;
-    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "Get-DnsClientNrptRule | where Namespace -eq $ns['n'] | Remove-DnsClientNrptRule -Force -ErrorAction SilentlyContinue\n");
+    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "Get-DnsClientNrptRule | where { $_.Namespace -eq $ns['n'] -and $_.Comment -eq 'Added by %s' } | Remove-DnsClientNrptRule -Force -ErrorAction SilentlyContinue\n", zet_id);
     if (!is_buffer_available(buf_len, (MAX_POWERSHELL_SCRIPT_LEN - copied), script)) {
         return;
     }

--- a/programs/ziti-edge-tunnel/windows-scripts.c
+++ b/programs/ziti-edge-tunnel/windows-scripts.c
@@ -322,6 +322,13 @@ char* get_nrpt_comment(const char* zet_id, bool exact) {
 void remove_orphaned_nrpt_rules(const char **running_ids, size_t count) {
     // Build a PowerShell array of running instance IDs, then remove any ZET NRPT
     // rules whose owner (Comment) is not in that list (orphaned from a dead process).
+    //
+    // Instance IDs take two forms:
+    //   - default instance:        "ziti-edge-tunnel"
+    //   - discriminated (-P foo):  "foo.ziti-edge-tunnel"
+    // The regex below matches both: an optional "<disc>." followed by the executable name
+    // at end-of-string. This also ensures a pre-multi-tun build's "StartsWith('Added by
+    // ziti-edge-tunnel')" nuke won't catch discriminated rules.
     char cmd[MAX_POWERSHELL_COMMAND_LEN] = { 0 };
     size_t copied = snprintf(cmd, MAX_POWERSHELL_COMMAND_LEN,
                              "powershell -Command \"$r=@(");
@@ -330,7 +337,7 @@ void remove_orphaned_nrpt_rules(const char **running_ids, size_t count) {
                            "%s'%s'", i > 0 ? "," : "", running_ids[i]);
     }
     copied += snprintf(cmd + copied, MAX_POWERSHELL_COMMAND_LEN - copied,
-        "); Get-DnsClientNrptRule | where { $_.Comment.StartsWith('Added by %s')"
+        "); Get-DnsClientNrptRule | where { $_.Comment -match '^Added by ([^ ]+\\.)?%s$'"
         " -and ($r -notcontains ($_.Comment -replace '^Added by ','')) }"
         " | Remove-DnsClientNrptRule -Force -ErrorAction SilentlyContinue\"",
         DEFAULT_EXECUTABLE_NAME);

--- a/programs/ziti-edge-tunnel/windows-scripts.c
+++ b/programs/ziti-edge-tunnel/windows-scripts.c
@@ -106,7 +106,7 @@ const char *normalize_hostname(char *hostname) {
     return hostname;
 }
 
-void chunked_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, const char* tun_ip) {
+void chunked_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, const char* tun_ip, const char* zet_instance) {
     char script[MAX_POWERSHELL_SCRIPT_LEN] = { 0 };
     size_t buf_len = snprintf(script, MAX_POWERSHELL_SCRIPT_LEN, "$Namespaces = @(");
     if (!is_buffer_available(buf_len, MAX_POWERSHELL_SCRIPT_LEN, script)) {
@@ -143,7 +143,7 @@ void chunked_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, co
         return;
     }
     copied += buf_len;
-    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "$Rule = @{Namespace=${ns}; NameServers=@('%s'); Comment='Added by %s'; DisplayName='%s:'+${ns}; }\n", tun_ip, DEFAULT_EXECUTABLE_NAME, DEFAULT_EXECUTABLE_NAME);
+    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "$Rule = @{Namespace=${ns}; NameServers=@('%s'); Comment='Added by %s'; DisplayName='%s:'+${ns}; }\n", tun_ip, zet_instance, zet_instance);
     if (!is_buffer_available(buf_len, (MAX_POWERSHELL_SCRIPT_LEN - copied), script)) {
         return;
     }
@@ -178,7 +178,7 @@ void chunked_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, co
     }
 }
 
-void add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip) {
+void add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip, const char* zet_id) {
     ZITI_LOG(VERBOSE, "Add nrpt rules");
 
     if (hostnames == NULL || model_map_size(hostnames) == 0) {
@@ -193,7 +193,7 @@ void add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_
     while(it != NULL) {
         const char* hostname = model_map_it_key(it);
         if (current_size > MAX_BUCKET_SIZE || rule_size > MAX_POWERSHELL_SCRIPT_LEN) {
-            chunked_add_nrpt_rules(nrpt_loop, &host_names_list, dns_ip);
+            chunked_add_nrpt_rules(nrpt_loop, &host_names_list, dns_ip, zet_id);
             rule_size = MIN_BUFFER_LEN;
             current_size = 0;
         }
@@ -206,11 +206,11 @@ void add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_
         it = model_map_it_remove(it);
     }
     if (current_size > 0) {
-        chunked_add_nrpt_rules(nrpt_loop, &host_names_list, dns_ip);
+        chunked_add_nrpt_rules(nrpt_loop, &host_names_list, dns_ip, zet_id);
     }
 }
 
-void chunked_remove_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames) {
+void chunked_remove_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, const char* discriminator) {
     char script[MAX_POWERSHELL_SCRIPT_LEN] = { 0 };
     size_t buf_len = snprintf(script, MAX_POWERSHELL_SCRIPT_LEN, "$toRemove = @(\n");
     if (!is_buffer_available(buf_len, MAX_POWERSHELL_SCRIPT_LEN, script)) {
@@ -269,7 +269,7 @@ void chunked_remove_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames)
     }
 }
 
-void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames) {
+void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* discriminator) {
     ZITI_LOG(VERBOSE, "Remove nrpt rules");
 
     if (hostnames == NULL || model_map_size(hostnames) == 0) {
@@ -284,7 +284,7 @@ void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames) {
     while(it != NULL) {
         const char* hostname = model_map_it_key(it);
         if (current_size > MAX_BUCKET_SIZE || rule_size > MAX_POWERSHELL_SCRIPT_LEN) {
-            chunked_remove_nrpt_rules(nrpt_loop, &host_names_list);
+            chunked_remove_nrpt_rules(nrpt_loop, &host_names_list, discriminator);
             rule_size = MIN_BUFFER_LEN;
             current_size = 0;
         }
@@ -297,7 +297,7 @@ void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames) {
         it = model_map_it_remove(it);
     }
     if (current_size > 0) {
-        chunked_remove_nrpt_rules(nrpt_loop, &host_names_list);
+        chunked_remove_nrpt_rules(nrpt_loop, &host_names_list, discriminator);
     }
 }
 
@@ -338,7 +338,7 @@ void remove_all_nrpt_rules(const char* zet_id, bool exact) {
     }
 }
 
-void chunked_remove_and_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, const char* dns_ip) {
+void chunked_remove_and_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, const char* dns_ip, const char* zet_id) {
     char script[MAX_POWERSHELL_SCRIPT_LEN] = { 0 };
     size_t buf_len = snprintf(script, MAX_POWERSHELL_SCRIPT_LEN, "$toRemoveAndAdd = @(\n");
     if (!is_buffer_available(buf_len, MAX_POWERSHELL_SCRIPT_LEN, script)) {
@@ -377,7 +377,7 @@ void chunked_remove_and_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *ho
         return;
     }
     copied += buf_len;
-    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "$Rule = @{Namespace=${nsToAdd}; NameServers=@('%s'); Comment='Added by %s'; DisplayName='%s:'+${ns}; }\n", dns_ip, DEFAULT_EXECUTABLE_NAME, DEFAULT_EXECUTABLE_NAME);
+    buf_len = snprintf(script + copied, (MAX_POWERSHELL_SCRIPT_LEN - copied), "$Rule = @{Namespace=${nsToAdd}; NameServers=@('%s'); Comment='Added by %s'; DisplayName='%s:'+${ns}; }\n", dns_ip, zet_id, zet_id);
     if (!is_buffer_available(buf_len, (MAX_POWERSHELL_SCRIPT_LEN - copied), script)) {
         return;
     }
@@ -412,7 +412,7 @@ void chunked_remove_and_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *ho
     }
 }
 
-void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip) {
+void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip, const char* zet_id) {
     ZITI_LOG(VERBOSE, "Remove and add nrpt rules");
 
     if (hostnames == NULL || model_map_size(hostnames) == 0) {
@@ -427,7 +427,7 @@ void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const
     while(it != NULL) {
         const char* hostname = model_map_it_key(it);
         if (current_size > MAX_BUCKET_SIZE || rule_size > MAX_POWERSHELL_SCRIPT_LEN) {
-            chunked_remove_and_add_nrpt_rules(nrpt_loop, &host_names_list, dns_ip);
+            chunked_remove_and_add_nrpt_rules(nrpt_loop, &host_names_list, dns_ip, zet_id);
             rule_size = MIN_BUFFER_LEN;
             current_size = 0;
         }
@@ -440,7 +440,7 @@ void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const
         it = model_map_it_remove(it);
     }
     if (current_size > 0) {
-        chunked_remove_and_add_nrpt_rules(nrpt_loop, &host_names_list, dns_ip);
+        chunked_remove_and_add_nrpt_rules(nrpt_loop, &host_names_list, dns_ip, zet_id);
     }
 }
 

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1563,7 +1563,20 @@ static void run(int argc, char *argv[]) {
     }
 #endif
 
-    configure_ipc(true, !started_by_scm && (other_zets > 0 || ipc_discriminator != NULL));
+    // Only auto-apply a PID discriminator when the default pipe is actually taken.
+    // Another instance running with -P <name> does not collide with the default path,
+    // so a fresh default can still use the default pipe in that case.
+    bool default_pipe_taken = false;
+    {
+        const char *sn;
+        MODEL_LIST_FOREACH(sn, ipc_list) {
+            if (strcmp(sn, sockfilebase) == 0) {
+                default_pipe_taken = true;
+                break;
+            }
+        }
+    }
+    configure_ipc(true, !started_by_scm && (default_pipe_taken || ipc_discriminator != NULL));
     model_list_clear(&ipc_list, free);
 
     // generate tunnel status instance and save active state and start time

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2376,13 +2376,7 @@ static void select_ipc_instance(void) {
     size_t count = find_other_zets(&ipc_list, sockfilebase);
     size_t base_len = strlen(sockfilebase);
 
-    if (count <= 1) {
-        const char *name;
-        MODEL_LIST_FOREACH(name, ipc_list) {
-            if (strlen(name) > base_len && name[base_len] == '.') {
-                ipc_discriminator = strdup(name + base_len + 1);
-            }
-        }
+    if (count == 0) {
         model_list_clear(&ipc_list, free);
         return;
     }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1506,6 +1506,39 @@ static void run(int argc, char *argv[]) {
     model_list ipc_list = {0};
     size_t other_zets = find_other_zets(&ipc_list, sockfilebase);
 
+#if !_WIN32
+    {
+        // On Linux/Mac socket files outlive their process; filter out stale ones.
+        size_t base_len = strlen(sockfilebase);
+        model_list live_list = {0};
+        const char *sock_name;
+        MODEL_LIST_FOREACH(sock_name, ipc_list) {
+            char probe_path[PATH_MAX];
+            char *disc = (strlen(sock_name) > base_len && sock_name[base_len] == '.')
+                         ? strdup(sock_name + base_len + 1) : NULL;
+            if (disc) {
+                snprintf(probe_path, sizeof(probe_path), "%s%s.%s", SOCKET_PATH, sockfilebase, disc);
+            } else {
+                snprintf(probe_path, sizeof(probe_path), "%s%s", SOCKET_PATH, sockfilebase);
+            }
+            free(disc);
+            struct sockaddr_un addr = { .sun_family = AF_UNIX };
+            strncpy(addr.sun_path, probe_path, sizeof(addr.sun_path) - 1);
+            int s = socket(AF_UNIX, SOCK_STREAM, 0);
+            bool live = connect(s, (const struct sockaddr *) &addr, sizeof(addr)) == 0;
+            close(s);
+            if (live) {
+                model_list_append(&live_list, strdup(sock_name));
+            } else {
+                ZITI_LOG(DEBUG, "ignoring stale socket: %s", probe_path);
+            }
+        }
+        model_list_clear(&ipc_list, free);
+        ipc_list = live_list;
+        other_zets = model_list_size(&ipc_list);
+    }
+#endif
+
 #if _WIN32
     {
         // Remove NRPT rules from dead instances only; preserve rules owned by running instances.
@@ -2389,7 +2422,7 @@ static void select_ipc_instance(void) {
     MODEL_LIST_FOREACH(name, ipc_list) {
         char *disc = (strlen(name) > base_len && name[base_len] == '.')
                      ? strdup(name + base_len + 1) : NULL;
-        char probe_path[256];
+        char probe_path[PATH_MAX];
         if (disc) {
             snprintf(probe_path, sizeof(probe_path), "%s%s.%s", SOCKET_PATH, sockfilebase, disc);
         } else {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2287,7 +2287,7 @@ static void probe_instance(const char *socket_path, char *tun_name_out, size_t t
         CloseHandle(h);
         return;
     }
-    char buf[16*1024] = {0};
+    char buf[32*1024] = {0};
     DWORD nr;
     if (!ReadFile(h, buf, sizeof(buf) - 1, &nr, NULL)) {
         CloseHandle(h);
@@ -2298,9 +2298,13 @@ static void probe_instance(const char *socket_path, char *tun_name_out, size_t t
     uv_os_sock_t s = socket(AF_UNIX, SOCK_STREAM, 0);
     struct sockaddr_un addr = { .sun_family = AF_UNIX };
     strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
-    if (connect(s, (const struct sockaddr *) &addr, sizeof(addr))) return;
-    if (write(s, status_cmd, strlen(status_cmd)) < 0) { close(s); return; }
-    char buf[16*1024] = {0};
+    if (connect(s, (const struct sockaddr *) &addr, sizeof(addr))) {
+        close(s); return;
+    }
+    if (write(s, status_cmd, strlen(status_cmd)) < 0) {
+        close(s); return;
+    }
+    char buf[32*1024] = {0};
     ssize_t nr = read(s, buf, sizeof(buf) - 1);
     close(s);
     if (nr <= 0) return;

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -2271,12 +2271,18 @@ static int send_message_to_tunnel(char* message, bool show_result) {
     return code;
 }
 
-// Connect to a single ziti-edge-tunnel IPC socket and retrieve its TunName, IP, and DNS
-// for display purposes. Fills output buffers with "?" on any failure.
-static void probe_instance(const char *socket_path, char *tun_name_out, size_t tun_name_sz, char *ip_out, size_t ip_sz, char *dns_out, size_t dns_sz) {
-    strncpy(tun_name_out, "?", tun_name_sz);
-    strncpy(ip_out, "?", ip_sz);
-    strncpy(dns_out, "?", dns_sz);
+typedef struct {
+    char tun_name[64];
+    char ip[32];
+    char dns[32];
+} probe_result;
+
+// Connect to a ziti-edge-tunnel and retrieve its TunName, IP, and DNS.
+// Fills result fields with "?" on any failure.
+static void probe_instance(const char *socket_path, probe_result *result) {
+    strncpy(result->tun_name, "?", sizeof(result->tun_name));
+    strncpy(result->ip, "?", sizeof(result->ip));
+    strncpy(result->dns, "?", sizeof(result->dns));
 
     const char *status_cmd = "{\"Command\":\"Status\"}";
 #if _WIN32
@@ -2319,20 +2325,20 @@ static void probe_instance(const char *socket_path, char *tun_name_out, size_t t
     struct json_object *data = json_object_object_get(resp, "Data");
     if (data) {
         struct json_object *tn = json_object_object_get(data, "TunName");
-        if (tn) strncpy(tun_name_out, json_object_get_string(tn), tun_name_sz - 1);
+        if (tn) strncpy(result->tun_name, json_object_get_string(tn), sizeof(result->tun_name) - 1);
         struct json_object *ip_info = json_object_object_get(data, "IpInfo");
         if (ip_info) {
             struct json_object *ip = json_object_object_get(ip_info, "Ip");
-            if (ip) strncpy(ip_out, json_object_get_string(ip), ip_sz - 1);
+            if (ip) strncpy(result->ip, json_object_get_string(ip), sizeof(result->ip) - 1);
             struct json_object *dns = json_object_object_get(ip_info, "DNS");
-            if (dns) strncpy(dns_out, json_object_get_string(dns), dns_sz - 1);
+            if (dns) strncpy(result->dns, json_object_get_string(dns), sizeof(result->dns) - 1);
         }
     }
     json_object_put(resp);
 }
 
 // If -P was not supplied, scan for running ziti-edge-tunnel IPC sockets.
-// With exactly one found, auto-select it. With multiple, probe each for its
+// If exactly one found, auto-select it. If multiple, probe each for its
 // tunnel info and prompt the user to choose before proceeding with the command.
 static void select_ipc_instance(void) {
     if (ipc_discriminator != NULL) {
@@ -2344,7 +2350,6 @@ static void select_ipc_instance(void) {
     size_t base_len = strlen(sockfilebase);
 
     if (count <= 1) {
-        // auto-select the single instance (or use default if none found)
         const char *name;
         MODEL_LIST_FOREACH(name, ipc_list) {
             if (strlen(name) > base_len && name[base_len] == '.') {
@@ -2355,7 +2360,7 @@ static void select_ipc_instance(void) {
         return;
     }
 
-    // Multiple instances: collect discriminators then prompt
+    // if multiple instances: collect discriminators then prompt
     char **discriminators = calloc(count, sizeof(char *));
     int idx = 0;
     const char *name;
@@ -2377,10 +2382,10 @@ static void select_ipc_instance(void) {
         } else {
             snprintf(probe_path, sizeof(probe_path), "%s%s", SOCKET_PATH, sockfilebase);
         }
-        char tun_name[64], ip[32], dns[32];
-        probe_instance(probe_path, tun_name, sizeof(tun_name), ip, sizeof(ip), dns, sizeof(dns));
+        probe_result r;
+        probe_instance(probe_path, &r);
         const char *label = discriminators[i] ? discriminators[i] : "default";
-        fprintf(stderr, "  [%d] %-10s  %-10s  IP: %-15s  DNS: %s\n", i, label, tun_name, ip, dns);
+        fprintf(stderr, "  [%d] %-10s  %-10s  IP: %-15s  DNS: %s\n", i, label, r.tun_name, r.ip, r.dns);
     }
 
     int choice = 0;
@@ -2398,7 +2403,7 @@ static void select_ipc_instance(void) {
         fprintf(stderr, "  Invalid input, please enter a number between 0 and %d\n", (int)count - 1);
     }
 
-    ipc_discriminator = discriminators[choice]; // transfer ownership
+    ipc_discriminator = discriminators[choice];
     for (int i = 0; i < (int)count; i++) {
         if (i != choice) free(discriminators[i]);
     }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1449,6 +1449,7 @@ size_t find_other_zets(model_list *ipcs, const char *ipc_prefix) {
             model_list_append(ipcs, strdup(file.name));
         }
     }
+    uv_fs_req_cleanup(&fs);
     return model_list_size(ipcs);
 }
 
@@ -1529,7 +1530,7 @@ static void run(int argc, char *argv[]) {
     }
 #endif
 
-    configure_ipc(true, other_zets > 0);
+    configure_ipc(true, !started_by_scm && (other_zets > 0 || ipc_discriminator != NULL));
     model_list_clear(&ipc_list, free);
 
     // generate tunnel status instance and save active state and start time

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1433,11 +1433,11 @@ static void interrupt_handler(int sig) {
 }
 #endif
 
-size_t find_other_zets(model_list *ipcs, const char *ipc_base, const char *ipc_prefix) {
+size_t find_other_zets(model_list *ipcs, const char *ipc_prefix) {
     uv_fs_t fs;
     int rc = uv_fs_scandir(uv_default_loop(), &fs, SOCKET_PATH, 0, NULL);
     if (rc < 0) {
-        ZITI_LOG(DEBUG, "failed to scan for other ziti-edge-tunnels at [%s]: %d/%s", ipc_base, rc, uv_strerror(rc));
+        ZITI_LOG(DEBUG, "failed to scan for other ziti-edge-tunnels at [%s]: %d/%s", SOCKET_PATH, rc, uv_strerror(rc));
         return 0;
     }
     uv_dirent_t file;
@@ -1502,7 +1502,7 @@ static void run(int argc, char *argv[]) {
 #endif
 
     model_list ipc_list = {0};
-    size_t other_zets = find_other_zets(&ipc_list, SOCKET_PATH, sockfilebase);
+    size_t other_zets = find_other_zets(&ipc_list, sockfilebase);
     configure_ipc(true, other_zets > 0);
     model_list_clear(&ipc_list, free);
 
@@ -2340,7 +2340,7 @@ static void select_ipc_instance(void) {
     }
 
     model_list ipc_list = {0};
-    size_t count = find_other_zets(&ipc_list, SOCKET_PATH, sockfilebase);
+    size_t count = find_other_zets(&ipc_list, sockfilebase);
     size_t base_len = strlen(sockfilebase);
 
     if (count <= 1) {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -133,7 +133,7 @@ static long metrics_latency = 5000;
 static char *configured_cidr = NULL;
 static char *configured_log_level = NULL;
 static char *configured_proxy = NULL;
-static char *ipc_discriminator = NULL;
+char *ipc_discriminator = NULL;
 static bool l2_tunnel = false;
 static char *pcap_iface = NULL;
 
@@ -153,15 +153,16 @@ static uv_cond_t stop_cond;
 IMPL_ENUM(event, EVENT_ACTIONS)
 
 #if _WIN32
-static char sockfile[] = "\\\\.\\pipe\\ziti-edge-tunnel.sock";
-static char eventsockfile[] = "\\\\.\\pipe\\ziti-edge-tunnel-event.sock";
+#define SOCKET_PATH "\\\\.\\pipe\\"
 #elif __unix__ || unix || ( __APPLE__ && __MACH__ )
 #include <grp.h>
 #include <sys/un.h>
-#define SOCKET_PATH "/tmp/.ziti"
-static char sockfile[] = SOCKET_PATH "/ziti-edge-tunnel.sock";
-static char eventsockfile[] = SOCKET_PATH "/ziti-edge-tunnel-event.sock";
+#define SOCKET_PATH "/tmp/.ziti/"
 #endif
+static char sockfilebase[] = "ziti-edge-tunnel.sock";
+static char eventsockfilebase[] = "ziti-edge-tunnel-event.sock";
+static char *sockfile;
+static char *eventsockfile;
 
 extern int start_cmd_socket(uv_loop_t *l, const char *sockfile);
 extern int start_event_socket(uv_loop_t *l, const char *eventsockfile);
@@ -628,13 +629,15 @@ static void on_event(const base_event *ev) {
             }
 
             if (id->Active && model_map_size(&hostnamesToEdit) > 0 && !is_host_only()) {
-                remove_and_add_nrpt_rules(global_loop_ref, &hostnamesToEdit, get_dns_ip()/*, ipc_discriminator*/);
+                remove_and_add_nrpt_rules(global_loop_ref, &hostnamesToEdit, get_dns_ip(), ipc_discriminator);
             }
             if (id->Active && model_map_size(&hostnamesToAdd) > 0 && !is_host_only()) {
-                add_nrpt_rules(global_loop_ref, &hostnamesToAdd, get_dns_ip()/*, ipc_discriminator*/);
+                char* zet_id = get_zet_instance_id(ipc_discriminator);
+                add_nrpt_rules(global_loop_ref, &hostnamesToAdd, get_dns_ip(), zet_id);
+                free(zet_id);
             }
             if (model_map_size(&hostnamesToRemove) > 0 && !is_host_only()) {
-                remove_nrpt_rules(global_loop_ref, &hostnamesToRemove/*, ipc_discriminator*/);
+                remove_nrpt_rules(global_loop_ref, &hostnamesToRemove, ipc_discriminator);
             }
 
 #endif
@@ -963,7 +966,7 @@ static int run_tunnel_host_mode(uv_loop_t *ziti_loop) {
 
 static int make_socket_path(uv_loop_t *loop) {
 
-#if defined(SOCKET_PATH)
+#if defined(SOCKET_PATH) && !_WIN32
 #define ZITI_GRNAME "ziti"
     uv_fs_t req;
     int rc;
@@ -1046,7 +1049,7 @@ static int make_socket_path(uv_loop_t *loop) {
     uv_fs_req_cleanup(&req);
     return perms_ok ? 0 : -1;
 
-#endif /* defined(SOCKET_PATH) */
+#endif
 
     return 0;
 }
@@ -1430,6 +1433,55 @@ static void interrupt_handler(int sig) {
 }
 #endif
 
+size_t find_other_zets(model_list *ipcs, const char *ipc_base, const char *ipc_prefix) {
+    uv_fs_t fs;
+    int rc = uv_fs_scandir(uv_default_loop(), &fs, SOCKET_PATH, 0, NULL);
+    if (rc < 0) {
+        ZITI_LOG(DEBUG, "failed to scan for other ziti-edge-tunnels at [%s]: %d/%s", ipc_base, rc, uv_strerror(rc));
+        return 0;
+    }
+    uv_dirent_t file;
+    while (uv_fs_scandir_next(&fs, &file) == 0) {
+        size_t len = strlen(ipc_prefix);
+        if (strncmp(file.name, ipc_prefix, len) == 0) {
+            model_list_append(ipcs, strdup(file.name));
+        }
+    }
+    return model_list_size(ipcs);
+}
+
+static void configure_ipc(bool automatic_ipc_discriminator, bool use_discriminator) {
+    if (ipc_discriminator == NULL && automatic_ipc_discriminator) {
+        int pid = getpid();
+        ipc_discriminator = calloc(10, sizeof(char));
+        snprintf(ipc_discriminator, 10, "%d", pid);
+    }
+
+    size_t socket_path_len = strlen(SOCKET_PATH);
+    size_t ipc_discriminator_len = ipc_discriminator != NULL ? strlen(ipc_discriminator) : 0;
+    size_t sockfilebase_len = strlen(sockfilebase);
+    size_t eventsockfilebase_len = strlen(eventsockfilebase);
+
+    sockfile = calloc(socket_path_len + sockfilebase_len + ipc_discriminator_len + 2, sizeof(char));
+    eventsockfile = calloc(socket_path_len + eventsockfilebase_len + ipc_discriminator_len + 2, sizeof(char));
+
+    if (use_discriminator) {
+        sprintf(sockfile, "%s%s.%s", SOCKET_PATH, sockfilebase, ipc_discriminator);
+        sprintf(eventsockfile, "%s%s.%s", SOCKET_PATH, eventsockfilebase, ipc_discriminator);
+    } else {
+        ipc_discriminator = NULL;
+        sprintf(sockfile, "%s%s", SOCKET_PATH, sockfilebase);
+        sprintf(eventsockfile, "%s%s", SOCKET_PATH, eventsockfilebase);
+    }
+    if (automatic_ipc_discriminator) {
+        ZITI_LOG(INFO, use_discriminator ?
+            "multiple ziti-edge-tunnels are running. applying ipc discriminator" :
+            "using default paths for IPC");
+        ZITI_LOG(INFO, "ipc command path: %s", sockfile);
+        ZITI_LOG(INFO, "ipc events  path: %s", eventsockfile);
+    }
+}
+
 static void run(int argc, char *argv[]) {
     uv_cond_init(&stop_cond);
     uv_mutex_init(&stop_mutex);
@@ -1448,6 +1500,10 @@ static void run(int argc, char *argv[]) {
 #else
     ziti_log_init(global_loop_ref, log_level, log_fn);
 #endif
+
+    model_list ipc_list = {0};
+    size_t other_zets = find_other_zets(&ipc_list, SOCKET_PATH, sockfilebase);
+    configure_ipc(true, other_zets > 0 || ipc_discriminator != NULL);
 
     // generate tunnel status instance and save active state and start time
     if (config_dir != NULL) {
@@ -1560,6 +1616,7 @@ static void run(int argc, char *argv[]) {
     char *csdk_version = "" to_str(ZITI_VERSION) ":" to_str(ZITI_BRANCH) "@" to_str(ZITI_COMMIT);
     ZITI_LOG(INFO,"	- C SDK Version    : %s", csdk_version);
     ZITI_LOG(INFO,"	- Tunneler SDK     : %s", ziti_tunneler_version());
+    ZITI_LOG(INFO,"	- IPC socket       : %s", sockfile);
     if(openssl_conf_resolved != NULL) {
         ZITI_LOG(INFO, "	- openssl config   : configured using %s found by %s", openssl_conf_resolved, openssl_conf_found_by);
     }
@@ -2212,6 +2269,7 @@ static int send_message_to_tunnel(char* message, bool show_result) {
 }
 
 static void send_message_to_tunnel_fn(int argc, char *argv[]) {
+    configure_ipc(false, ipc_discriminator != NULL);
     char* json = tunnel_command_to_json(&cmd, MODEL_JSON_COMPACT, NULL);
     int result = send_message_to_tunnel(json, cmd.show_result);
     free_tunnel_command(&cmd);
@@ -2865,7 +2923,7 @@ static CommandLine enroll_cmd = make_command(
 #endif
 
 static CommandLine run_cmd = make_command("run", "run Ziti tunnel (required superuser access)",
-                                          "-i <id.file> [-r N] [-v N] [-d|--dns-ip-range N.N.N.N/N] " DIVERTER_OPTS_SUMMARY "[-u|--dns-upstream N.N.N.N]\n",
+                                          "-i <id.file> [-r N] [-v N] [-d|--dns-ip-range N.N.N.N/N] " DIVERTER_OPTS_SUMMARY "[-u|--dns-upstream N.N.N.N] [-P|--pipe <name>]\n",
                                           "\t-i|--identity <identity>\trun with provided identity file (required)\n"
                                           "\t-I|--identity-dir <dir>\tload identities from provided directory\n"
                                           "\t-x|--proxy type://[username[:password]@]hostname_or_ip:port\tproxy to use when"
@@ -2877,16 +2935,20 @@ static CommandLine run_cmd = make_command("run", "run Ziti tunnel (required supe
                                           "\t-d|--dns-ip-range <ip range>\tspecify CIDR block in which service DNS names"
                                           " are assigned in N.N.N.N/n format (default " DEFAULT_DNS_CIDR ")\n"
                                           DIVERTER_OPTS_DETAIL
-                                          "\t-u|--dns-upstream <ip addr>\tresolver listening on 53/udp for DNS queries that do not match a Ziti service\n",
+                                          "\t-u|--dns-upstream <ip addr>\tresolver listening on 53/udp for DNS queries that do not match a Ziti service\n"
+                                          "\t-P|--pipe <name>\tIPC socket discriminator suffix for running multiple ziti-edge-tunnel instances side-by-side. "
+                                          "When omitted, the PID is used automatically if other instances are detected; otherwise the default socket path is used.\n",
                                           run_opts, run);
 static CommandLine run_host_cmd = make_command("run-host", "run Ziti tunnel to host services",
-                                          "-i <id.file> [-r N] [-v N]",
+                                          "-i <id.file> [-r N] [-v N] [-P|--pipe <name>]",
                                           "\t-i|--identity <identity>\trun with provided identity file (required)\n"
                                           "\t-I|--identity-dir <dir>\tload identities from provided directory\n"
                                           "\t-x|--proxy type://[username[:password]@]hostname_or_ip:port\tproxy to use when"
                                           " connecting to OpenZiti controller and edge routers"
                                           "\t-v|--verbose N\tset log level, higher level -- more verbose (default 3)\n"
-                                          "\t-r|--refresh N\tset service polling interval in seconds (default 10)\n",
+                                          "\t-r|--refresh N\tset service polling interval in seconds (default 10)\n"
+                                          "\t-P|--pipe <name>\tIPC socket discriminator suffix for running multiple ziti-edge-tunnel instances side-by-side. "
+                                          "When omitted, the PID is used automatically if other instances are detected; otherwise the default socket path is used.\n",
                                           run_host_opts, run);
 static CommandLine dump_cmd = make_command("dump", "dump the identities information", "[-i <identity>] [-p <dir>]",
                                            "\t-i|--identity\tdump identity info\n"
@@ -2994,7 +3056,12 @@ static CommandLine main_cmd = make_command_set(
         NULL,
         "Ziti Tunnel App",
         "<command> [<args>]", "to get help for specific command run 'ziti-edge-tunnel help <command>' "
-                              "or 'ziti-edge-tunnel <command> -h'",
+                              "or 'ziti-edge-tunnel <command> -h'.\n"
+                              "\n"
+                              "Global flag (accepted by any command): -P|--pipe <name> overrides the IPC socket "
+                              "discriminator suffix. When running, this controls the socket this instance listens on; "
+                              "when invoking a client subcommand (add, on, off, dump, ...), this selects which "
+                              "running instance to talk to.\n",
         NULL, main_cmds);
 
 #if _WIN32
@@ -3182,6 +3249,19 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 #endif
+
+    // Pre-extract -P/--pipe before subcommand dispatch so all commands support it
+    // without each opts function needing to handle it individually.
+    for (int i = 1; i < argc - 1; i++) {
+        if (strcmp(argv[i], "-P") == 0 || strcmp(argv[i], "--pipe") == 0) {
+            ipc_discriminator = argv[i + 1];
+            for (int j = i; j < argc - 2; j++) {
+                argv[j] = argv[j + 2];
+            }
+            argc -= 2;
+            break;
+        }
+    }
 
     commandline_run(&main_cmd, argc, argv);
     return 0;

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1503,7 +1503,8 @@ static void run(int argc, char *argv[]) {
 
     model_list ipc_list = {0};
     size_t other_zets = find_other_zets(&ipc_list, SOCKET_PATH, sockfilebase);
-    configure_ipc(true, other_zets > 0 || ipc_discriminator != NULL);
+    configure_ipc(true, other_zets > 0);
+    model_list_clear(&ipc_list, free);
 
     // generate tunnel status instance and save active state and start time
     if (config_dir != NULL) {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -628,16 +628,18 @@ static void on_event(const base_event *ev) {
                 }
             }
 
-            if (id->Active && model_map_size(&hostnamesToEdit) > 0 && !is_host_only()) {
-                remove_and_add_nrpt_rules(global_loop_ref, &hostnamesToEdit, get_dns_ip(), ipc_discriminator);
-            }
-            if (id->Active && model_map_size(&hostnamesToAdd) > 0 && !is_host_only()) {
+            if ((model_map_size(&hostnamesToEdit) > 0 || model_map_size(&hostnamesToAdd) > 0 || model_map_size(&hostnamesToRemove) > 0) && !is_host_only()) {
                 char* zet_id = get_zet_instance_id(ipc_discriminator);
-                add_nrpt_rules(global_loop_ref, &hostnamesToAdd, get_dns_ip(), zet_id);
+                if (id->Active && model_map_size(&hostnamesToEdit) > 0) {
+                    remove_and_add_nrpt_rules(global_loop_ref, &hostnamesToEdit, get_dns_ip(), zet_id);
+                }
+                if (id->Active && model_map_size(&hostnamesToAdd) > 0) {
+                    add_nrpt_rules(global_loop_ref, &hostnamesToAdd, get_dns_ip(), zet_id);
+                }
+                if (model_map_size(&hostnamesToRemove) > 0) {
+                    remove_nrpt_rules(global_loop_ref, &hostnamesToRemove, zet_id);
+                }
                 free(zet_id);
-            }
-            if (model_map_size(&hostnamesToRemove) > 0 && !is_host_only()) {
-                remove_nrpt_rules(global_loop_ref, &hostnamesToRemove, ipc_discriminator);
             }
 
 #endif
@@ -1496,13 +1498,37 @@ static void run(int argc, char *argv[]) {
     signal(SIGINT, interrupt_handler);
     log_init(global_loop_ref, log_level, ziti_log_writer); // level from config file set below
     log_fn = ziti_log_writer;
-    remove_all_nrpt_rules(DEFAULT_EXECUTABLE_NAME, false); //remove all rules starting with ziti-edge-tunnel
 #else
     ziti_log_init(global_loop_ref, log_level, log_fn);
 #endif
 
     model_list ipc_list = {0};
     size_t other_zets = find_other_zets(&ipc_list, sockfilebase);
+
+#if _WIN32
+    {
+        // Remove NRPT rules from dead instances only; preserve rules owned by running instances.
+        size_t base_len = strlen(sockfilebase);
+        const char **running_ids = calloc(other_zets + 1, sizeof(char *));
+        size_t n = 0;
+        const char *sock_name;
+        MODEL_LIST_FOREACH(sock_name, ipc_list) {
+            char *disc = (strlen(sock_name) > base_len && sock_name[base_len] == '.')
+                         ? strdup(sock_name + base_len + 1) : NULL;
+            running_ids[n++] = get_zet_instance_id(disc);
+            free(disc);
+        }
+        if (n > 0) {
+            ZITI_LOG(INFO, "preserving NRPT rules for %zd running instance(s); removing orphaned rules", n);
+        } else {
+            ZITI_LOG(INFO, "no other instances running; removing all orphaned NRPT rules");
+        }
+        remove_orphaned_nrpt_rules(running_ids, n);
+        for (size_t i = 0; i < n; i++) free((char *)running_ids[i]);
+        free(running_ids);
+    }
+#endif
+
     configure_ipc(true, other_zets > 0);
     model_list_clear(&ipc_list, free);
 
@@ -2360,54 +2386,68 @@ static void select_ipc_instance(void) {
         return;
     }
 
-    // if multiple instances: collect discriminators then prompt
+    // probe all candidates and keep only the responsive ones
     char **discriminators = calloc(count, sizeof(char *));
-    int idx = 0;
+    probe_result *results = calloc(count, sizeof(probe_result));
+    int live = 0;
     const char *name;
     MODEL_LIST_FOREACH(name, ipc_list) {
-        if (strlen(name) > base_len && name[base_len] == '.') {
-            discriminators[idx] = strdup(name + base_len + 1);
-        } else {
-            discriminators[idx] = NULL; // default instance
-        }
-        idx++;
-    }
-    model_list_clear(&ipc_list, free);
-
-    fprintf(stderr, "Multiple ziti-edge-tunnel instances found. Select one:\n");
-    for (int i = 0; i < (int)count; i++) {
+        char *disc = (strlen(name) > base_len && name[base_len] == '.')
+                     ? strdup(name + base_len + 1) : NULL;
         char probe_path[256];
-        if (discriminators[i]) {
-            snprintf(probe_path, sizeof(probe_path), "%s%s.%s", SOCKET_PATH, sockfilebase, discriminators[i]);
+        if (disc) {
+            snprintf(probe_path, sizeof(probe_path), "%s%s.%s", SOCKET_PATH, sockfilebase, disc);
         } else {
             snprintf(probe_path, sizeof(probe_path), "%s%s", SOCKET_PATH, sockfilebase);
         }
-        probe_result r;
-        probe_instance(probe_path, &r);
+        probe_instance(probe_path, &results[live]);
+        if (strcmp(results[live].tun_name, "?") != 0) {
+            discriminators[live++] = disc;
+        } else {
+            ZITI_LOG(DEBUG, "skipping unresponsive socket: %s", probe_path);
+            free(disc);
+        }
+    }
+    model_list_clear(&ipc_list, free);
+
+    if (live <= 1) {
+        if (live == 1 && discriminators[0] != NULL) {
+            ipc_discriminator = discriminators[0];
+        } else {
+            free(discriminators[0]);
+        }
+        free(discriminators);
+        free(results);
+        return;
+    }
+
+    fprintf(stderr, "Multiple ziti-edge-tunnel instances found. Select one:\n");
+    for (int i = 0; i < live; i++) {
         const char *label = discriminators[i] ? discriminators[i] : "default";
-        fprintf(stderr, "  [%d] %-10s  %-10s  IP: %-15s  DNS: %s\n", i, label, r.tun_name, r.ip, r.dns);
+        fprintf(stderr, "  [%d] %-10s  %-10s  IP: %-15s  DNS: %s\n", i, label, results[i].tun_name, results[i].ip, results[i].dns);
     }
 
     int choice = 0;
     fprintf(stderr, "  (use -P <value> to skip this prompt)\n");
     char input[32];
     for (;;) {
-        fprintf(stderr, "Enter number [0-%d] (default 0): ", (int)count - 1);
+        fprintf(stderr, "Enter number [0-%d] (default 0): ", live - 1);
         if (fgets(input, sizeof(input), stdin) == NULL) break; // EOF -> default 0
         if (input[0] == '\n') break; // empty -> default 0
         int parsed = -1;
-        if (sscanf(input, "%d", &parsed) == 1 && parsed >= 0 && parsed < (int)count) {
+        if (sscanf(input, "%d", &parsed) == 1 && parsed >= 0 && parsed < live) {
             choice = parsed;
             break;
         }
-        fprintf(stderr, "  Invalid input, please enter a number between 0 and %d\n", (int)count - 1);
+        fprintf(stderr, "  Invalid input, please enter a number between 0 and %d\n", live - 1);
     }
 
     ipc_discriminator = discriminators[choice];
-    for (int i = 0; i < (int)count; i++) {
+    for (int i = 0; i < live; i++) {
         if (i != choice) free(discriminators[i]);
     }
     free(discriminators);
+    free(results);
 }
 
 static void send_message_to_tunnel_fn(int argc, char *argv[]) {
@@ -3269,7 +3309,9 @@ void stop_tunnel_and_cleanup() {
     send_tunnel_command_inline(tnl_cmd, NULL);
 
     ZITI_LOG(INFO,"removing nrpt rules");
-    remove_all_nrpt_rules(DEFAULT_EXECUTABLE_NAME, false); //remove all rules starting with ziti-edge-tunnel
+    char *zet_id = get_zet_instance_id(ipc_discriminator);
+    remove_all_nrpt_rules(zet_id, true);
+    free(zet_id);
 
     ZITI_LOG(INFO,"cleaning instance config ");
     cleanup_instance_config();

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1616,7 +1616,9 @@ static void run(int argc, char *argv[]) {
     char *csdk_version = "" to_str(ZITI_VERSION) ":" to_str(ZITI_BRANCH) "@" to_str(ZITI_COMMIT);
     ZITI_LOG(INFO,"	- C SDK Version    : %s", csdk_version);
     ZITI_LOG(INFO,"	- Tunneler SDK     : %s", ziti_tunneler_version());
-    ZITI_LOG(INFO,"	- IPC socket       : %s", sockfile);
+    if(ipc_discriminator != NULL) {
+        ZITI_LOG(INFO,"	- IPC socket       : %s", sockfile);
+    }
     if(openssl_conf_resolved != NULL) {
         ZITI_LOG(INFO, "	- openssl config   : configured using %s found by %s", openssl_conf_resolved, openssl_conf_found_by);
     }
@@ -2268,7 +2270,138 @@ static int send_message_to_tunnel(char* message, bool show_result) {
     return code;
 }
 
+// Connect to a single ziti-edge-tunnel IPC socket and retrieve its TunName, IP, and DNS
+// for display purposes. Fills output buffers with "?" on any failure.
+static void probe_instance(const char *socket_path, char *tun_name_out, size_t tun_name_sz, char *ip_out, size_t ip_sz, char *dns_out, size_t dns_sz) {
+    strncpy(tun_name_out, "?", tun_name_sz);
+    strncpy(ip_out, "?", ip_sz);
+    strncpy(dns_out, "?", dns_sz);
+
+    const char *status_cmd = "{\"Command\":\"Status\"}";
+#if _WIN32
+    HANDLE h = CreateFileA(socket_path, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+                           OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
+    if (h == INVALID_HANDLE_VALUE) return;
+    DWORD written;
+    if (!WriteFile(h, status_cmd, (DWORD)strlen(status_cmd), &written, NULL)) {
+        CloseHandle(h);
+        return;
+    }
+    char buf[16*1024] = {0};
+    DWORD nr;
+    if (!ReadFile(h, buf, sizeof(buf) - 1, &nr, NULL)) {
+        CloseHandle(h);
+        return;
+    }
+    CloseHandle(h);
+#else
+    uv_os_sock_t s = socket(AF_UNIX, SOCK_STREAM, 0);
+    struct sockaddr_un addr = { .sun_family = AF_UNIX };
+    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+    if (connect(s, (const struct sockaddr *) &addr, sizeof(addr))) return;
+    if (write(s, status_cmd, strlen(status_cmd)) < 0) { close(s); return; }
+    char buf[16*1024] = {0};
+    ssize_t nr = read(s, buf, sizeof(buf) - 1);
+    close(s);
+    if (nr <= 0) return;
+#endif
+
+    struct json_tokener *tok = json_tokener_new();
+    struct json_object *resp = json_tokener_parse_ex(tok, buf, (int)nr);
+    json_tokener_free(tok);
+    if (!resp) return;
+
+    struct json_object *data = json_object_object_get(resp, "Data");
+    if (data) {
+        struct json_object *tn = json_object_object_get(data, "TunName");
+        if (tn) strncpy(tun_name_out, json_object_get_string(tn), tun_name_sz - 1);
+        struct json_object *ip_info = json_object_object_get(data, "IpInfo");
+        if (ip_info) {
+            struct json_object *ip = json_object_object_get(ip_info, "Ip");
+            if (ip) strncpy(ip_out, json_object_get_string(ip), ip_sz - 1);
+            struct json_object *dns = json_object_object_get(ip_info, "DNS");
+            if (dns) strncpy(dns_out, json_object_get_string(dns), dns_sz - 1);
+        }
+    }
+    json_object_put(resp);
+}
+
+// If -P was not supplied, scan for running ziti-edge-tunnel IPC sockets.
+// With exactly one found, auto-select it. With multiple, probe each for its
+// tunnel info and prompt the user to choose before proceeding with the command.
+static void select_ipc_instance(void) {
+    if (ipc_discriminator != NULL) {
+        return; // user already specified -P
+    }
+
+    model_list ipc_list = {0};
+    size_t count = find_other_zets(&ipc_list, SOCKET_PATH, sockfilebase);
+    size_t base_len = strlen(sockfilebase);
+
+    if (count <= 1) {
+        // auto-select the single instance (or use default if none found)
+        const char *name;
+        MODEL_LIST_FOREACH(name, ipc_list) {
+            if (strlen(name) > base_len && name[base_len] == '.') {
+                ipc_discriminator = strdup(name + base_len + 1);
+            }
+        }
+        model_list_clear(&ipc_list, free);
+        return;
+    }
+
+    // Multiple instances: collect discriminators then prompt
+    char **discriminators = calloc(count, sizeof(char *));
+    int idx = 0;
+    const char *name;
+    MODEL_LIST_FOREACH(name, ipc_list) {
+        if (strlen(name) > base_len && name[base_len] == '.') {
+            discriminators[idx] = strdup(name + base_len + 1);
+        } else {
+            discriminators[idx] = NULL; // default instance
+        }
+        idx++;
+    }
+    model_list_clear(&ipc_list, free);
+
+    fprintf(stderr, "Multiple ziti-edge-tunnel instances found. Select one:\n");
+    for (int i = 0; i < (int)count; i++) {
+        char probe_path[256];
+        if (discriminators[i]) {
+            snprintf(probe_path, sizeof(probe_path), "%s%s.%s", SOCKET_PATH, sockfilebase, discriminators[i]);
+        } else {
+            snprintf(probe_path, sizeof(probe_path), "%s%s", SOCKET_PATH, sockfilebase);
+        }
+        char tun_name[64], ip[32], dns[32];
+        probe_instance(probe_path, tun_name, sizeof(tun_name), ip, sizeof(ip), dns, sizeof(dns));
+        const char *label = discriminators[i] ? discriminators[i] : "default";
+        fprintf(stderr, "  [%d] %-10s  %-10s  IP: %-15s  DNS: %s\n", i, label, tun_name, ip, dns);
+    }
+
+    int choice = 0;
+    fprintf(stderr, "  (use -P <value> to skip this prompt)\n");
+    char input[32];
+    for (;;) {
+        fprintf(stderr, "Enter number [0-%d] (default 0): ", (int)count - 1);
+        if (fgets(input, sizeof(input), stdin) == NULL) break; // EOF -> default 0
+        if (input[0] == '\n') break; // empty -> default 0
+        int parsed = -1;
+        if (sscanf(input, "%d", &parsed) == 1 && parsed >= 0 && parsed < (int)count) {
+            choice = parsed;
+            break;
+        }
+        fprintf(stderr, "  Invalid input, please enter a number between 0 and %d\n", (int)count - 1);
+    }
+
+    ipc_discriminator = discriminators[choice]; // transfer ownership
+    for (int i = 0; i < (int)count; i++) {
+        if (i != choice) free(discriminators[i]);
+    }
+    free(discriminators);
+}
+
 static void send_message_to_tunnel_fn(int argc, char *argv[]) {
+    select_ipc_instance();
     configure_ipc(false, ipc_discriminator != NULL);
     char* json = tunnel_command_to_json(&cmd, MODEL_JSON_COMPACT, NULL);
     int result = send_message_to_tunnel(json, cmd.show_result);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1451,16 +1451,16 @@ size_t find_other_zets(model_list *ipcs, const char *ipc_base, const char *ipc_p
 }
 
 static void configure_ipc(bool automatic_ipc_discriminator, bool use_discriminator) {
-    if (ipc_discriminator == NULL && automatic_ipc_discriminator) {
-        int pid = getpid();
+    if (ipc_discriminator == NULL && automatic_ipc_discriminator && use_discriminator) {
+        const int pid = getpid();
         ipc_discriminator = calloc(10, sizeof(char));
         snprintf(ipc_discriminator, 10, "%d", pid);
     }
 
-    size_t socket_path_len = strlen(SOCKET_PATH);
-    size_t ipc_discriminator_len = ipc_discriminator != NULL ? strlen(ipc_discriminator) : 0;
-    size_t sockfilebase_len = strlen(sockfilebase);
-    size_t eventsockfilebase_len = strlen(eventsockfilebase);
+    const size_t socket_path_len = strlen(SOCKET_PATH);
+    const size_t ipc_discriminator_len = ipc_discriminator != NULL ? strlen(ipc_discriminator) : 0;
+    const size_t sockfilebase_len = strlen(sockfilebase);
+    const size_t eventsockfilebase_len = strlen(eventsockfilebase);
 
     sockfile = calloc(socket_path_len + sockfilebase_len + ipc_discriminator_len + 2, sizeof(char));
     eventsockfile = calloc(socket_path_len + eventsockfilebase_len + ipc_discriminator_len + 2, sizeof(char));


### PR DESCRIPTION
This PR will: 

  - add a new global flag -P|--pipe <name> suffixes the IPC pipe (\\.\pipe\ziti-edge-tunnel.sock.<name>),
accepted by every subcommand. This is to support addressing a targetted tunneler. If no -P is supplied, it uses the 'default' socket for backward compatibility.
  - A run with no -P uses the default pipe if free, if the default pipe is in use it will fall back to appending a PID suffix except on windows when running as a service. The windows service is expected to always use the default pipe.
  - On windows, NRPT rules are tagged in their Comment with an instance ID; add/remove uses exact match, so
  one instance never touches another's rules. On startup, the new process will do a sweep for orphans only by detecting running tunnelers and only removing ones that don't match running tunnelers.
  - Client-side instance picker: subcommands like add/on/off/dump without -P probe live
  instances and prompt if more than one is running, so multi-instance is usable from the CLI, not
  just write-only.
  - Linux/Mac stale-socket cleanup: Unix sockets outlive their process, so on startup each candidate
  is connect()-probed and dead ones are ignored, instead of confusing multi-instance detection.
