### PR TITLE
install git from standard ubuntu package repos 

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,7 +34,7 @@ jobs:
             name: Windows x86_64(win32crypto)
             preset: windows-x64-win32crypto
 
-          - os: windows-latest
+          - os: windows-2022
             name: Windows arm64
             preset: windows-arm64-vs2022
 

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -63,20 +63,16 @@ jobs:
       - name: Print Environment Variables and Event JSON
         uses: hmarr/debug-action@v3
 
-      # only focal-20.04 has >= 2.18, which is required by actions/checkout to clone
-      # which enables cmake version discovery
       - name: Install contemporary Git in runner container if Ubuntu
         if: ${{ matrix.distro.name == 'ubuntu' }}
         shell: bash
         run: |
           set -o pipefail
           set -o xtrace
-          #apt-get update
-          #apt-get install --yes software-properties-common
-          #add-apt-repository --yes ppa:git-core/ppa
-          #apt-get update
-          #echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/80retries
-          #apt-get install --yes git
+          apt-get update
+          apt-get install --yes git
+          # note: only focal-20.04 has >= 2.18, which is required by actions/checkout to clone
+          # which enables cmake version discovery
           git --version
 
       - name: Install contemporary Git in runner container if RedHat

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -75,6 +75,7 @@ jobs:
           apt-get install --yes software-properties-common
           add-apt-repository --yes ppa:git-core/ppa
           apt-get update
+          echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/80retries
           apt-get install --yes git
           git --version
 

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -63,6 +63,22 @@ jobs:
       - name: Print Environment Variables and Event JSON
         uses: hmarr/debug-action@v3
 
+      # only focal-20.04 has >= 2.18, which is required by actions/checkout to clone
+      # which enables cmake version discovery
+      - name: Install contemporary Git in runner container if Ubuntu
+        if: ${{ matrix.distro.name == 'ubuntu' }}
+        shell: bash
+        run: |
+          set -o pipefail
+          set -o xtrace
+          #apt-get update
+          #apt-get install --yes software-properties-common
+          #add-apt-repository --yes ppa:git-core/ppa
+          #apt-get update
+          #echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/80retries
+          #apt-get install --yes git
+          git --version
+
       - name: Install contemporary Git in runner container if RedHat
         if: ${{ matrix.distro.name == 'redhat' }}
         shell: bash

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -63,22 +63,6 @@ jobs:
       - name: Print Environment Variables and Event JSON
         uses: hmarr/debug-action@v3
 
-      # only focal-20.04 has >= 2.18, which is required by actions/checkout to clone
-      # which enables cmake version discovery
-      - name: Install contemporary Git in runner container if Ubuntu
-        if: ${{ matrix.distro.name == 'ubuntu' }}
-        shell: bash
-        run: |
-          set -o pipefail
-          set -o xtrace
-          apt-get update
-          apt-get install --yes software-properties-common
-          add-apt-repository --yes ppa:git-core/ppa
-          apt-get update
-          echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/80retries
-          apt-get install --yes git
-          git --version
-
       - name: Install contemporary Git in runner container if RedHat
         if: ${{ matrix.distro.name == 'redhat' }}
         shell: bash


### PR DESCRIPTION
The git-core ppa was acting up, and we no longer need it since our oldest supported distro includes a sufficiently modern version of git.