### PR TITLE
Expand IPC integration tests: MFA flows + Enrollment

### DIFF
--- a/tests/integration/add_identity_test.go
+++ b/tests/integration/add_identity_test.go
@@ -33,6 +33,7 @@ func TestAddIdentity(t *testing.T) {
 	t.Run("withJwtSucceeds", testAddIdentityWithJwtSucceeds)
 	t.Run("sameJwtTwiceSecondFails", testAddIdentitySameJwtTwiceSecondFails)
 	t.Run("withInvalidJwtFails", testAddIdentityWithInvalidJwtFails)
+	t.Run("withEmptyJwtFails", testAddIdentityWithEmptyJwtFails)
 	t.Run("emitsIdentityAddedEvent", testAddIdentityEmitsIdentityAddedEvent)
 }
 
@@ -124,6 +125,32 @@ func testAddIdentityWithInvalidJwtFails(t *testing.T) {
 	require.False(t, resp.Success, "invalid JWT should be rejected, got Success=true")
 	require.NotEqual(t, 0, resp.Code, "expected non-zero error code for invalid JWT")
 	t.Logf("invalid JWT correctly rejected: code=%d error=%q", resp.Code, resp.Error)
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after failed AddIdentity\n%s", zet.Logs())
+	idFile := filepath.Join(status.ConfigDir, identityName+".json")
+	_, statErr := os.Stat(idFile)
+	require.True(t, os.IsNotExist(statErr), "identity file should not exist after failed enroll: %s\n%s", idFile, zet.Logs())
+}
+
+func testAddIdentityWithEmptyJwtFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityName := identityNameFor(t)
+	emptyJwt := ""
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: identityName,
+		JwtContent:       &emptyJwt,
+	}
+	resp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "IPC send should succeed even when enrollment fails\n%s", zet.Logs())
+	require.False(t, resp.Success, "empty JWT should be rejected, got Success=true")
+	t.Logf("empty JWT correctly rejected: code=%d error=%q", resp.Code, resp.Error)
 
 	status, err := client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after failed AddIdentity\n%s", zet.Logs())

--- a/tests/integration/add_identity_test.go
+++ b/tests/integration/add_identity_test.go
@@ -37,6 +37,7 @@ func TestAddIdentity(t *testing.T) {
 	t.Run("withDeletedIdentityFails", testAddIdentityWithDeletedIdentityFails)
 	t.Run("withSlashInFilenameFails", testAddIdentityWithSlashInFilenameFails)
 	t.Run("withDotDotInFilenameFails", testAddIdentityWithDotDotInFilenameFails)
+	t.Run("filenameExceedsCharLimitFails", testAddIdentityFilenameExceedsCharLimitFails)
 	t.Run("emitsIdentityAddedEvent", testAddIdentityEmitsIdentityAddedEvent)
 }
 
@@ -235,6 +236,29 @@ func testAddIdentityWithDotDotInFilenameFails(t *testing.T) {
 	require.NoError(t, err, "IPC send\n%s", zet.Logs())
 	require.False(t, resp.Success, "filename with .. should be rejected, got Success=true")
 	t.Logf("dot-dot filename correctly rejected: code=%d error=%q", resp.Code, resp.Error)
+}
+
+func testAddIdentityFilenameExceedsCharLimitFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	jwt, err := overlay.CreateIdentityJWT(ctx, identityNameFor(t))
+	require.NoError(t, err, "mint JWT via overlay")
+	require.NotEmpty(t, jwt)
+
+	longName := strings.Repeat("a", 300)
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: longName,
+		JwtContent:       &jwt,
+	}
+	resp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "IPC send\n%s", zet.Logs())
+	require.False(t, resp.Success, "long filename should be rejected, got Success=true")
+	t.Logf("long filename correctly rejected: code=%d error=%q", resp.Code, resp.Error)
 }
 
 func testAddIdentityEmitsIdentityAddedEvent(t *testing.T) {

--- a/tests/integration/add_identity_test.go
+++ b/tests/integration/add_identity_test.go
@@ -51,7 +51,6 @@ func testAddIdentityWithJwtSucceeds(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, identityName)
 	require.NoError(t, err, "mint JWT via overlay")
 	require.NotEmpty(t, jwt, "JWT content should not be empty")
-	t.Logf("JWT minted for identity %q (%d bytes)", identityName, len(jwt))
 
 	client, err := testutil.DialIPC(ctx)
 	require.NoError(t, err, "dial ZET IPC pipe")
@@ -65,7 +64,6 @@ func testAddIdentityWithJwtSucceeds(t *testing.T) {
 	resp, err := client.AddIdentity(ctx, identityData)
 	require.NoError(t, err, "send AddIdentity command\n%s", zet.Logs())
 	require.True(t, resp.Success, "AddIdentity failed: error=%q code=%d\n%s", resp.Error, resp.Code, zet.Logs())
-	t.Logf("AddIdentity succeeded: filename=%q code=%d", identityName, resp.Code)
 
 	status, err := client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
@@ -85,7 +83,6 @@ func testAddIdentitySameJwtTwiceSecondFails(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, identityName)
 	require.NoError(t, err, "mint JWT via overlay")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", identityName, len(jwt))
 
 	client, err := testutil.DialIPC(ctx)
 	require.NoError(t, err, "dial ZET IPC pipe")
@@ -99,7 +96,6 @@ func testAddIdentitySameJwtTwiceSecondFails(t *testing.T) {
 	first, err := client.AddIdentity(ctx, identityData)
 	require.NoError(t, err, "first AddIdentity send\n%s", zet.Logs())
 	require.True(t, first.Success, "first AddIdentity should succeed: error=%q\n%s", first.Error, zet.Logs())
-	t.Logf("first AddIdentity succeeded")
 
 	second, err := client.AddIdentity(ctx, identityData)
 	require.NoError(t, err, "second AddIdentity send\n%s", zet.Logs())
@@ -144,7 +140,6 @@ func testAddIdentityEmitsIdentityAddedEvent(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, identityName)
 	require.NoError(t, err, "mint JWT via overlay")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", identityName, len(jwt))
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -171,7 +166,6 @@ func testAddIdentityEmitsIdentityAddedEvent(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
 		if event.Op != "identity" || event.Action != "added" || event.Fingerprint != identityName {
-			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
 			continue
 		}
 

--- a/tests/integration/add_identity_test.go
+++ b/tests/integration/add_identity_test.go
@@ -35,6 +35,7 @@ func TestAddIdentity(t *testing.T) {
 	t.Run("withInvalidJwtFails", testAddIdentityWithInvalidJwtFails)
 	t.Run("withEmptyJwtFails", testAddIdentityWithEmptyJwtFails)
 	t.Run("withDeletedIdentityFails", testAddIdentityWithDeletedIdentityFails)
+	t.Run("withInvalidFilenameFails", testAddIdentityWithInvalidFilenameFails)
 	t.Run("emitsIdentityAddedEvent", testAddIdentityEmitsIdentityAddedEvent)
 }
 
@@ -189,6 +190,28 @@ func testAddIdentityWithDeletedIdentityFails(t *testing.T) {
 	idFile := filepath.Join(status.ConfigDir, identityName+".json")
 	_, statErr := os.Stat(idFile)
 	require.True(t, os.IsNotExist(statErr), "identity file should not exist after failed enroll: %s\n%s", idFile, zet.Logs())
+}
+
+func testAddIdentityWithInvalidFilenameFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	jwt, err := overlay.CreateIdentityJWT(ctx, identityNameFor(t))
+	require.NoError(t, err, "mint JWT via overlay")
+	require.NotEmpty(t, jwt)
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: "../escape",
+		JwtContent:       &jwt,
+	}
+	resp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "IPC send\n%s", zet.Logs())
+	require.False(t, resp.Success, "path-traversal filename should be rejected, got Success=true")
+	t.Logf("path-traversal filename correctly rejected: code=%d error=%q", resp.Code, resp.Error)
 }
 
 func testAddIdentityEmitsIdentityAddedEvent(t *testing.T) {

--- a/tests/integration/add_identity_test.go
+++ b/tests/integration/add_identity_test.go
@@ -35,7 +35,8 @@ func TestAddIdentity(t *testing.T) {
 	t.Run("withInvalidJwtFails", testAddIdentityWithInvalidJwtFails)
 	t.Run("withEmptyJwtFails", testAddIdentityWithEmptyJwtFails)
 	t.Run("withDeletedIdentityFails", testAddIdentityWithDeletedIdentityFails)
-	t.Run("withInvalidFilenameFails", testAddIdentityWithInvalidFilenameFails)
+	t.Run("withSlashInFilenameFails", testAddIdentityWithSlashInFilenameFails)
+	t.Run("withDotDotInFilenameFails", testAddIdentityWithDotDotInFilenameFails)
 	t.Run("emitsIdentityAddedEvent", testAddIdentityEmitsIdentityAddedEvent)
 }
 
@@ -192,7 +193,29 @@ func testAddIdentityWithDeletedIdentityFails(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "identity file should not exist after failed enroll: %s\n%s", idFile, zet.Logs())
 }
 
-func testAddIdentityWithInvalidFilenameFails(t *testing.T) {
+func testAddIdentityWithSlashInFilenameFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	jwt, err := overlay.CreateIdentityJWT(ctx, identityNameFor(t))
+	require.NoError(t, err, "mint JWT via overlay")
+	require.NotEmpty(t, jwt)
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: "foo/bar",
+		JwtContent:       &jwt,
+	}
+	resp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "IPC send\n%s", zet.Logs())
+	require.False(t, resp.Success, "filename with slash should be rejected, got Success=true")
+	t.Logf("slash filename correctly rejected: code=%d error=%q", resp.Code, resp.Error)
+}
+
+func testAddIdentityWithDotDotInFilenameFails(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -210,8 +233,8 @@ func testAddIdentityWithInvalidFilenameFails(t *testing.T) {
 	}
 	resp, err := client.AddIdentity(ctx, identityData)
 	require.NoError(t, err, "IPC send\n%s", zet.Logs())
-	require.False(t, resp.Success, "path-traversal filename should be rejected, got Success=true")
-	t.Logf("path-traversal filename correctly rejected: code=%d error=%q", resp.Code, resp.Error)
+	require.False(t, resp.Success, "filename with .. should be rejected, got Success=true")
+	t.Logf("dot-dot filename correctly rejected: code=%d error=%q", resp.Code, resp.Error)
 }
 
 func testAddIdentityEmitsIdentityAddedEvent(t *testing.T) {

--- a/tests/integration/add_identity_test.go
+++ b/tests/integration/add_identity_test.go
@@ -34,6 +34,7 @@ func TestAddIdentity(t *testing.T) {
 	t.Run("sameJwtTwiceSecondFails", testAddIdentitySameJwtTwiceSecondFails)
 	t.Run("withInvalidJwtFails", testAddIdentityWithInvalidJwtFails)
 	t.Run("withEmptyJwtFails", testAddIdentityWithEmptyJwtFails)
+	t.Run("withDeletedIdentityFails", testAddIdentityWithDeletedIdentityFails)
 	t.Run("emitsIdentityAddedEvent", testAddIdentityEmitsIdentityAddedEvent)
 }
 
@@ -151,6 +152,37 @@ func testAddIdentityWithEmptyJwtFails(t *testing.T) {
 	require.NoError(t, err, "IPC send should succeed even when enrollment fails\n%s", zet.Logs())
 	require.False(t, resp.Success, "empty JWT should be rejected, got Success=true")
 	t.Logf("empty JWT correctly rejected: code=%d error=%q", resp.Code, resp.Error)
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after failed AddIdentity\n%s", zet.Logs())
+	idFile := filepath.Join(status.ConfigDir, identityName+".json")
+	_, statErr := os.Stat(idFile)
+	require.True(t, os.IsNotExist(statErr), "identity file should not exist after failed enroll: %s\n%s", idFile, zet.Logs())
+}
+
+func testAddIdentityWithDeletedIdentityFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	identityName := identityNameFor(t)
+	jwt, err := overlay.CreateIdentityJWT(ctx, identityName)
+	require.NoError(t, err, "mint JWT via overlay")
+	require.NotEmpty(t, jwt)
+
+	require.NoError(t, overlay.DeleteIdentity(ctx, identityName), "delete identity via overlay")
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: identityName,
+		JwtContent:       &jwt,
+	}
+	resp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "IPC send should succeed even when enrollment fails\n%s", zet.Logs())
+	require.False(t, resp.Success, "JWT for deleted identity should be rejected, got Success=true")
+	t.Logf("JWT identity deleted from controller correctly rejected: code=%d error=%q", resp.Code, resp.Error)
 
 	status, err := client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after failed AddIdentity\n%s", zet.Logs())

--- a/tests/integration/identity_on_off_test.go
+++ b/tests/integration/identity_on_off_test.go
@@ -42,7 +42,6 @@ func testIdentityOnOffTogglesActiveOff(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	identityData := testutil.AddIdentityData{
 		IdentityFilename: name,
@@ -60,7 +59,6 @@ func testIdentityOnOffTogglesActiveOff(t *testing.T) {
 	offResp, err := client.IdentityOnOff(ctx, entry.Identifier, false)
 	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
 	require.True(t, offResp.Success, "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
-	t.Logf("IdentityOnOff(false) succeeded")
 
 	status, err = client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status send after off\n%s", zet.Logs())
@@ -82,7 +80,6 @@ func testIdentityOnOffTogglesActiveOn(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	identityData := testutil.AddIdentityData{
 		IdentityFilename: name,
@@ -104,7 +101,6 @@ func testIdentityOnOffTogglesActiveOn(t *testing.T) {
 	onResp, err := client.IdentityOnOff(ctx, entry.Identifier, true)
 	require.NoError(t, err, "IdentityOnOff(true) send\n%s", zet.Logs())
 	require.True(t, onResp.Success, "IdentityOnOff(true) failed: error=%q code=%d", onResp.Error, onResp.Code)
-	t.Logf("IdentityOnOff(true) succeeded")
 
 	status, err = client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status send after on\n%s", zet.Logs())

--- a/tests/integration/identity_on_off_test.go
+++ b/tests/integration/identity_on_off_test.go
@@ -67,6 +67,7 @@ func testIdentityOnOffTogglesActiveOff(t *testing.T) {
 	entry = status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after off", name)
 	require.False(t, entry.Active, "Status.Identities[%q].Active should be false after IdentityOnOff(false)", name)
+	t.Logf("IdentityOnOff(false) ID Active=%t", entry.Active)
 }
 
 func testIdentityOnOffTogglesActiveOn(t *testing.T) {
@@ -110,4 +111,5 @@ func testIdentityOnOffTogglesActiveOn(t *testing.T) {
 	entry = status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after on", name)
 	require.True(t, entry.Active, "Status.Identities[%q].Active should be true after IdentityOnOff(true)", name)
+	t.Logf("IdentityOnOff(true) ID Active=%t", entry.Active)
 }

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -60,7 +60,6 @@ func testEnableMFAAcceptsJwtEnrolledIdentity(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -90,7 +89,6 @@ func testEnableMFAAcceptsJwtEnrolledIdentity(t *testing.T) {
 	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
 	require.NotEmpty(t, mfa.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
 	require.False(t, mfa.IsVerified, "EnableMFA Data.IsVerified should be false before verify_mfa")
-	t.Logf("EnableMFA succeeded: provisioning_url=%q recovery_codes=%d", mfa.ProvisioningUrl, len(mfa.RecoveryCodes))
 }
 
 func testEnableMFAAcceptsTotpRequiredAuthPolicy(t *testing.T) {
@@ -102,12 +100,10 @@ func testEnableMFAAcceptsTotpRequiredAuthPolicy(t *testing.T) {
 	name := identityNameFor(t)
 	policy := name + "-policy"
 	require.NoError(t, overlay.CreateAuthPolicyRequiringTOTP(ctx, policy), "create auth policy")
-	t.Logf("auth policy %q created (--secondary-req-totp)", policy)
 
 	jwt, err := overlay.CreateIdentityJWTWithAuthPolicy(ctx, name, policy)
 	require.NoError(t, err, "mint JWT for identity bound to %q", policy)
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q bound to policy %q (%d bytes)", name, policy, len(jwt))
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -136,7 +132,6 @@ func testEnableMFAAcceptsTotpRequiredAuthPolicy(t *testing.T) {
 	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
 	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
 	require.NotEmpty(t, mfa.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
-	t.Logf("EnableMFA succeeded for TOTP-required identity: provisioning_url=%q", mfa.ProvisioningUrl)
 }
 
 func testVerifyMFAAcceptsValidTotp(t *testing.T) {
@@ -147,7 +142,6 @@ func testVerifyMFAAcceptsValidTotp(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -183,12 +177,10 @@ func testVerifyMFAAcceptsValidTotp(t *testing.T) {
 
 	code, err := generateTotpCode(secret, time.Now())
 	require.NoError(t, err, "compute TOTP")
-	t.Logf("computed TOTP code from secret (%d chars)", len(secret))
 
 	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
-	t.Logf("VerifyMFA succeeded: code=%d", verifyResp.Code)
 
 	status, err = client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after VerifyMFA\n%s", zet.Logs())
@@ -206,7 +198,6 @@ func testVerifyMFARejectsInvalidTotp(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -255,7 +246,6 @@ func testMFAReauthenticationAcceptsValidTotp(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -295,7 +285,6 @@ func testMFAReauthenticationAcceptsValidTotp(t *testing.T) {
 	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
-	t.Logf("VerifyMFA succeeded")
 
 	offResp, err := client.IdentityOnOff(ctx, entry.Identifier, false)
 	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
@@ -319,7 +308,6 @@ func testMFAReauthenticationAcceptsValidTotp(t *testing.T) {
 	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
 	require.True(t, submitResp.Success, "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, zet.Logs())
-	t.Logf("SubmitMFA succeeded: code=%d", submitResp.Code)
 
 	status, err = client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after SubmitMFA\n%s", zet.Logs())
@@ -338,7 +326,6 @@ func testMFAReauthenticationAcceptsRecoveryCode(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -379,7 +366,6 @@ func testMFAReauthenticationAcceptsRecoveryCode(t *testing.T) {
 	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
-	t.Logf("VerifyMFA succeeded")
 
 	offResp, err := client.IdentityOnOff(ctx, entry.Identifier, false)
 	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
@@ -400,7 +386,6 @@ func testMFAReauthenticationAcceptsRecoveryCode(t *testing.T) {
 	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, mfa.RecoveryCodes[0])
 	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
 	require.True(t, submitResp.Success, "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, zet.Logs())
-	t.Logf("SubmitMFA with recovery code succeeded: code=%d", submitResp.Code)
 
 	status, err = client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after SubmitMFA\n%s", zet.Logs())
@@ -419,7 +404,6 @@ func testRemoveMFAAcceptsValidTotp(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -459,7 +443,6 @@ func testRemoveMFAAcceptsValidTotp(t *testing.T) {
 	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
-	t.Logf("VerifyMFA succeeded")
 
 	code, err = generateTotpCode(secret, time.Now())
 	require.NoError(t, err, "compute TOTP")
@@ -467,7 +450,6 @@ func testRemoveMFAAcceptsValidTotp(t *testing.T) {
 	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
 	require.True(t, removeResp.Success, "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, zet.Logs())
-	t.Logf("RemoveMFA succeeded: code=%d", removeResp.Code)
 
 	status, err = client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after RemoveMFA\n%s", zet.Logs())
@@ -485,7 +467,6 @@ func testRemoveMFAAcceptsRecoveryCode(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -526,12 +507,10 @@ func testRemoveMFAAcceptsRecoveryCode(t *testing.T) {
 	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
-	t.Logf("VerifyMFA succeeded")
 
 	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, mfa.RecoveryCodes[0])
 	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
 	require.True(t, removeResp.Success, "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, zet.Logs())
-	t.Logf("RemoveMFA succeeded with recovery code: code=%d", removeResp.Code)
 
 	status, err = client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after RemoveMFA\n%s", zet.Logs())

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -42,7 +42,8 @@ func TestVerifyMFA(t *testing.T) {
 }
 
 func TestMFAReauthentication(t *testing.T) {
-	t.Run("afterIdentityToggle", testMFAReauthenticationAfterIdentityToggle)
+	t.Run("withValidTotp", testMFAReauthenticationWithValidTotp)
+	t.Run("withRecoveryCode", testMFAReauthenticationWithRecoveryCode)
 }
 
 func TestRemoveMFA(t *testing.T) {
@@ -196,7 +197,7 @@ func testVerifyMFAWithValidTotp(t *testing.T) {
 	t.Logf("VerifyMFA ID MfaEnabled=%t", entry.MfaEnabled)
 }
 
-func testMFAReauthenticationAfterIdentityToggle(t *testing.T) {
+func testMFAReauthenticationWithValidTotp(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -269,6 +270,87 @@ func testMFAReauthenticationAfterIdentityToggle(t *testing.T) {
 	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
 	require.True(t, submitResp.Success, "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, zet.Logs())
 	t.Logf("SubmitMFA succeeded: code=%d", submitResp.Code)
+
+	status, err = client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after SubmitMFA\n%s", zet.Logs())
+	entry = status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after SubmitMFA", name)
+	require.False(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should be false after SubmitMFA", name)
+	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain true after SubmitMFA", name)
+	t.Logf("SubmitMFA ID MfaEnabled=%t MfaNeeded=%t", entry.MfaEnabled, entry.MfaNeeded)
+}
+
+func testMFAReauthenticationWithRecoveryCode(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	jwt, err := overlay.CreateIdentityJWT(ctx, name)
+	require.NoError(t, err, "mint JWT")
+	require.NotEmpty(t, jwt)
+	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
+
+	events, err := testutil.DialEvents(ctx)
+	require.NoError(t, err, "dial ZET event pipe")
+	t.Cleanup(func() { _ = events.Close() })
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		JwtContent:       &jwt,
+	}
+	addResp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
+	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
+
+	events.WaitFor(t, ctx, "controller", "connected", name)
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
+
+	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
+	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
+	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+	require.NotEmpty(t, mfa.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
+
+	parsed, err := url.Parse(mfa.ProvisioningUrl)
+	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
+	secret := parsed.Query().Get("secret")
+	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
+
+	code, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
+
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+	t.Logf("VerifyMFA succeeded")
+
+	offResp, err := client.IdentityOnOff(ctx, entry.Identifier, false)
+	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
+	require.True(t, offResp.Success, "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
+
+	onResp, err := client.IdentityOnOff(ctx, entry.Identifier, true)
+	require.NoError(t, err, "IdentityOnOff(true) send\n%s", zet.Logs())
+	require.True(t, onResp.Success, "IdentityOnOff(true) failed: error=%q code=%d", onResp.Error, onResp.Code)
+
+	events.WaitFor(t, ctx, "mfa", "auth_challenge", name)
+
+	status, err = client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after auth_challenge\n%s", zet.Logs())
+	entry = status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after auth_challenge", name)
+	require.True(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should be true after off→on cycle", name)
+
+	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, mfa.RecoveryCodes[0])
+	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
+	require.True(t, submitResp.Success, "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, zet.Logs())
+	t.Logf("SubmitMFA with recovery code succeeded: code=%d", submitResp.Code)
 
 	status, err = client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after SubmitMFA\n%s", zet.Logs())

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -180,7 +180,7 @@ func testVerifyMFAWithValidTotp(t *testing.T) {
 	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
 
 	code, err := generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP code")
+	require.NoError(t, err, "compute TOTP")
 	t.Logf("computed TOTP code from secret (%d chars)", len(secret))
 
 	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
@@ -238,10 +238,10 @@ func testMFAReauthenticationAfterIdentityToggle(t *testing.T) {
 	secret := parsed.Query().Get("secret")
 	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
 
-	verifyCode, err := generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP code for verify")
+	code, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
 
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, verifyCode)
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
 	t.Logf("VerifyMFA succeeded")
@@ -262,7 +262,10 @@ func testMFAReauthenticationAfterIdentityToggle(t *testing.T) {
 	require.NotNil(t, entry, "identity %q not found in Status after auth_challenge", name)
 	require.True(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should be true after off→on cycle", name)
 
-	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, verifyCode)
+	code, err = generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
+
+	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
 	require.True(t, submitResp.Success, "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, zet.Logs())
 	t.Logf("SubmitMFA succeeded: code=%d", submitResp.Code)
@@ -277,7 +280,7 @@ func testMFAReauthenticationAfterIdentityToggle(t *testing.T) {
 }
 
 func testRemoveMFAWithValidTotp(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	name := identityNameFor(t)
@@ -318,25 +321,18 @@ func testRemoveMFAWithValidTotp(t *testing.T) {
 	secret := parsed.Query().Get("secret")
 	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
 
-	verifyCode, err := generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP code for verify")
+	code, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
 
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, verifyCode)
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
 	t.Logf("VerifyMFA succeeded")
 
-	// TOTP codes are single-use within their 30s step; sleep into the next step before computing the remove code.
-	nextStep := time.Unix((time.Now().Unix()/30+1)*30, 0)
-	wait := time.Until(nextStep) + 100*time.Millisecond
-	t.Logf("waiting %s for next TOTP step before RemoveMFA", wait)
-	time.Sleep(wait)
+	code, err = generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
 
-	removeCode, err := generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP code for remove")
-	require.NotEqual(t, verifyCode, removeCode, "remove TOTP should be from a different step than verify TOTP")
-
-	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, removeCode)
+	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
 	require.True(t, removeResp.Success, "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, zet.Logs())
 	t.Logf("RemoveMFA succeeded: code=%d", removeResp.Code)
@@ -392,10 +388,10 @@ func testRemoveMFAWithRecoveryCode(t *testing.T) {
 	secret := parsed.Query().Get("secret")
 	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
 
-	verifyCode, err := generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP code for verify")
+	code, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
 
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, verifyCode)
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
 	t.Logf("VerifyMFA succeeded")

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -51,6 +51,7 @@ func TestMFAReauthentication(t *testing.T) {
 func TestRemoveMFA(t *testing.T) {
 	t.Run("acceptsValidTotp", testRemoveMFAAcceptsValidTotp)
 	t.Run("acceptsRecoveryCode", testRemoveMFAAcceptsRecoveryCode)
+	t.Run("rejectsInvalidTotp", testRemoveMFARejectsInvalidTotp)
 }
 
 func testEnableMFAAcceptsJwtEnrolledIdentity(t *testing.T) {
@@ -590,6 +591,66 @@ func testRemoveMFAAcceptsRecoveryCode(t *testing.T) {
 	require.NotNil(t, entry, "identity %q not found in Status after RemoveMFA", name)
 	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be false after RemoveMFA", name)
 	t.Logf("RemoveMFA ID with recovery code MfaEnabled=%t", entry.MfaEnabled)
+}
+
+func testRemoveMFARejectsInvalidTotp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	jwt, err := overlay.CreateIdentityJWT(ctx, name)
+	require.NoError(t, err, "mint JWT")
+	require.NotEmpty(t, jwt)
+
+	events, err := testutil.DialEvents(ctx)
+	require.NoError(t, err, "dial ZET event pipe")
+	t.Cleanup(func() { _ = events.Close() })
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		JwtContent:       &jwt,
+	}
+	addResp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
+	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
+
+	events.WaitFor(t, ctx, "controller", "connected", name)
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status send\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
+
+	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
+	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
+	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+
+	parsed, err := url.Parse(mfa.ProvisioningUrl)
+	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
+	secret := parsed.Query().Get("secret")
+	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
+
+	code, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
+
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+
+	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, "000000")
+	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
+	require.False(t, removeResp.Success, "RemoveMFA with invalid TOTP should fail but Success=true")
+	t.Logf("RemoveMFA correctly rejected invalid TOTP: error=%q code=%d", removeResp.Error, removeResp.Code)
+
+	status, err = client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after rejected RemoveMFA\n%s", zet.Logs())
+	entry = status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after rejected RemoveMFA", name)
+	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain true after rejected RemoveMFA", name)
 }
 
 func generateTotpCode(secret string, at time.Time) (string, error) {

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -44,6 +44,7 @@ func TestVerifyMFA(t *testing.T) {
 
 func TestRemoveMFA(t *testing.T) {
 	t.Run("withValidTotp", testRemoveMFAWithValidTotp)
+	t.Run("withRecoveryCode", testRemoveMFAWithRecoveryCode)
 }
 
 func testEnableMFAWithJwtEnrolledIdentity(t *testing.T) {
@@ -318,7 +319,85 @@ func testRemoveMFAWithValidTotp(t *testing.T) {
 	entry = status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after RemoveMFA", name)
 	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be false after RemoveMFA", name)
-	t.Logf("RemoveMFA ID MfaEnabled=%t", entry.MfaEnabled)
+	t.Logf("RemoveMFA ID with TOTP MfaEnabled=%t", entry.MfaEnabled)
+}
+
+func testRemoveMFAWithRecoveryCode(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	jwt, err := overlay.CreateIdentityJWT(ctx, name)
+	require.NoError(t, err, "mint JWT")
+	require.NotEmpty(t, jwt)
+	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
+
+	events, err := testutil.DialEvents(ctx)
+	require.NoError(t, err, "dial ZET event pipe")
+	t.Cleanup(func() { _ = events.Close() })
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		JwtContent:       &jwt,
+	}
+	addResp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
+	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
+
+	for {
+		raw, err := events.ReadEvent(ctx)
+		require.NoError(t, err, "read event waiting for controller:connected\n%s", zet.Logs())
+
+		var event struct {
+			Op, Action, Fingerprint string
+		}
+		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
+		if event.Op != "controller" || event.Action != "connected" || event.Fingerprint != name {
+			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
+			continue
+		}
+		t.Logf("controller:connected received for %q", name)
+		break
+	}
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status send\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
+
+	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
+	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
+	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+	require.NotEmpty(t, mfa.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
+
+	parsed, err := url.Parse(mfa.ProvisioningUrl)
+	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
+	secret := parsed.Query().Get("secret")
+	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
+
+	verifyCode, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP code for verify")
+
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, verifyCode)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+	t.Logf("VerifyMFA succeeded")
+
+	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, mfa.RecoveryCodes[0])
+	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
+	require.True(t, removeResp.Success, "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, zet.Logs())
+	t.Logf("RemoveMFA succeeded with recovery code: code=%d", removeResp.Code)
+
+	status, err = client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after RemoveMFA\n%s", zet.Logs())
+	entry = status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after RemoveMFA", name)
+	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be false after RemoveMFA", name)
+	t.Logf("RemoveMFA ID with recovery code MfaEnabled=%t", entry.MfaEnabled)
 }
 
 func generateTotpCode(secret string, at time.Time) (string, error) {

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha1"
 	"encoding/base32"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -73,21 +72,7 @@ func testEnableMFAWithJwtEnrolledIdentity(t *testing.T) {
 	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
 	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
 
-	for {
-		raw, err := events.ReadEvent(ctx)
-		require.NoError(t, err, "read event waiting for controller:connected\n%s", zet.Logs())
-
-		var event struct {
-			Op, Action, Fingerprint string
-		}
-		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
-		if event.Op != "controller" || event.Action != "connected" || event.Fingerprint != name {
-			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
-			continue
-		}
-		t.Logf("controller:connected received for %q", name)
-		break
-	}
+	events.WaitFor(t, ctx, "controller", "connected", name)
 
 	status, err := client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
@@ -134,21 +119,7 @@ func testEnableMFAWithTotpRequiredAuthPolicy(t *testing.T) {
 	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
 	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
 
-	for {
-		raw, err := events.ReadEvent(ctx)
-		require.NoError(t, err, "read event waiting for identity:added\n%s", zet.Logs())
-
-		var event struct {
-			Op, Action, Fingerprint string
-		}
-		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
-		if event.Op != "identity" || event.Action != "added" || event.Fingerprint != name {
-			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
-			continue
-		}
-		t.Logf("identity:added received for %q", name)
-		break
-	}
+	events.WaitFor(t, ctx, "identity", "added", name)
 
 	status, err := client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
@@ -188,21 +159,7 @@ func testVerifyMFAWithValidTotp(t *testing.T) {
 	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
 	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
 
-	for {
-		raw, err := events.ReadEvent(ctx)
-		require.NoError(t, err, "read event waiting for controller:connected\n%s", zet.Logs())
-
-		var event struct {
-			Op, Action, Fingerprint string
-		}
-		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
-		if event.Op != "controller" || event.Action != "connected" || event.Fingerprint != name {
-			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
-			continue
-		}
-		t.Logf("controller:connected received for %q", name)
-		break
-	}
+	events.WaitFor(t, ctx, "controller", "connected", name)
 
 	status, err := client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
@@ -261,21 +218,7 @@ func testRemoveMFAWithValidTotp(t *testing.T) {
 	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
 	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
 
-	for {
-		raw, err := events.ReadEvent(ctx)
-		require.NoError(t, err, "read event waiting for controller:connected\n%s", zet.Logs())
-
-		var event struct {
-			Op, Action, Fingerprint string
-		}
-		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
-		if event.Op != "controller" || event.Action != "connected" || event.Fingerprint != name {
-			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
-			continue
-		}
-		t.Logf("controller:connected received for %q", name)
-		break
-	}
+	events.WaitFor(t, ctx, "controller", "connected", name)
 
 	status, err := client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status send\n%s", zet.Logs())
@@ -348,21 +291,7 @@ func testRemoveMFAWithRecoveryCode(t *testing.T) {
 	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
 	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
 
-	for {
-		raw, err := events.ReadEvent(ctx)
-		require.NoError(t, err, "read event waiting for controller:connected\n%s", zet.Logs())
-
-		var event struct {
-			Op, Action, Fingerprint string
-		}
-		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
-		if event.Op != "controller" || event.Action != "connected" || event.Fingerprint != name {
-			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
-			continue
-		}
-		t.Logf("controller:connected received for %q", name)
-		break
-	}
+	events.WaitFor(t, ctx, "controller", "connected", name)
 
 	status, err := client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status send\n%s", zet.Logs())

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -33,25 +33,26 @@ import (
 )
 
 func TestEnableMFA(t *testing.T) {
-	t.Run("withJwtEnrolledIdentity", testEnableMFAWithJwtEnrolledIdentity)
-	t.Run("withTotpRequiredAuthPolicy", testEnableMFAWithTotpRequiredAuthPolicy)
+	t.Run("acceptsJwtEnrolledIdentity", testEnableMFAAcceptsJwtEnrolledIdentity)
+	t.Run("acceptsTotpRequiredAuthPolicy", testEnableMFAAcceptsTotpRequiredAuthPolicy)
 }
 
 func TestVerifyMFA(t *testing.T) {
-	t.Run("withValidTotp", testVerifyMFAWithValidTotp)
+	t.Run("acceptsValidTotp", testVerifyMFAAcceptsValidTotp)
+	t.Run("rejectsInvalidTotp", testVerifyMFARejectsInvalidTotp)
 }
 
 func TestMFAReauthentication(t *testing.T) {
-	t.Run("withValidTotp", testMFAReauthenticationWithValidTotp)
-	t.Run("withRecoveryCode", testMFAReauthenticationWithRecoveryCode)
+	t.Run("acceptsValidTotp", testMFAReauthenticationAcceptsValidTotp)
+	t.Run("acceptsRecoveryCode", testMFAReauthenticationAcceptsRecoveryCode)
 }
 
 func TestRemoveMFA(t *testing.T) {
-	t.Run("withValidTotp", testRemoveMFAWithValidTotp)
-	t.Run("withRecoveryCode", testRemoveMFAWithRecoveryCode)
+	t.Run("acceptsValidTotp", testRemoveMFAAcceptsValidTotp)
+	t.Run("acceptsRecoveryCode", testRemoveMFAAcceptsRecoveryCode)
 }
 
-func testEnableMFAWithJwtEnrolledIdentity(t *testing.T) {
+func testEnableMFAAcceptsJwtEnrolledIdentity(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -92,7 +93,7 @@ func testEnableMFAWithJwtEnrolledIdentity(t *testing.T) {
 	t.Logf("EnableMFA succeeded: provisioning_url=%q recovery_codes=%d", mfa.ProvisioningUrl, len(mfa.RecoveryCodes))
 }
 
-func testEnableMFAWithTotpRequiredAuthPolicy(t *testing.T) {
+func testEnableMFAAcceptsTotpRequiredAuthPolicy(t *testing.T) {
 	t.Skip("Tracking https://github.com/openziti/desktop-edge-win/issues/947 and https://openziti.discourse.group/t/enrolling-mfa-totp-from-zdew-fails/5482 - EnableMFA fails with 'failed to authenticate' for identities bound to TOTP-required auth policies")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -138,7 +139,7 @@ func testEnableMFAWithTotpRequiredAuthPolicy(t *testing.T) {
 	t.Logf("EnableMFA succeeded for TOTP-required identity: provisioning_url=%q", mfa.ProvisioningUrl)
 }
 
-func testVerifyMFAWithValidTotp(t *testing.T) {
+func testVerifyMFAAcceptsValidTotp(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -197,7 +198,56 @@ func testVerifyMFAWithValidTotp(t *testing.T) {
 	t.Logf("VerifyMFA ID MfaEnabled=%t", entry.MfaEnabled)
 }
 
-func testMFAReauthenticationWithValidTotp(t *testing.T) {
+func testVerifyMFARejectsInvalidTotp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	jwt, err := overlay.CreateIdentityJWT(ctx, name)
+	require.NoError(t, err, "mint JWT")
+	require.NotEmpty(t, jwt)
+	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
+
+	events, err := testutil.DialEvents(ctx)
+	require.NoError(t, err, "dial ZET event pipe")
+	t.Cleanup(func() { _ = events.Close() })
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		JwtContent:       &jwt,
+	}
+	addResp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
+	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
+
+	events.WaitFor(t, ctx, "controller", "connected", name)
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
+
+	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
+	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
+	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, "000000")
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.False(t, verifyResp.Success, "VerifyMFA with invalid TOTP should fail but Success=true")
+	t.Logf("VerifyMFA correctly rejected invalid TOTP: error=%q code=%d", verifyResp.Error, verifyResp.Code)
+
+	status, err = client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after VerifyMFA\n%s", zet.Logs())
+	entry = status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after VerifyMFA", name)
+	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain false after rejected VerifyMFA", name)
+}
+
+func testMFAReauthenticationAcceptsValidTotp(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -280,7 +330,7 @@ func testMFAReauthenticationWithValidTotp(t *testing.T) {
 	t.Logf("SubmitMFA ID MfaEnabled=%t MfaNeeded=%t", entry.MfaEnabled, entry.MfaNeeded)
 }
 
-func testMFAReauthenticationWithRecoveryCode(t *testing.T) {
+func testMFAReauthenticationAcceptsRecoveryCode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -361,7 +411,7 @@ func testMFAReauthenticationWithRecoveryCode(t *testing.T) {
 	t.Logf("SubmitMFA ID MfaEnabled=%t MfaNeeded=%t", entry.MfaEnabled, entry.MfaNeeded)
 }
 
-func testRemoveMFAWithValidTotp(t *testing.T) {
+func testRemoveMFAAcceptsValidTotp(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -427,7 +477,7 @@ func testRemoveMFAWithValidTotp(t *testing.T) {
 	t.Logf("RemoveMFA ID with TOTP MfaEnabled=%t", entry.MfaEnabled)
 }
 
-func testRemoveMFAWithRecoveryCode(t *testing.T) {
+func testRemoveMFAAcceptsRecoveryCode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -45,6 +45,7 @@ func TestVerifyMFA(t *testing.T) {
 func TestMFAReauthentication(t *testing.T) {
 	t.Run("acceptsValidTotp", testMFAReauthenticationAcceptsValidTotp)
 	t.Run("acceptsRecoveryCode", testMFAReauthenticationAcceptsRecoveryCode)
+	t.Run("rejectsInvalidTotp", testMFAReauthenticationRejectsInvalidTotp)
 }
 
 func TestRemoveMFA(t *testing.T) {
@@ -394,6 +395,77 @@ func testMFAReauthenticationAcceptsRecoveryCode(t *testing.T) {
 	require.False(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should be false after SubmitMFA", name)
 	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain true after SubmitMFA", name)
 	t.Logf("SubmitMFA ID MfaEnabled=%t MfaNeeded=%t", entry.MfaEnabled, entry.MfaNeeded)
+}
+
+func testMFAReauthenticationRejectsInvalidTotp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	jwt, err := overlay.CreateIdentityJWT(ctx, name)
+	require.NoError(t, err, "mint JWT")
+	require.NotEmpty(t, jwt)
+
+	events, err := testutil.DialEvents(ctx)
+	require.NoError(t, err, "dial ZET event pipe")
+	t.Cleanup(func() { _ = events.Close() })
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		JwtContent:       &jwt,
+	}
+	addResp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
+	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
+
+	events.WaitFor(t, ctx, "controller", "connected", name)
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
+
+	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
+	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
+	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+
+	parsed, err := url.Parse(mfa.ProvisioningUrl)
+	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
+	secret := parsed.Query().Get("secret")
+	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
+
+	code, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
+
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+
+	offResp, err := client.IdentityOnOff(ctx, entry.Identifier, false)
+	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
+	require.True(t, offResp.Success, "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
+
+	onResp, err := client.IdentityOnOff(ctx, entry.Identifier, true)
+	require.NoError(t, err, "IdentityOnOff(true) send\n%s", zet.Logs())
+	require.True(t, onResp.Success, "IdentityOnOff(true) failed: error=%q code=%d", onResp.Error, onResp.Code)
+
+	events.WaitFor(t, ctx, "mfa", "auth_challenge", name)
+
+	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, "000000")
+	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
+	require.False(t, submitResp.Success, "SubmitMFA with invalid TOTP should fail but Success=true")
+	t.Logf("SubmitMFA correctly rejected invalid TOTP: error=%q code=%d", submitResp.Error, submitResp.Code)
+
+	status, err = client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after rejected SubmitMFA\n%s", zet.Logs())
+	entry = status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after rejected SubmitMFA", name)
+	require.True(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should remain true after rejected SubmitMFA", name)
+	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain true after rejected SubmitMFA", name)
 }
 
 func testRemoveMFAAcceptsValidTotp(t *testing.T) {

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -42,6 +42,10 @@ func TestVerifyMFA(t *testing.T) {
 	t.Run("withValidTotp", testVerifyMFAWithValidTotp)
 }
 
+func TestRemoveMFA(t *testing.T) {
+	t.Run("withValidTotp", testRemoveMFAWithValidTotp)
+}
+
 func testEnableMFAWithJwtEnrolledIdentity(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -213,7 +217,7 @@ func testVerifyMFAWithValidTotp(t *testing.T) {
 	secret := parsed.Query().Get("secret")
 	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
 
-	code, err := totpCode(secret, time.Now())
+	code, err := generateTotpCode(secret, time.Now())
 	require.NoError(t, err, "compute TOTP code")
 	t.Logf("computed TOTP code from secret (%d chars)", len(secret))
 
@@ -227,9 +231,97 @@ func testVerifyMFAWithValidTotp(t *testing.T) {
 	entry = status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after VerifyMFA", name)
 	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be true after VerifyMFA", name)
+	t.Logf("VerifyMFA ID MfaEnabled=%t", entry.MfaEnabled)
 }
 
-func totpCode(secret string, at time.Time) (string, error) {
+func testRemoveMFAWithValidTotp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	jwt, err := overlay.CreateIdentityJWT(ctx, name)
+	require.NoError(t, err, "mint JWT")
+	require.NotEmpty(t, jwt)
+	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
+
+	events, err := testutil.DialEvents(ctx)
+	require.NoError(t, err, "dial ZET event pipe")
+	t.Cleanup(func() { _ = events.Close() })
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		JwtContent:       &jwt,
+	}
+	addResp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
+	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
+
+	for {
+		raw, err := events.ReadEvent(ctx)
+		require.NoError(t, err, "read event waiting for controller:connected\n%s", zet.Logs())
+
+		var event struct {
+			Op, Action, Fingerprint string
+		}
+		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
+		if event.Op != "controller" || event.Action != "connected" || event.Fingerprint != name {
+			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
+			continue
+		}
+		t.Logf("controller:connected received for %q", name)
+		break
+	}
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status send\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
+
+	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
+	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
+	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+
+	parsed, err := url.Parse(mfa.ProvisioningUrl)
+	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
+	secret := parsed.Query().Get("secret")
+	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
+
+	verifyCode, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP code for verify")
+
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, verifyCode)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+	t.Logf("VerifyMFA succeeded")
+
+	// TOTP codes are single-use within their 30s step; sleep into the next step before computing the remove code.
+	nextStep := time.Unix((time.Now().Unix()/30+1)*30, 0)
+	wait := time.Until(nextStep) + 100*time.Millisecond
+	t.Logf("waiting %s for next TOTP step before RemoveMFA", wait)
+	time.Sleep(wait)
+
+	removeCode, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP code for remove")
+	require.NotEqual(t, verifyCode, removeCode, "remove TOTP should be from a different step than verify TOTP")
+
+	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, removeCode)
+	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
+	require.True(t, removeResp.Success, "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, zet.Logs())
+	t.Logf("RemoveMFA succeeded: code=%d", removeResp.Code)
+
+	status, err = client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after RemoveMFA\n%s", zet.Logs())
+	entry = status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after RemoveMFA", name)
+	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be false after RemoveMFA", name)
+	t.Logf("RemoveMFA ID MfaEnabled=%t", entry.MfaEnabled)
+}
+
+func generateTotpCode(secret string, at time.Time) (string, error) {
 	key, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(strings.ToUpper(strings.TrimRight(secret, "=")))
 	if err != nil {
 		return "", fmt.Errorf("base32 decode secret: %w", err)

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -58,39 +58,9 @@ func testEnableMFAAcceptsJwtEnrolledIdentity(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	name := identityNameFor(t)
-	jwt, err := overlay.CreateIdentityJWT(ctx, name)
-	require.NoError(t, err, "mint JWT")
-	require.NotEmpty(t, jwt)
+	enrolled := newEnrolledMFA(t, ctx, identityNameFor(t))
 
-	events, err := testutil.DialEvents(ctx)
-	require.NoError(t, err, "dial ZET event pipe")
-	t.Cleanup(func() { _ = events.Close() })
-
-	client, err := testutil.DialIPC(ctx)
-	require.NoError(t, err, "dial ZET IPC pipe")
-	t.Cleanup(func() { _ = client.Close() })
-
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		JwtContent:       &jwt,
-	}
-	addResp, err := client.AddIdentity(ctx, identityData)
-	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
-	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
-
-	events.WaitFor(t, ctx, "controller", "connected", name)
-
-	status, err := client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
-	entry := status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
-
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
-	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
-	require.NotEmpty(t, mfa.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
-	require.False(t, mfa.IsVerified, "EnableMFA Data.IsVerified should be false before verify_mfa")
+	require.False(t, enrolled.IsVerified, "EnableMFA Data.IsVerified should be false before verify_mfa")
 }
 
 func testEnableMFAAcceptsTotpRequiredAuthPolicy(t *testing.T) {
@@ -130,10 +100,10 @@ func testEnableMFAAcceptsTotpRequiredAuthPolicy(t *testing.T) {
 	entry := status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
 
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
+	enrollment, err := client.GetMFAEnrollment(ctx, entry.Identifier)
 	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
-	require.NotEmpty(t, mfa.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
+	require.NotEmpty(t, enrollment.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+	require.NotEmpty(t, enrollment.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
 }
 
 func testVerifyMFAAcceptsValidTotp(t *testing.T) {
@@ -141,52 +111,18 @@ func testVerifyMFAAcceptsValidTotp(t *testing.T) {
 	defer cancel()
 
 	name := identityNameFor(t)
-	jwt, err := overlay.CreateIdentityJWT(ctx, name)
-	require.NoError(t, err, "mint JWT")
-	require.NotEmpty(t, jwt)
+	enrolled := newEnrolledMFA(t, ctx, name)
 
-	events, err := testutil.DialEvents(ctx)
-	require.NoError(t, err, "dial ZET event pipe")
-	t.Cleanup(func() { _ = events.Close() })
-
-	client, err := testutil.DialIPC(ctx)
-	require.NoError(t, err, "dial ZET IPC pipe")
-	t.Cleanup(func() { _ = client.Close() })
-
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		JwtContent:       &jwt,
-	}
-	addResp, err := client.AddIdentity(ctx, identityData)
-	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
-	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
-
-	events.WaitFor(t, ctx, "controller", "connected", name)
-
-	status, err := client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
-	entry := status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
-
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
-	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
-
-	parsed, err := url.Parse(mfa.ProvisioningUrl)
-	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
-	secret := parsed.Query().Get("secret")
-	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
-
-	code, err := generateTotpCode(secret, time.Now())
+	code, err := generateTotpCode(enrolled.Secret, time.Now())
 	require.NoError(t, err, "compute TOTP")
 
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
+	verifyResp, err := enrolled.Client.VerifyMFA(ctx, enrolled.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
 
-	status, err = client.GetTunnelStatus(ctx)
+	status, err := enrolled.Client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after VerifyMFA\n%s", zet.Logs())
-	entry = status.FindIdentity(name)
+	entry := status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after VerifyMFA", name)
 	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be true after VerifyMFA", name)
 	t.Logf("VerifyMFA ID MfaEnabled=%t", entry.MfaEnabled)
@@ -197,45 +133,16 @@ func testVerifyMFARejectsInvalidTotp(t *testing.T) {
 	defer cancel()
 
 	name := identityNameFor(t)
-	jwt, err := overlay.CreateIdentityJWT(ctx, name)
-	require.NoError(t, err, "mint JWT")
-	require.NotEmpty(t, jwt)
+	enrolled := newEnrolledMFA(t, ctx, name)
 
-	events, err := testutil.DialEvents(ctx)
-	require.NoError(t, err, "dial ZET event pipe")
-	t.Cleanup(func() { _ = events.Close() })
-
-	client, err := testutil.DialIPC(ctx)
-	require.NoError(t, err, "dial ZET IPC pipe")
-	t.Cleanup(func() { _ = client.Close() })
-
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		JwtContent:       &jwt,
-	}
-	addResp, err := client.AddIdentity(ctx, identityData)
-	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
-	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
-
-	events.WaitFor(t, ctx, "controller", "connected", name)
-
-	status, err := client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
-	entry := status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
-
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
-	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
-
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, "000000")
+	verifyResp, err := enrolled.Client.VerifyMFA(ctx, enrolled.Identifier, "000000")
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.False(t, verifyResp.Success, "VerifyMFA with invalid TOTP should fail but Success=true")
 	t.Logf("VerifyMFA correctly rejected invalid TOTP: error=%q code=%d", verifyResp.Error, verifyResp.Code)
 
-	status, err = client.GetTunnelStatus(ctx)
+	status, err := enrolled.Client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after VerifyMFA\n%s", zet.Logs())
-	entry = status.FindIdentity(name)
+	entry := status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after VerifyMFA", name)
 	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain false after rejected VerifyMFA", name)
 }
@@ -245,73 +152,43 @@ func testMFAReauthenticationAcceptsValidTotp(t *testing.T) {
 	defer cancel()
 
 	name := identityNameFor(t)
-	jwt, err := overlay.CreateIdentityJWT(ctx, name)
-	require.NoError(t, err, "mint JWT")
-	require.NotEmpty(t, jwt)
+	enrolled := newEnrolledMFA(t, ctx, name)
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
 	t.Cleanup(func() { _ = events.Close() })
 
-	client, err := testutil.DialIPC(ctx)
-	require.NoError(t, err, "dial ZET IPC pipe")
-	t.Cleanup(func() { _ = client.Close() })
-
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		JwtContent:       &jwt,
-	}
-	addResp, err := client.AddIdentity(ctx, identityData)
-	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
-	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
-
-	events.WaitFor(t, ctx, "controller", "connected", name)
-
-	status, err := client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
-	entry := status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
-
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
-	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
-
-	parsed, err := url.Parse(mfa.ProvisioningUrl)
-	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
-	secret := parsed.Query().Get("secret")
-	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
-
-	code, err := generateTotpCode(secret, time.Now())
+	code, err := generateTotpCode(enrolled.Secret, time.Now())
 	require.NoError(t, err, "compute TOTP")
 
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
+	verifyResp, err := enrolled.Client.VerifyMFA(ctx, enrolled.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
 
-	offResp, err := client.IdentityOnOff(ctx, entry.Identifier, false)
+	offResp, err := enrolled.Client.IdentityOnOff(ctx, enrolled.Identifier, false)
 	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
 	require.True(t, offResp.Success, "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
 
-	onResp, err := client.IdentityOnOff(ctx, entry.Identifier, true)
+	onResp, err := enrolled.Client.IdentityOnOff(ctx, enrolled.Identifier, true)
 	require.NoError(t, err, "IdentityOnOff(true) send\n%s", zet.Logs())
 	require.True(t, onResp.Success, "IdentityOnOff(true) failed: error=%q code=%d", onResp.Error, onResp.Code)
 
 	events.WaitFor(t, ctx, "mfa", "auth_challenge", name)
 
-	status, err = client.GetTunnelStatus(ctx)
+	status, err := enrolled.Client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after auth_challenge\n%s", zet.Logs())
-	entry = status.FindIdentity(name)
+	entry := status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after auth_challenge", name)
 	require.True(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should be true after off→on cycle", name)
 
-	code, err = generateTotpCode(secret, time.Now())
+	code, err = generateTotpCode(enrolled.Secret, time.Now())
 	require.NoError(t, err, "compute TOTP")
 
-	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, code)
+	submitResp, err := enrolled.Client.SubmitMFA(ctx, enrolled.Identifier, code)
 	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
 	require.True(t, submitResp.Success, "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, zet.Logs())
 
-	status, err = client.GetTunnelStatus(ctx)
+	status, err = enrolled.Client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after SubmitMFA\n%s", zet.Logs())
 	entry = status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after SubmitMFA", name)
@@ -325,71 +202,40 @@ func testMFAReauthenticationAcceptsRecoveryCode(t *testing.T) {
 	defer cancel()
 
 	name := identityNameFor(t)
-	jwt, err := overlay.CreateIdentityJWT(ctx, name)
-	require.NoError(t, err, "mint JWT")
-	require.NotEmpty(t, jwt)
+	enrolled := newEnrolledMFA(t, ctx, name)
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
 	t.Cleanup(func() { _ = events.Close() })
 
-	client, err := testutil.DialIPC(ctx)
-	require.NoError(t, err, "dial ZET IPC pipe")
-	t.Cleanup(func() { _ = client.Close() })
-
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		JwtContent:       &jwt,
-	}
-	addResp, err := client.AddIdentity(ctx, identityData)
-	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
-	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
-
-	events.WaitFor(t, ctx, "controller", "connected", name)
-
-	status, err := client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
-	entry := status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
-
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
-	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
-	require.NotEmpty(t, mfa.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
-
-	parsed, err := url.Parse(mfa.ProvisioningUrl)
-	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
-	secret := parsed.Query().Get("secret")
-	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
-
-	code, err := generateTotpCode(secret, time.Now())
+	code, err := generateTotpCode(enrolled.Secret, time.Now())
 	require.NoError(t, err, "compute TOTP")
 
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
+	verifyResp, err := enrolled.Client.VerifyMFA(ctx, enrolled.Identifier, code)
 	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
 	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
 
-	offResp, err := client.IdentityOnOff(ctx, entry.Identifier, false)
+	offResp, err := enrolled.Client.IdentityOnOff(ctx, enrolled.Identifier, false)
 	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
 	require.True(t, offResp.Success, "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
 
-	onResp, err := client.IdentityOnOff(ctx, entry.Identifier, true)
+	onResp, err := enrolled.Client.IdentityOnOff(ctx, enrolled.Identifier, true)
 	require.NoError(t, err, "IdentityOnOff(true) send\n%s", zet.Logs())
 	require.True(t, onResp.Success, "IdentityOnOff(true) failed: error=%q code=%d", onResp.Error, onResp.Code)
 
 	events.WaitFor(t, ctx, "mfa", "auth_challenge", name)
 
-	status, err = client.GetTunnelStatus(ctx)
+	status, err := enrolled.Client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after auth_challenge\n%s", zet.Logs())
-	entry = status.FindIdentity(name)
+	entry := status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after auth_challenge", name)
 	require.True(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should be true after off→on cycle", name)
 
-	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, mfa.RecoveryCodes[0])
+	submitResp, err := enrolled.Client.SubmitMFA(ctx, enrolled.Identifier, enrolled.RecoveryCodes[0])
 	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
 	require.True(t, submitResp.Success, "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, zet.Logs())
 
-	status, err = client.GetTunnelStatus(ctx)
+	status, err = enrolled.Client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after SubmitMFA\n%s", zet.Logs())
 	entry = status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after SubmitMFA", name)
@@ -403,13 +249,141 @@ func testMFAReauthenticationRejectsInvalidTotp(t *testing.T) {
 	defer cancel()
 
 	name := identityNameFor(t)
+	enrolled := newEnrolledMFA(t, ctx, name)
+
+	events, err := testutil.DialEvents(ctx)
+	require.NoError(t, err, "dial ZET event pipe")
+	t.Cleanup(func() { _ = events.Close() })
+
+	code, err := generateTotpCode(enrolled.Secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
+
+	verifyResp, err := enrolled.Client.VerifyMFA(ctx, enrolled.Identifier, code)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+
+	offResp, err := enrolled.Client.IdentityOnOff(ctx, enrolled.Identifier, false)
+	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
+	require.True(t, offResp.Success, "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
+
+	onResp, err := enrolled.Client.IdentityOnOff(ctx, enrolled.Identifier, true)
+	require.NoError(t, err, "IdentityOnOff(true) send\n%s", zet.Logs())
+	require.True(t, onResp.Success, "IdentityOnOff(true) failed: error=%q code=%d", onResp.Error, onResp.Code)
+
+	events.WaitFor(t, ctx, "mfa", "auth_challenge", name)
+
+	submitResp, err := enrolled.Client.SubmitMFA(ctx, enrolled.Identifier, "000000")
+	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
+	require.False(t, submitResp.Success, "SubmitMFA with invalid TOTP should fail but Success=true")
+	t.Logf("SubmitMFA correctly rejected invalid TOTP: error=%q code=%d", submitResp.Error, submitResp.Code)
+
+	status, err := enrolled.Client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after rejected SubmitMFA\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after rejected SubmitMFA", name)
+	require.True(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should remain true after rejected SubmitMFA", name)
+	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain true after rejected SubmitMFA", name)
+}
+
+func testRemoveMFAAcceptsValidTotp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	enrolled := newEnrolledMFA(t, ctx, name)
+
+	code, err := generateTotpCode(enrolled.Secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
+
+	verifyResp, err := enrolled.Client.VerifyMFA(ctx, enrolled.Identifier, code)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+
+	code, err = generateTotpCode(enrolled.Secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
+
+	removeResp, err := enrolled.Client.RemoveMFA(ctx, enrolled.Identifier, code)
+	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
+	require.True(t, removeResp.Success, "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, zet.Logs())
+
+	status, err := enrolled.Client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after RemoveMFA\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after RemoveMFA", name)
+	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be false after RemoveMFA", name)
+	t.Logf("RemoveMFA ID with TOTP MfaEnabled=%t", entry.MfaEnabled)
+}
+
+func testRemoveMFAAcceptsRecoveryCode(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	enrolled := newEnrolledMFA(t, ctx, name)
+
+	code, err := generateTotpCode(enrolled.Secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
+
+	verifyResp, err := enrolled.Client.VerifyMFA(ctx, enrolled.Identifier, code)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+
+	removeResp, err := enrolled.Client.RemoveMFA(ctx, enrolled.Identifier, enrolled.RecoveryCodes[0])
+	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
+	require.True(t, removeResp.Success, "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, zet.Logs())
+
+	status, err := enrolled.Client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after RemoveMFA\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after RemoveMFA", name)
+	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be false after RemoveMFA", name)
+	t.Logf("RemoveMFA ID with recovery code MfaEnabled=%t", entry.MfaEnabled)
+}
+
+func testRemoveMFARejectsInvalidTotp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	enrolled := newEnrolledMFA(t, ctx, name)
+
+	code, err := generateTotpCode(enrolled.Secret, time.Now())
+	require.NoError(t, err, "compute TOTP")
+
+	verifyResp, err := enrolled.Client.VerifyMFA(ctx, enrolled.Identifier, code)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+
+	removeResp, err := enrolled.Client.RemoveMFA(ctx, enrolled.Identifier, "000000")
+	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
+	require.False(t, removeResp.Success, "RemoveMFA with invalid TOTP should fail but Success=true")
+	t.Logf("RemoveMFA correctly rejected invalid TOTP: error=%q code=%d", removeResp.Error, removeResp.Code)
+
+	status, err := enrolled.Client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after rejected RemoveMFA\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after rejected RemoveMFA", name)
+	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain true after rejected RemoveMFA", name)
+}
+
+type enrolledMFA struct {
+	Client        *testutil.IPCClient
+	Identifier    string
+	IsVerified    bool
+	RecoveryCodes []string
+	Secret        string
+}
+
+func newEnrolledMFA(t *testing.T, ctx context.Context, name string) *enrolledMFA {
+	t.Helper()
+
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
-	t.Cleanup(func() { _ = events.Close() })
+	defer func() { _ = events.Close() }()
 
 	client, err := testutil.DialIPC(ctx)
 	require.NoError(t, err, "dial ZET IPC pipe")
@@ -429,228 +403,25 @@ func testMFAReauthenticationRejectsInvalidTotp(t *testing.T) {
 	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
 	entry := status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
+	identifier := entry.Identifier
 
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
+	enrollment, err := client.GetMFAEnrollment(ctx, identifier)
 	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+	require.NotEmpty(t, enrollment.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+	require.NotEmpty(t, enrollment.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
 
-	parsed, err := url.Parse(mfa.ProvisioningUrl)
-	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
+	parsed, err := url.Parse(enrollment.ProvisioningUrl)
+	require.NoError(t, err, "parse provisioning url %q", enrollment.ProvisioningUrl)
 	secret := parsed.Query().Get("secret")
-	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
+	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", enrollment.ProvisioningUrl)
 
-	code, err := generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP")
-
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
-	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
-	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
-
-	offResp, err := client.IdentityOnOff(ctx, entry.Identifier, false)
-	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
-	require.True(t, offResp.Success, "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
-
-	onResp, err := client.IdentityOnOff(ctx, entry.Identifier, true)
-	require.NoError(t, err, "IdentityOnOff(true) send\n%s", zet.Logs())
-	require.True(t, onResp.Success, "IdentityOnOff(true) failed: error=%q code=%d", onResp.Error, onResp.Code)
-
-	events.WaitFor(t, ctx, "mfa", "auth_challenge", name)
-
-	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, "000000")
-	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
-	require.False(t, submitResp.Success, "SubmitMFA with invalid TOTP should fail but Success=true")
-	t.Logf("SubmitMFA correctly rejected invalid TOTP: error=%q code=%d", submitResp.Error, submitResp.Code)
-
-	status, err = client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status after rejected SubmitMFA\n%s", zet.Logs())
-	entry = status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status after rejected SubmitMFA", name)
-	require.True(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should remain true after rejected SubmitMFA", name)
-	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain true after rejected SubmitMFA", name)
-}
-
-func testRemoveMFAAcceptsValidTotp(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	name := identityNameFor(t)
-	jwt, err := overlay.CreateIdentityJWT(ctx, name)
-	require.NoError(t, err, "mint JWT")
-	require.NotEmpty(t, jwt)
-
-	events, err := testutil.DialEvents(ctx)
-	require.NoError(t, err, "dial ZET event pipe")
-	t.Cleanup(func() { _ = events.Close() })
-
-	client, err := testutil.DialIPC(ctx)
-	require.NoError(t, err, "dial ZET IPC pipe")
-	t.Cleanup(func() { _ = client.Close() })
-
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		JwtContent:       &jwt,
+	return &enrolledMFA{
+		Client:        client,
+		Identifier:    identifier,
+		IsVerified:    enrollment.IsVerified,
+		RecoveryCodes: enrollment.RecoveryCodes,
+		Secret:        secret,
 	}
-	addResp, err := client.AddIdentity(ctx, identityData)
-	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
-	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
-
-	events.WaitFor(t, ctx, "controller", "connected", name)
-
-	status, err := client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status send\n%s", zet.Logs())
-	entry := status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
-
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
-	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
-
-	parsed, err := url.Parse(mfa.ProvisioningUrl)
-	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
-	secret := parsed.Query().Get("secret")
-	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
-
-	code, err := generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP")
-
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
-	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
-	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
-
-	code, err = generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP")
-
-	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, code)
-	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
-	require.True(t, removeResp.Success, "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, zet.Logs())
-
-	status, err = client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status after RemoveMFA\n%s", zet.Logs())
-	entry = status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status after RemoveMFA", name)
-	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be false after RemoveMFA", name)
-	t.Logf("RemoveMFA ID with TOTP MfaEnabled=%t", entry.MfaEnabled)
-}
-
-func testRemoveMFAAcceptsRecoveryCode(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	name := identityNameFor(t)
-	jwt, err := overlay.CreateIdentityJWT(ctx, name)
-	require.NoError(t, err, "mint JWT")
-	require.NotEmpty(t, jwt)
-
-	events, err := testutil.DialEvents(ctx)
-	require.NoError(t, err, "dial ZET event pipe")
-	t.Cleanup(func() { _ = events.Close() })
-
-	client, err := testutil.DialIPC(ctx)
-	require.NoError(t, err, "dial ZET IPC pipe")
-	t.Cleanup(func() { _ = client.Close() })
-
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		JwtContent:       &jwt,
-	}
-	addResp, err := client.AddIdentity(ctx, identityData)
-	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
-	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
-
-	events.WaitFor(t, ctx, "controller", "connected", name)
-
-	status, err := client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status send\n%s", zet.Logs())
-	entry := status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
-
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
-	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
-	require.NotEmpty(t, mfa.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
-
-	parsed, err := url.Parse(mfa.ProvisioningUrl)
-	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
-	secret := parsed.Query().Get("secret")
-	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
-
-	code, err := generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP")
-
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
-	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
-	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
-
-	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, mfa.RecoveryCodes[0])
-	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
-	require.True(t, removeResp.Success, "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, zet.Logs())
-
-	status, err = client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status after RemoveMFA\n%s", zet.Logs())
-	entry = status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status after RemoveMFA", name)
-	require.False(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be false after RemoveMFA", name)
-	t.Logf("RemoveMFA ID with recovery code MfaEnabled=%t", entry.MfaEnabled)
-}
-
-func testRemoveMFARejectsInvalidTotp(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	name := identityNameFor(t)
-	jwt, err := overlay.CreateIdentityJWT(ctx, name)
-	require.NoError(t, err, "mint JWT")
-	require.NotEmpty(t, jwt)
-
-	events, err := testutil.DialEvents(ctx)
-	require.NoError(t, err, "dial ZET event pipe")
-	t.Cleanup(func() { _ = events.Close() })
-
-	client, err := testutil.DialIPC(ctx)
-	require.NoError(t, err, "dial ZET IPC pipe")
-	t.Cleanup(func() { _ = client.Close() })
-
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		JwtContent:       &jwt,
-	}
-	addResp, err := client.AddIdentity(ctx, identityData)
-	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
-	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
-
-	events.WaitFor(t, ctx, "controller", "connected", name)
-
-	status, err := client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status send\n%s", zet.Logs())
-	entry := status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
-
-	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
-	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
-	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
-
-	parsed, err := url.Parse(mfa.ProvisioningUrl)
-	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
-	secret := parsed.Query().Get("secret")
-	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
-
-	code, err := generateTotpCode(secret, time.Now())
-	require.NoError(t, err, "compute TOTP")
-
-	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, code)
-	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
-	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
-
-	removeResp, err := client.RemoveMFA(ctx, entry.Identifier, "000000")
-	require.NoError(t, err, "RemoveMFA send\n%s", zet.Logs())
-	require.False(t, removeResp.Success, "RemoveMFA with invalid TOTP should fail but Success=true")
-	t.Logf("RemoveMFA correctly rejected invalid TOTP: error=%q code=%d", removeResp.Error, removeResp.Code)
-
-	status, err = client.GetTunnelStatus(ctx)
-	require.NoError(t, err, "Status after rejected RemoveMFA\n%s", zet.Logs())
-	entry = status.FindIdentity(name)
-	require.NotNil(t, entry, "identity %q not found in Status after rejected RemoveMFA", name)
-	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain true after rejected RemoveMFA", name)
 }
 
 func generateTotpCode(secret string, at time.Time) (string, error) {

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -41,6 +41,10 @@ func TestVerifyMFA(t *testing.T) {
 	t.Run("withValidTotp", testVerifyMFAWithValidTotp)
 }
 
+func TestMFAReauthentication(t *testing.T) {
+	t.Run("afterIdentityToggle", testMFAReauthenticationAfterIdentityToggle)
+}
+
 func TestRemoveMFA(t *testing.T) {
 	t.Run("withValidTotp", testRemoveMFAWithValidTotp)
 	t.Run("withRecoveryCode", testRemoveMFAWithRecoveryCode)
@@ -190,6 +194,86 @@ func testVerifyMFAWithValidTotp(t *testing.T) {
 	require.NotNil(t, entry, "identity %q not found in Status after VerifyMFA", name)
 	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should be true after VerifyMFA", name)
 	t.Logf("VerifyMFA ID MfaEnabled=%t", entry.MfaEnabled)
+}
+
+func testMFAReauthenticationAfterIdentityToggle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	name := identityNameFor(t)
+	jwt, err := overlay.CreateIdentityJWT(ctx, name)
+	require.NoError(t, err, "mint JWT")
+	require.NotEmpty(t, jwt)
+	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
+
+	events, err := testutil.DialEvents(ctx)
+	require.NoError(t, err, "dial ZET event pipe")
+	t.Cleanup(func() { _ = events.Close() })
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		JwtContent:       &jwt,
+	}
+	addResp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
+	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
+
+	events.WaitFor(t, ctx, "controller", "connected", name)
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
+	entry := status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status.Identities", name)
+
+	mfa, err := client.GetMFAEnrollment(ctx, entry.Identifier)
+	require.NoError(t, err, "EnableMFA\n%s", zet.Logs())
+	require.NotEmpty(t, mfa.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+
+	parsed, err := url.Parse(mfa.ProvisioningUrl)
+	require.NoError(t, err, "parse provisioning url %q", mfa.ProvisioningUrl)
+	secret := parsed.Query().Get("secret")
+	require.NotEmpty(t, secret, "provisioning url missing secret param: %q", mfa.ProvisioningUrl)
+
+	verifyCode, err := generateTotpCode(secret, time.Now())
+	require.NoError(t, err, "compute TOTP code for verify")
+
+	verifyResp, err := client.VerifyMFA(ctx, entry.Identifier, verifyCode)
+	require.NoError(t, err, "VerifyMFA send\n%s", zet.Logs())
+	require.True(t, verifyResp.Success, "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, zet.Logs())
+	t.Logf("VerifyMFA succeeded")
+
+	offResp, err := client.IdentityOnOff(ctx, entry.Identifier, false)
+	require.NoError(t, err, "IdentityOnOff(false) send\n%s", zet.Logs())
+	require.True(t, offResp.Success, "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
+
+	onResp, err := client.IdentityOnOff(ctx, entry.Identifier, true)
+	require.NoError(t, err, "IdentityOnOff(true) send\n%s", zet.Logs())
+	require.True(t, onResp.Success, "IdentityOnOff(true) failed: error=%q code=%d", onResp.Error, onResp.Code)
+
+	events.WaitFor(t, ctx, "mfa", "auth_challenge", name)
+
+	status, err = client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after auth_challenge\n%s", zet.Logs())
+	entry = status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after auth_challenge", name)
+	require.True(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should be true after off→on cycle", name)
+
+	submitResp, err := client.SubmitMFA(ctx, entry.Identifier, verifyCode)
+	require.NoError(t, err, "SubmitMFA send\n%s", zet.Logs())
+	require.True(t, submitResp.Success, "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, zet.Logs())
+	t.Logf("SubmitMFA succeeded: code=%d", submitResp.Code)
+
+	status, err = client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after SubmitMFA\n%s", zet.Logs())
+	entry = status.FindIdentity(name)
+	require.NotNil(t, entry, "identity %q not found in Status after SubmitMFA", name)
+	require.False(t, entry.MfaNeeded, "Status.Identities[%q].MfaNeeded should be false after SubmitMFA", name)
+	require.True(t, entry.MfaEnabled, "Status.Identities[%q].MfaEnabled should remain true after SubmitMFA", name)
+	t.Logf("SubmitMFA ID MfaEnabled=%t MfaNeeded=%t", entry.MfaEnabled, entry.MfaNeeded)
 }
 
 func testRemoveMFAWithValidTotp(t *testing.T) {

--- a/tests/integration/remove_identity_test.go
+++ b/tests/integration/remove_identity_test.go
@@ -43,7 +43,6 @@ func testRemoveIdentityWithIdentifierFromStatus(t *testing.T) {
 	jwt, err := overlay.CreateIdentityJWT(ctx, name)
 	require.NoError(t, err, "mint JWT")
 	require.NotEmpty(t, jwt)
-	t.Logf("JWT minted for identity %q (%d bytes)", name, len(jwt))
 
 	identityData := testutil.AddIdentityData{
 		IdentityFilename: name,
@@ -52,13 +51,11 @@ func testRemoveIdentityWithIdentifierFromStatus(t *testing.T) {
 	addResp, err := client.AddIdentity(ctx, identityData)
 	require.NoError(t, err, "AddIdentity send\n%s", zet.Logs())
 	require.True(t, addResp.Success, "AddIdentity failed: error=%q code=%d", addResp.Error, addResp.Code)
-	t.Logf("AddIdentity succeeded: filename=%q code=%d", name, addResp.Code)
 
 	status, err := client.GetTunnelStatus(ctx)
 	require.NoError(t, err, "Status after AddIdentity\n%s", zet.Logs())
 	entry := status.FindIdentity(name)
 	require.NotNil(t, entry, "identity %q not found in Status after AddIdentity", name)
-	t.Logf("identifier from Status: %s", entry.Identifier)
 
 	info, err := os.Stat(entry.Identifier)
 	require.NoError(t, err, "identity file should exist after AddIdentity")
@@ -67,7 +64,6 @@ func testRemoveIdentityWithIdentifierFromStatus(t *testing.T) {
 	removeResp, err := client.RemoveIdentity(ctx, entry.Identifier)
 	require.NoError(t, err, "RemoveIdentity send\n%s", zet.Logs())
 	require.True(t, removeResp.Success, "RemoveIdentity failed: error=%q code=%d", removeResp.Error, removeResp.Code)
-	t.Logf("RemoveIdentity succeeded: identifier=%s code=%d", entry.Identifier, removeResp.Code)
 
 	_, statErr := os.Stat(entry.Identifier)
 	require.True(t, os.IsNotExist(statErr), "identity file should be removed after RemoveIdentity: %s\n%s", entry.Identifier, zet.Logs())

--- a/tests/integration/set_log_level_test.go
+++ b/tests/integration/set_log_level_test.go
@@ -41,7 +41,6 @@ func testSetLogLevelChangesLogLevelInStatus(t *testing.T) {
 	setResp, err := client.SetLogLevel(ctx, "trace")
 	require.NoError(t, err, "SetLogLevel send\n%s", zet.Logs())
 	require.True(t, setResp.Success, "SetLogLevel failed: error=%q code=%d", setResp.Error, setResp.Code)
-	t.Logf("SetLogLevel(trace) succeeded: code=%d", setResp.Code)
 
 	statusResp, err := client.Status(ctx)
 	require.NoError(t, err, "Status send\n%s", zet.Logs())

--- a/tests/integration/testutil/commands.go
+++ b/tests/integration/testutil/commands.go
@@ -126,6 +126,7 @@ type IdentityStatus struct {
 	Active      bool   `json:"Active"`
 	FingerPrint string `json:"FingerPrint"`
 	MfaEnabled  bool   `json:"MfaEnabled"`
+	MfaNeeded   bool   `json:"MfaNeeded"`
 }
 
 type TunnelStatus struct {

--- a/tests/integration/testutil/commands.go
+++ b/tests/integration/testutil/commands.go
@@ -86,13 +86,23 @@ type StatusChangeData struct {
 	Unlocked bool `json:"Unlocked"`
 }
 
+type EnrollMode string
+
+const (
+	EnrollModeNone  EnrollMode = "none"
+	EnrollModeCert  EnrollMode = "cert"
+	EnrollModeToken EnrollMode = "token"
+)
+
 type AddIdentityData struct {
-	UseKeychain      bool    `json:"UseKeychain"`
-	IdentityFilename string  `json:"IdentityFilename"`
-	JwtContent       *string `json:"JwtContent"`
-	Key              *string `json:"Key"`
-	Certificate      *string `json:"Certificate"`
-	ControllerURL    *string `json:"ControllerURL"`
+	UseKeychain      bool        `json:"UseKeychain"`
+	IdentityFilename string      `json:"IdentityFilename"`
+	JwtContent       *string     `json:"JwtContent"`
+	Key              *string     `json:"Key"`
+	Certificate      *string     `json:"Certificate"`
+	ControllerURL    *string     `json:"ControllerURL"`
+	EnrollMode       *EnrollMode `json:"EnrollMode"`
+	Provider         *string     `json:"Provider"`
 }
 
 type IdentityInfo struct {

--- a/tests/integration/testutil/ipc.go
+++ b/tests/integration/testutil/ipc.go
@@ -41,7 +41,7 @@ type Response struct {
 }
 
 type IPCClient struct {
-	conn net.Conn
+	conn   net.Conn
 	reader *bufio.Reader
 }
 
@@ -96,7 +96,7 @@ func (c *IPCClient) Close() error {
 }
 
 type EventClient struct {
-	conn net.Conn
+	conn   net.Conn
 	reader *bufio.Reader
 }
 
@@ -137,7 +137,7 @@ type Event struct {
 	Fingerprint string `json:"Fingerprint"`
 }
 
-// WaitFor drains events until one matches op/action/fingerprint, logging skipped events along the way.
+// WaitFor drains events until one matches op/action/fingerprint
 func (c *EventClient) WaitFor(t *testing.T, ctx context.Context, op, action, fingerprint string) {
 	t.Helper()
 	for {

--- a/tests/integration/testutil/ipc.go
+++ b/tests/integration/testutil/ipc.go
@@ -147,10 +147,8 @@ func (c *EventClient) WaitFor(t *testing.T, ctx context.Context, op, action, fin
 		var event Event
 		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
 		if event.Op != op || event.Action != action || event.Fingerprint != fingerprint {
-			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
 			continue
 		}
-		t.Logf("%s:%s received for %q", op, action, fingerprint)
 		return
 	}
 }

--- a/tests/integration/testutil/ipc.go
+++ b/tests/integration/testutil/ipc.go
@@ -22,7 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 type Command struct {
@@ -126,6 +129,30 @@ func (c *EventClient) ReadEvent(ctx context.Context) (json.RawMessage, error) {
 		return nil, fmt.Errorf("read event: %w", err)
 	}
 	return json.RawMessage(line), nil
+}
+
+type Event struct {
+	Op          string `json:"Op"`
+	Action      string `json:"Action"`
+	Fingerprint string `json:"Fingerprint"`
+}
+
+// WaitFor drains events until one matches op/action/fingerprint, logging skipped events along the way.
+func (c *EventClient) WaitFor(t *testing.T, ctx context.Context, op, action, fingerprint string) {
+	t.Helper()
+	for {
+		raw, err := c.ReadEvent(ctx)
+		require.NoError(t, err, "read event waiting for %s:%s for %s", op, action, fingerprint)
+
+		var event Event
+		require.NoError(t, json.Unmarshal(raw, &event), "parse event: %s", raw)
+		if event.Op != op || event.Action != action || event.Fingerprint != fingerprint {
+			t.Logf("skipped event: Op=%s Action=%s Fingerprint=%s", event.Op, event.Action, event.Fingerprint)
+			continue
+		}
+		t.Logf("%s:%s received for %q", op, action, fingerprint)
+		return
+	}
 }
 
 func (c *EventClient) Close() error {

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -135,6 +135,13 @@ func (o *Overlay) CreateIdentityJWT(ctx context.Context, name string) (string, e
 	return string(bytes.TrimSpace(content)), nil
 }
 
+func (o *Overlay) DeleteIdentity(ctx context.Context, name string) error {
+	if _, err := o.runZiti(ctx, "edge", "delete", "identity", name); err != nil {
+		return fmt.Errorf("delete identity %s: %w", name, err)
+	}
+	return nil
+}
+
 func (o *Overlay) CreateAuthPolicyRequiringTOTP(ctx context.Context, name string) error {
 	if _, err := o.runZiti(ctx, "edge", "create", "auth-policy", name,
 		"--primary-cert-allowed",


### PR DESCRIPTION
### Tests added
- **MFA**: enable, verify, re-auth after toggling an identity off/on, and remove. Both TOTP and recovery codes are covered, plus invalid-code rejection on each.
- **AddIdentity**: empty JWT, JWT for an identity deleted from the controller, bad filenames (slashes, `..`, over the OS limit).

### Util additions
- `events.WaitFor(t, ctx, op, action, fingerprint)`: drains the event pipe until an event matches and skips the rest. Pulled out of an inline event-drain loop that was duplicated across MFA and identity tests.
- `Overlay.DeleteIdentity`: wraps `ziti edge delete identity` 