### PR TITLE
Add integration tests for URL enrollment and external auth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,14 @@ jobs:
             --ctrl-address=localhost --ctrl-port=1280 \
             --router-address=localhost --router-port=3022 &
           until curl -sk --max-time 2 https://localhost:1280/ >/dev/null \
-             && (echo > /dev/tcp/localhost/3022) 2>/dev/null; do sleep 1; done
+             && (echo > /dev/tcp/localhost/3022) 2>/dev/null; do
+            if (( SECONDS > 120 )); then
+              echo "::error::overlay never came up within 120s" >&2
+              kill %1 2>/dev/null
+              exit 1
+            fi
+            sleep 1
+          done
           kill %1
           wait %1 2>/dev/null || true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,6 +155,41 @@ jobs:
           mkdir -p "$ZET_LOG_DIR"
           chmod 1777 "$ZET_LOG_DIR"
 
+      - name: Seed test overlay PKI
+        shell: bash
+        run: |
+          "$ZITI_BIN" edge quickstart --home="$RUNNER_TEMP" \
+            --ctrl-address=localhost --ctrl-port=1280 \
+            --router-address=localhost --router-port=3022 &
+          until curl -sk --max-time 2 https://localhost:1280/ >/dev/null \
+             && (echo > /dev/tcp/localhost/3022) 2>/dev/null; do sleep 1; done
+          kill %1
+          wait %1 2>/dev/null || true
+
+      - name: Install test overlay CA into OS trust (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo cp "$RUNNER_TEMP/pki/root-ca/certs/root-ca.cert" \
+            /usr/local/share/ca-certificates/ziti-test.crt
+          sudo update-ca-certificates
+
+      - name: Install test overlay CA into OS trust (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          sudo security add-trusted-cert -d -r trustRoot \
+            -k /Library/Keychains/System.keychain \
+            "$RUNNER_TEMP/pki/root-ca/certs/root-ca.cert"
+
+      - name: Install test overlay CA into OS trust (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Import-Certificate `
+            -FilePath "$env:RUNNER_TEMP\pki\root-ca\certs\root-ca.cert" `
+            -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+
       - name: Run integration tests
         shell: bash
         working-directory: tests/integration
@@ -164,18 +199,44 @@ jobs:
               # ulimit -c unlimited must be set inside the privileged shell: sudo
               # resets resource limits via PAM, so setting it in the outer shell
               # has no effect on ZET child processes.
-              sudo env "PATH=$PATH" "ZET_BIN=$ZET_BIN" "ZITI_BIN=$ZITI_BIN" \
+              sudo env "PATH=$PATH" "ZET_BIN=$ZET_BIN" "ZITI_BIN=$ZITI_BIN" "RUNNER_TEMP=$RUNNER_TEMP" \
                 sh -c 'ulimit -c unlimited && exec go test ./... -v -timeout 20m \
                   -zet-bin="$ZET_BIN" -ziti-bin="$ZITI_BIN" \
-                  -zet-log-dir="${{ env.ZET_LOG_DIR }}"'
+                  -zet-log-dir="${{ env.ZET_LOG_DIR }}" \
+                  -overlay-home="$RUNNER_TEMP"'
               ;;
             *)
               go test ./... -v -timeout 20m \
                 -zet-bin="$ZET_BIN" \
                 -ziti-bin="$ZITI_BIN" \
-                -zet-log-dir="${{ env.ZET_LOG_DIR }}"
+                -zet-log-dir="${{ env.ZET_LOG_DIR }}" \
+                -overlay-home="$RUNNER_TEMP"
               ;;
           esac
+
+      - name: Uninstall test overlay CA (Linux)
+        if: always() && runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo rm -f /usr/local/share/ca-certificates/ziti-test.crt
+          sudo update-ca-certificates --fresh
+
+      - name: Uninstall test overlay CA (macOS)
+        if: always() && runner.os == 'macOS'
+        shell: bash
+        run: |
+          thumb=$(openssl x509 \
+            -in "$RUNNER_TEMP/pki/root-ca/certs/root-ca.cert" \
+            -noout -fingerprint -sha1 | sed 's/.*=//' | tr -d ':')
+          sudo security delete-certificate -Z "$thumb" /Library/Keychains/System.keychain || true
+
+      - name: Uninstall test overlay CA (Windows)
+        if: always() && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 `
+            "$env:RUNNER_TEMP\pki\root-ca\certs\root-ca.cert"
+          Get-ChildItem Cert:\LocalMachine\Root | Where-Object Thumbprint -eq $cert.Thumbprint | Remove-Item
 
       - name: Log core file backtraces
         if: ${{ failure() && matrix.core-dir != '' }}

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openziti/ziti-tunnel-sdk-c/tests/integration/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalAuth(t *testing.T) {
+	overlay.RequireCATrusted(t)
+	t.Run("onUrlEnrolledIdentityCompletes", testExternalAuthOnUrlEnrolledIdentityCompletes)
+}
+
+func testExternalAuthOnUrlEnrolledIdentityCompletes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	controllerBase := overlay.ControllerHostPort()
+	signerName := identityNameFor(t) + "-signer"
+	policyName := identityNameFor(t) + "-policy"
+	identityName := identityNameFor(t)
+
+	adminID, err := overlay.IdentityID(ctx, "Default Admin")
+	require.NoError(t, err, "look up admin identity ID")
+
+	jwksURI, err := testutil.DiscoverOIDCJWKS(ctx, controllerBase+"/oidc")
+	require.NoError(t, err, "discover controller OIDC jwks_uri")
+
+	signerID, err := overlay.CreateExtJwtSigner(ctx,
+		signerName,
+		controllerBase+"/oidc",
+		jwksURI,
+		"openziti",
+		"openziti",
+		controllerBase+"/oidc",
+	)
+	require.NoError(t, err, "create ext-jwt-signer")
+	require.NoError(t, overlay.CreateAuthPolicyForExtJwt(ctx, policyName, signerID), "create auth policy with ext-jwt-signer")
+	require.NoError(t, overlay.CreateIdentityWithExternalId(ctx, identityName, adminID, policyName), "create controller identity with externalId=adminID")
+
+	events, err := testutil.DialEvents(ctx)
+	require.NoError(t, err, "dial ZET event pipe")
+	t.Cleanup(func() { _ = events.Close() })
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: identityName,
+		ControllerURL:    &controllerBase,
+	}
+	enrollResp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "URL AddIdentity send\n%s", zet.Logs())
+	require.True(t, enrollResp.Success, "URL AddIdentity should succeed: error=%q\n%s", enrollResp.Error, zet.Logs())
+
+	events.WaitFor(t, ctx, "identity", "needs_ext_login", identityName)
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after URL AddIdentity\n%s", zet.Logs())
+	entry := status.FindIdentity(identityName)
+	require.NotNil(t, entry, "identity %q not found in Status after URL AddIdentity", identityName)
+
+	authResp, err := client.GetExternalAuth(ctx, entry.Identifier, signerName)
+	require.NoError(t, err, "ExternalAuth\n%s", zet.Logs())
+	require.NotEmpty(t, authResp.URL, "ExternalAuth should return a non-empty auth URL")
+
+	require.NoError(t, testutil.DriveControllerOIDC(ctx, authResp.URL, controllerBase, "admin", "admin"), "drive controller OIDC flow")
+
+	events.WaitFor(t, ctx, "identity", "added", identityName)
+
+	finalStatus, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after ExternalAuth\n%s", zet.Logs())
+	finalEntry := finalStatus.FindIdentity(identityName)
+	require.NotNil(t, finalEntry, "identity %q missing from Status after ExternalAuth", identityName)
+	require.False(t, finalEntry.NeedsExtAuth, "NeedsExtAuth should be false after successful ExternalAuth\n%s", zet.Logs())
+}

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -38,9 +38,11 @@ func testExternalAuthOnUrlEnrolledIdentityCompletes(t *testing.T) {
 	signerName := identityNameFor(t) + "-signer"
 	policyName := identityNameFor(t) + "-policy"
 	identityName := identityNameFor(t)
+	testUserName := identityNameFor(t) + "-user"
+	testUserPassword := "test-password"
 
-	adminID, err := overlay.IdentityID(ctx, "Default Admin")
-	require.NoError(t, err, "look up admin identity ID")
+	testUserID, err := overlay.CreateUpdbUser(ctx, testUserName, testUserName, testUserPassword)
+	require.NoError(t, err, "create updb test user")
 
 	jwksURI, err := testutil.DiscoverOIDCJWKS(ctx, controllerBase+"/oidc")
 	require.NoError(t, err, "discover controller OIDC jwks_uri")
@@ -55,7 +57,7 @@ func testExternalAuthOnUrlEnrolledIdentityCompletes(t *testing.T) {
 	)
 	require.NoError(t, err, "create ext-jwt-signer")
 	require.NoError(t, overlay.CreateAuthPolicyForExtJwt(ctx, policyName, signerID), "create auth policy with ext-jwt-signer")
-	require.NoError(t, overlay.CreateIdentityWithExternalId(ctx, identityName, adminID, policyName), "create controller identity with externalId=adminID")
+	require.NoError(t, overlay.CreateIdentityWithExternalId(ctx, identityName, testUserID, policyName), "create controller identity with externalId=testUserID")
 
 	events, err := testutil.DialEvents(ctx)
 	require.NoError(t, err, "dial ZET event pipe")
@@ -84,7 +86,7 @@ func testExternalAuthOnUrlEnrolledIdentityCompletes(t *testing.T) {
 	require.NoError(t, err, "ExternalAuth\n%s", zet.Logs())
 	require.NotEmpty(t, authResp.URL, "ExternalAuth should return a non-empty auth URL")
 
-	require.NoError(t, testutil.DriveControllerOIDC(ctx, authResp.URL, controllerBase, "admin", "admin"), "drive controller OIDC flow")
+	require.NoError(t, testutil.DriveControllerOIDC(ctx, authResp.URL, controllerBase, testUserName, testUserPassword), "drive controller OIDC flow")
 
 	events.WaitFor(t, ctx, "identity", "added", identityName)
 

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -29,21 +29,21 @@ import (
 )
 
 var (
-	zetBin        string
-	zitiBin       string
-	zetLogDir     string
-	keepArtifacts bool
-	overlay       *testutil.Overlay
-	zet           *testutil.ZET
-	zetB          *testutil.ZET
-	tempRoot      string
+	zetBin      string
+	zitiBin     string
+	zetLogDir   string
+	overlay     *testutil.Overlay
+	zet         *testutil.ZET
+	zetB        *testutil.ZET
+	overlayHome string
+	zetTempRoot string
 )
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&zetBin, "zet-bin", "", "path to ziti-edge-tunnel binary (required)")
 	flag.StringVar(&zitiBin, "ziti-bin", "", "path to ziti binary for controller+router bring-up (required)")
 	flag.StringVar(&zetLogDir, "zet-log-dir", "", "if set, write each zet's combined stdout+stderr to <dir>/zet-<name>.log")
-	flag.BoolVar(&keepArtifacts, "keep-artifacts", false, "leave temp dirs on disk after tests finish")
+	flag.StringVar(&overlayHome, "overlay-home", filepath.Join(os.TempDir(), "ziti-tunnel-test-quickstart"), "directory for the test overlay's persistent quickstart state (PKI lives here across runs)")
 	flag.Parse()
 
 	if zetBin == "" || zitiBin == "" {
@@ -64,28 +64,26 @@ func run(m *testing.M) (int, error) {
 		return 0, err
 	}
 	var err error
-	tempRoot, err = os.MkdirTemp("", "ziti-tunnel-integ-*")
+	zetTempRoot, err = os.MkdirTemp("", "ziti-tunnel-zet-*")
 	if err != nil {
-		return 0, fmt.Errorf("create temp root: %w", err)
+		return 0, fmt.Errorf("create zet temp root: %w", err)
 	}
-	defer func() {
-		if !keepArtifacts {
-			_ = os.RemoveAll(tempRoot)
-		} else {
-			fmt.Fprintf(os.Stderr, "artifacts kept at %s\n", tempRoot)
-		}
-	}()
+	defer os.RemoveAll(zetTempRoot)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	overlay, err = testutil.StartOverlay(ctx, zitiBin, filepath.Join(tempRoot, "overlay"))
+	overlay, err = testutil.StartOverlay(ctx, zitiBin, overlayHome)
 	if err != nil {
 		return 0, fmt.Errorf("start overlay: %w", err)
 	}
 	defer overlay.Stop()
 
-	zet, err = testutil.StartZET(ctx, zetBin, filepath.Join(tempRoot, "zet-identities"), testutil.ZETOptions{
+	if err := overlay.PurgeIdentities(ctx, "Test"); err != nil {
+		return 0, fmt.Errorf("purge stale test identities: %w", err)
+	}
+
+	zet, err = testutil.StartZET(ctx, zetBin, filepath.Join(zetTempRoot, "zet-identities"), testutil.ZETOptions{
 		LogDir: zetLogDir,
 	})
 	if err != nil {
@@ -93,7 +91,7 @@ func run(m *testing.M) (int, error) {
 	}
 	defer zet.Stop()
 
-	zetB, err = testutil.StartZET(ctx, zetBin, filepath.Join(tempRoot, "zetB-identities"), testutil.ZETOptions{
+	zetB, err = testutil.StartZET(ctx, zetBin, filepath.Join(zetTempRoot, "zetB-identities"), testutil.ZETOptions{
 		Discriminator: "zetB",
 		DNSRange:      "100.128.0.1/10",
 		LogDir:        zetLogDir,

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -82,6 +82,12 @@ func run(m *testing.M) (int, error) {
 	if err := overlay.PurgeIdentities(ctx, "Test"); err != nil {
 		return 0, fmt.Errorf("purge stale test identities: %w", err)
 	}
+	if err := overlay.PurgeAuthPolicies(ctx, "Test"); err != nil {
+		return 0, fmt.Errorf("purge stale test auth policies: %w", err)
+	}
+	if err := overlay.PurgeExtJwtSigners(ctx, "Test"); err != nil {
+		return 0, fmt.Errorf("purge stale test ext-jwt-signers: %w", err)
+	}
 
 	zet, err = testutil.StartZET(ctx, zetBin, filepath.Join(zetTempRoot, "zet-identities"), testutil.ZETOptions{
 		LogDir: zetLogDir,

--- a/tests/integration/testutil/commands.go
+++ b/tests/integration/testutil/commands.go
@@ -131,12 +131,13 @@ type ServiceVersion struct {
 type TapInfo struct{}
 
 type IdentityStatus struct {
-	Name        string `json:"Name"`
-	Identifier  string `json:"Identifier"`
-	Active      bool   `json:"Active"`
-	FingerPrint string `json:"FingerPrint"`
-	MfaEnabled  bool   `json:"MfaEnabled"`
-	MfaNeeded   bool   `json:"MfaNeeded"`
+	Name         string `json:"Name"`
+	Identifier   string `json:"Identifier"`
+	Active       bool   `json:"Active"`
+	FingerPrint  string `json:"FingerPrint"`
+	MfaEnabled   bool   `json:"MfaEnabled"`
+	MfaNeeded    bool   `json:"MfaNeeded"`
+	NeedsExtAuth bool   `json:"NeedsExtAuth"`
 }
 
 type TunnelStatus struct {
@@ -264,6 +265,29 @@ func (c *IPCClient) UpdateInterfaceConfig(ctx context.Context, cfg InterfaceConf
 
 func (c *IPCClient) ExternalAuth(ctx context.Context, identifier, provider string) (*Response, error) {
 	return c.SendCommand(ctx, Command{Command: "ExternalAuth", Data: ExternalAuthData{Identifier: identifier, Provider: provider}})
+}
+
+// ExtAuth is the parsed payload of an ExternalAuth response: the URL the user
+// must open to begin the OIDC flow.
+type ExtAuth struct {
+	Identifier string `json:"identifier"`
+	URL        string `json:"url"`
+}
+
+// GetExternalAuth sends ExternalAuth, asserts success, and unmarshals the response.
+func (c *IPCClient) GetExternalAuth(ctx context.Context, identifier, provider string) (*ExtAuth, error) {
+	resp, err := c.ExternalAuth(ctx, identifier, provider)
+	if err != nil {
+		return nil, fmt.Errorf("external auth: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("external auth failed: %s (code %d)", resp.Error, resp.Code)
+	}
+	var out ExtAuth
+	if err := json.Unmarshal(resp.Data, &out); err != nil {
+		return nil, fmt.Errorf("parse external auth: %w", err)
+	}
+	return &out, nil
 }
 
 func (c *IPCClient) Status(ctx context.Context) (*Response, error) {

--- a/tests/integration/testutil/oidc_flow.go
+++ b/tests/integration/testutil/oidc_flow.go
@@ -1,0 +1,135 @@
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DiscoverOIDCJWKS fetches <issuerBase>/.well-known/openid-configuration and
+// returns the jwks_uri the provider advertises.
+func DiscoverOIDCJWKS(ctx context.Context, issuerBase string) (string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, issuerBase+"/.well-known/openid-configuration", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("discovery status=%d", resp.StatusCode)
+	}
+	var doc struct {
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return "", fmt.Errorf("parse discovery: %w", err)
+	}
+	if doc.JWKSURI == "" {
+		return "", fmt.Errorf("discovery missing jwks_uri")
+	}
+	return doc.JWKSURI, nil
+}
+
+// DriveControllerOIDC walks the controller's built-in OIDC login flow against
+// the authorize URL ZET hands back from ExternalAuth: GET /oidc/authorize,
+// POST /oidc/login/username, then GET /oidc/authorize/callback, whose 302
+// sends the code into ZET's loopback listener at localhost:20314.
+func DriveControllerOIDC(ctx context.Context, authURL, controllerBaseURL, username, password string) error {
+	client := &http.Client{
+		Timeout:       30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, authURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("get authorize: %w", err)
+	}
+	resp.Body.Close()
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	authRequestID := loc.Query().Get("authRequestID")
+	if authRequestID == "" {
+		return fmt.Errorf("authRequestID missing from authorize response (status=%d location=%q)",
+			resp.StatusCode, resp.Header.Get("Location"))
+	}
+
+	form := url.Values{"id": {authRequestID}, "username": {username}, "password": {password}}
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost,
+		controllerBaseURL+"/oidc/login/username", strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err = client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post login: %w", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("login status=%d", resp.StatusCode)
+	}
+
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet,
+		controllerBaseURL+"/oidc/authorize/callback?id="+url.QueryEscape(authRequestID), nil)
+	if err != nil {
+		return err
+	}
+	resp, err = client.Do(req)
+	if err != nil {
+		return fmt.Errorf("get callback: %w", err)
+	}
+	resp.Body.Close()
+	loopback := resp.Header.Get("Location")
+	if loopback == "" {
+		return fmt.Errorf("loopback URL missing from callback response (status=%d)", resp.StatusCode)
+	}
+
+	// ziti-sdk-c can return the auth URL before localhost:20314 is reachable; retry.
+	loopCtx, loopCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer loopCancel()
+	for {
+		req, err = http.NewRequestWithContext(loopCtx, http.MethodGet, loopback, nil)
+		if err != nil {
+			return err
+		}
+		resp, err = client.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			return nil
+		}
+		select {
+		case <-loopCtx.Done():
+			return fmt.Errorf("hit loopback: %w (last: %v)", loopCtx.Err(), err)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -199,6 +199,64 @@ func (o *Overlay) CreateIdentityJWTWithAuthPolicy(ctx context.Context, name, aut
 	return string(bytes.TrimSpace(content)), nil
 }
 
+// CreateExtJwtSigner registers an external JWT signer on the controller and
+// returns its assigned ID. jwksEndpoint is the URL the controller fetches
+// public keys from to verify incoming JWTs; externalAuthURL is what the SDK
+// directs users to so they can obtain a JWT (the IdP's /authorize equivalent).
+func (o *Overlay) CreateExtJwtSigner(ctx context.Context, name, issuer, jwksEndpoint, audience, clientID, externalAuthURL string) (string, error) {
+	out, err := o.runZiti(ctx, "edge", "create", "ext-jwt-signer", name, issuer,
+		"--jwks-endpoint", jwksEndpoint,
+		"--audience", audience,
+		"--client-id", clientID,
+		"--external-auth-url", externalAuthURL,
+	)
+	if err != nil {
+		return "", fmt.Errorf("create ext-jwt-signer %s: %w", name, err)
+	}
+	return string(bytes.TrimSpace(out)), nil
+}
+
+// CreateAuthPolicyForExtJwt creates an auth policy whose primary auth method
+// is the ext-jwt-signer with the given ID.
+func (o *Overlay) CreateAuthPolicyForExtJwt(ctx context.Context, name, signerID string) error {
+	if _, err := o.runZiti(ctx, "edge", "create", "auth-policy", name,
+		"--primary-ext-jwt-allowed",
+		"--primary-ext-jwt-allowed-signers", signerID,
+	); err != nil {
+		return fmt.Errorf("create auth policy %s: %w", name, err)
+	}
+	return nil
+}
+
+// CreateIdentityWithExternalId provisions a non-admin identity bound to the
+// named auth policy and stamped with externalId so the controller can match it
+// against the "sub" claim of an ext-jwt-signer-issued JWT.
+func (o *Overlay) CreateIdentityWithExternalId(ctx context.Context, name, externalID, authPolicy string) error {
+	if _, err := o.runZiti(ctx, "edge", "create", "identity", name,
+		"--external-id", externalID,
+		"-P", authPolicy,
+	); err != nil {
+		return fmt.Errorf("create identity %s with externalId %s: %w", name, externalID, err)
+	}
+	return nil
+}
+
+// DeleteExtJwtSigner removes an ext-jwt-signer by name.
+func (o *Overlay) DeleteExtJwtSigner(ctx context.Context, name string) error {
+	if _, err := o.runZiti(ctx, "edge", "delete", "ext-jwt-signer", name); err != nil {
+		return fmt.Errorf("delete ext-jwt-signer %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteAuthPolicy removes an auth policy by name.
+func (o *Overlay) DeleteAuthPolicy(ctx context.Context, name string) error {
+	if _, err := o.runZiti(ctx, "edge", "delete", "auth-policy", name); err != nil {
+		return fmt.Errorf("delete auth policy %s: %w", name, err)
+	}
+	return nil
+}
+
 // CreateHostConfigV1 creates a host.v1 config that forwards to forwardAddr:forwardPort.
 func (o *Overlay) CreateHostConfigV1(ctx context.Context, name, protocol, forwardAddr string, forwardPort int) error {
 	body, err := json.Marshal(struct {
@@ -335,28 +393,73 @@ func (o *Overlay) runZiti(ctx context.Context, args ...string) ([]byte, error) {
 	return []byte(stdout.String()), nil
 }
 
-// PurgeIdentities deletes every identity on the controller whose name starts
-// with prefix. Reuses DeleteIdentity for the per-name delete.
-func (o *Overlay) PurgeIdentities(ctx context.Context, prefix string) error {
-	filter := fmt.Sprintf(`name contains "%s"`, prefix)
+// IdentityID looks up an identity by exact name and returns its controller ID.
+func (o *Overlay) IdentityID(ctx context.Context, name string) (string, error) {
+	filter := fmt.Sprintf(`name = "%s"`, name)
 	out, err := o.runZiti(ctx, "edge", "list", "identities", filter, "-j")
 	if err != nil {
-		return fmt.Errorf("list identities: %w", err)
+		return "", fmt.Errorf("list identity %q: %w", name, err)
 	}
 	var listResp struct {
 		Data []struct {
+			ID   string `json:"id"`
 			Name string `json:"name"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(out, &listResp); err != nil {
-		return fmt.Errorf("parse identities list: %w", err)
+		return "", fmt.Errorf("parse identity list: %w", err)
 	}
 	for _, id := range listResp.Data {
-		if !strings.HasPrefix(id.Name, prefix) {
-			continue
+		if id.Name == name {
+			return id.ID, nil
 		}
-		if err := o.DeleteIdentity(ctx, id.Name); err != nil {
-			return err
+	}
+	return "", fmt.Errorf("identity %q not found", name)
+}
+
+// PurgeIdentities deletes every identity on the controller whose name starts
+// with prefix. Reuses DeleteIdentity for the per-name delete.
+func (o *Overlay) PurgeIdentities(ctx context.Context, prefix string) error {
+	return o.purgeByPrefix(ctx, "identities", prefix, o.DeleteIdentity)
+}
+
+// PurgeAuthPolicies deletes every auth policy whose name starts with prefix.
+func (o *Overlay) PurgeAuthPolicies(ctx context.Context, prefix string) error {
+	return o.purgeByPrefix(ctx, "auth-policies", prefix, o.DeleteAuthPolicy)
+}
+
+// PurgeExtJwtSigners deletes every ext-jwt-signer whose name starts with prefix.
+func (o *Overlay) PurgeExtJwtSigners(ctx context.Context, prefix string) error {
+	return o.purgeByPrefix(ctx, "ext-jwt-signers", prefix, o.DeleteExtJwtSigner)
+}
+
+func (o *Overlay) purgeByPrefix(ctx context.Context, entity, prefix string, del func(context.Context, string) error) error {
+	filter := fmt.Sprintf(`name contains "%s"`, prefix)
+	for {
+		out, err := o.runZiti(ctx, "edge", "list", entity, filter, "-j")
+		if err != nil {
+			return fmt.Errorf("list %s: %w", entity, err)
+		}
+		var listResp struct {
+			Data []struct {
+				Name string `json:"name"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(out, &listResp); err != nil {
+			return fmt.Errorf("parse %s list: %w", entity, err)
+		}
+		deleted := 0
+		for _, item := range listResp.Data {
+			if !strings.HasPrefix(item.Name, prefix) {
+				continue
+			}
+			if err := del(ctx, item.Name); err != nil {
+				return err
+			}
+			deleted++
+		}
+		if deleted == 0 {
+			return nil
 		}
 	}
 }

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -128,16 +128,22 @@ func (o *Overlay) RequireCATrusted(t *testing.T) {
 		install = fmt.Sprintf(`sudo cp %s /usr/local/share/ca-certificates/ziti-test.crt && sudo update-ca-certificates`, caPath)
 		cleanup = `sudo rm /usr/local/share/ca-certificates/ziti-test.crt && sudo update-ca-certificates --fresh`
 	default:
-		t.Skipf("tests need the CA at %s in OS trust (no install instructions for %s)", caPath, runtime.GOOS)
+		t.Skipf(`tests need the CA at %s in OS trust (no install instructions for %s).
+
+  Current -overlay-home: %s
+  Pass a durable path with -overlay-home so the PKI (and this trust install) persists across runs.`, caPath, runtime.GOOS, o.Home)
 		return
 	}
 	t.Skipf(`tests need the test overlay's CA in OS trust.
+
+  Current -overlay-home: %s
+  Pass a durable path with -overlay-home so the PKI (and this trust install) persists across runs.
 
   Install:
   %s
 
   Cleanup when done:
-  %s`, install, cleanup)
+  %s`, o.Home, install, cleanup)
 }
 
 func (o *Overlay) Stop() {

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -19,12 +19,16 @@ package testutil
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"testing"
 	"time"
 )
 
@@ -99,6 +103,41 @@ func StartOverlay(ctx context.Context, zitiBin, home string) (*Overlay, error) {
 
 func (o *Overlay) ControllerHostPort() string {
 	return fmt.Sprintf("https://localhost:%d", o.ControllerPort)
+}
+
+// RequireCATrusted skips the test (with OS-specific install/cleanup
+// instructions) if the overlay's CA isn't in the calling OS's trust store.
+func (o *Overlay) RequireCATrusted(t *testing.T) {
+	t.Helper()
+	hostport := fmt.Sprintf("localhost:%d", o.ControllerPort)
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 2 * time.Second}, "tcp", hostport, nil)
+	if err == nil {
+		_ = conn.Close()
+		return
+	}
+	caPath := filepath.Join(o.Home, "pki", "root-ca", "certs", "root-ca.cert")
+	var install, cleanup string
+	switch runtime.GOOS {
+	case "windows":
+		install = fmt.Sprintf(`Import-Certificate -FilePath "%s" -CertStoreLocation Cert:\LocalMachine\Root`, caPath)
+		cleanup = fmt.Sprintf(`$c = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 "%s"; Get-ChildItem Cert:\LocalMachine\Root | ? Thumbprint -eq $c.Thumbprint | Remove-Item`, caPath)
+	case "darwin":
+		install = fmt.Sprintf(`sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain %s`, caPath)
+		cleanup = fmt.Sprintf(`sudo security delete-certificate -Z $(openssl x509 -in %s -noout -fingerprint -sha1 | sed 's/.*=//' | tr -d ':') /Library/Keychains/System.keychain`, caPath)
+	case "linux":
+		install = fmt.Sprintf(`sudo cp %s /usr/local/share/ca-certificates/ziti-test.crt && sudo update-ca-certificates`, caPath)
+		cleanup = `sudo rm /usr/local/share/ca-certificates/ziti-test.crt && sudo update-ca-certificates --fresh`
+	default:
+		t.Skipf("tests need the CA at %s in OS trust (no install instructions for %s)", caPath, runtime.GOOS)
+		return
+	}
+	t.Skipf(`tests need the test overlay's CA in OS trust.
+
+  Install:
+  %s
+
+  Cleanup when done:
+  %s`, install, cleanup)
 }
 
 func (o *Overlay) Stop() {
@@ -320,5 +359,4 @@ func (o *Overlay) PurgeIdentities(ctx context.Context, prefix string) error {
 			return err
 		}
 	}
-	return nil
 }

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,8 +29,10 @@ import (
 )
 
 const (
-	adminUsername = "admin"
-	adminPassword = "admin"
+	adminUsername    = "admin"
+	adminPassword    = "admin"
+	overlayCtrlPort  = 1280
+	overlayRtrPort   = 3022
 )
 
 type Overlay struct {
@@ -50,14 +51,6 @@ type Overlay struct {
 // waits for the controller to accept an admin login, and returns a handle.
 // Callers must defer Stop().
 func StartOverlay(ctx context.Context, zitiBin, home string) (*Overlay, error) {
-	ctrlPort, err := findAvailablePort()
-	if err != nil {
-		return nil, fmt.Errorf("allocate controller port: %w", err)
-	}
-	rtrPort, err := findAvailablePort()
-	if err != nil {
-		return nil, fmt.Errorf("allocate router port: %w", err)
-	}
 	if err := os.MkdirAll(home, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir home: %w", err)
 	}
@@ -66,9 +59,9 @@ func StartOverlay(ctx context.Context, zitiBin, home string) (*Overlay, error) {
 		"edge", "quickstart",
 		"--home=" + home,
 		"--ctrl-address=localhost",
-		fmt.Sprintf("--ctrl-port=%d", ctrlPort),
+		fmt.Sprintf("--ctrl-port=%d", overlayCtrlPort),
 		"--router-address=localhost",
-		fmt.Sprintf("--router-port=%d", rtrPort),
+		fmt.Sprintf("--router-port=%d", overlayRtrPort),
 	}
 	cmd := exec.CommandContext(ctx, zitiBin, args...)
 	cmd.Env = append(os.Environ(),
@@ -86,8 +79,8 @@ func StartOverlay(ctx context.Context, zitiBin, home string) (*Overlay, error) {
 	o := &Overlay{
 		ZitiBin:        zitiBin,
 		Home:           home,
-		ControllerPort: ctrlPort,
-		RouterPort:     rtrPort,
+		ControllerPort: overlayCtrlPort,
+		RouterPort:     overlayRtrPort,
 		extCmd:         cmd,
 		stdout:         stdout,
 		stderr:         stderr,
@@ -303,11 +296,29 @@ func (o *Overlay) runZiti(ctx context.Context, args ...string) ([]byte, error) {
 	return []byte(stdout.String()), nil
 }
 
-func findAvailablePort() (uint16, error) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+// PurgeIdentities deletes every identity on the controller whose name starts
+// with prefix. Reuses DeleteIdentity for the per-name delete.
+func (o *Overlay) PurgeIdentities(ctx context.Context, prefix string) error {
+	filter := fmt.Sprintf(`name contains "%s"`, prefix)
+	out, err := o.runZiti(ctx, "edge", "list", "identities", filter, "-j")
 	if err != nil {
-		return 0, err
+		return fmt.Errorf("list identities: %w", err)
 	}
-	defer l.Close()
-	return uint16(l.Addr().(*net.TCPAddr).Port), nil
+	var listResp struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &listResp); err != nil {
+		return fmt.Errorf("parse identities list: %w", err)
+	}
+	for _, id := range listResp.Data {
+		if !strings.HasPrefix(id.Name, prefix) {
+			continue
+		}
+		if err := o.DeleteIdentity(ctx, id.Name); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -247,6 +247,31 @@ func (o *Overlay) CreateIdentityWithExternalId(ctx context.Context, name, extern
 	return nil
 }
 
+// CreateUpdbUser creates a non-admin identity with a UPDB authenticator so the
+// identity can authenticate via the controller's built-in OIDC username/password
+// login. Returns the new identity's controller ID.
+func (o *Overlay) CreateUpdbUser(ctx context.Context, name, username, password string) (string, error) {
+	out, err := o.runZiti(ctx, "edge", "create", "identity", name, "-j")
+	if err != nil {
+		return "", fmt.Errorf("create identity %s: %w", name, err)
+	}
+	var resp struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return "", fmt.Errorf("parse create identity %s response: %w", name, err)
+	}
+	if resp.Data.ID == "" {
+		return "", fmt.Errorf("create identity %s returned empty id", name)
+	}
+	if _, err := o.runZiti(ctx, "edge", "create", "authenticator", "updb", resp.Data.ID, username, password); err != nil {
+		return "", fmt.Errorf("create updb authenticator for %s: %w", name, err)
+	}
+	return resp.Data.ID, nil
+}
+
 // DeleteExtJwtSigner removes an ext-jwt-signer by name.
 func (o *Overlay) DeleteExtJwtSigner(ctx context.Context, name string) error {
 	if _, err := o.runZiti(ctx, "edge", "delete", "ext-jwt-signer", name); err != nil {
@@ -397,30 +422,6 @@ func (o *Overlay) runZiti(ctx context.Context, args ...string) ([]byte, error) {
 			o.ZitiBin, args, err, stdout.String(), stderr.String())
 	}
 	return []byte(stdout.String()), nil
-}
-
-// IdentityID looks up an identity by exact name and returns its controller ID.
-func (o *Overlay) IdentityID(ctx context.Context, name string) (string, error) {
-	filter := fmt.Sprintf(`name = "%s"`, name)
-	out, err := o.runZiti(ctx, "edge", "list", "identities", filter, "-j")
-	if err != nil {
-		return "", fmt.Errorf("list identity %q: %w", name, err)
-	}
-	var listResp struct {
-		Data []struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(out, &listResp); err != nil {
-		return "", fmt.Errorf("parse identity list: %w", err)
-	}
-	for _, id := range listResp.Data {
-		if id.Name == name {
-			return id.ID, nil
-		}
-	}
-	return "", fmt.Errorf("identity %q not found", name)
 }
 
 // PurgeIdentities deletes every identity whose name contains prefix.

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -423,49 +423,25 @@ func (o *Overlay) IdentityID(ctx context.Context, name string) (string, error) {
 	return "", fmt.Errorf("identity %q not found", name)
 }
 
-// PurgeIdentities deletes every identity on the controller whose name starts
-// with prefix. Reuses DeleteIdentity for the per-name delete.
+// PurgeIdentities deletes every identity whose name contains prefix.
 func (o *Overlay) PurgeIdentities(ctx context.Context, prefix string) error {
-	return o.purgeByPrefix(ctx, "identities", prefix, o.DeleteIdentity)
+	return o.deleteWhere(ctx, "identities", prefix)
 }
 
-// PurgeAuthPolicies deletes every auth policy whose name starts with prefix.
+// PurgeAuthPolicies deletes every auth policy whose name contains prefix.
 func (o *Overlay) PurgeAuthPolicies(ctx context.Context, prefix string) error {
-	return o.purgeByPrefix(ctx, "auth-policies", prefix, o.DeleteAuthPolicy)
+	return o.deleteWhere(ctx, "auth-policies", prefix)
 }
 
-// PurgeExtJwtSigners deletes every ext-jwt-signer whose name starts with prefix.
+// PurgeExtJwtSigners deletes every ext-jwt-signer whose name contains prefix.
 func (o *Overlay) PurgeExtJwtSigners(ctx context.Context, prefix string) error {
-	return o.purgeByPrefix(ctx, "ext-jwt-signers", prefix, o.DeleteExtJwtSigner)
+	return o.deleteWhere(ctx, "ext-jwt-signers", prefix)
 }
 
-func (o *Overlay) purgeByPrefix(ctx context.Context, entity, prefix string, del func(context.Context, string) error) error {
-	filter := fmt.Sprintf(`name contains "%s"`, prefix)
-	for {
-		out, err := o.runZiti(ctx, "edge", "list", entity, filter, "-j")
-		if err != nil {
-			return fmt.Errorf("list %s: %w", entity, err)
-		}
-		var listResp struct {
-			Data []struct {
-				Name string `json:"name"`
-			} `json:"data"`
-		}
-		if err := json.Unmarshal(out, &listResp); err != nil {
-			return fmt.Errorf("parse %s list: %w", entity, err)
-		}
-		deleted := 0
-		for _, item := range listResp.Data {
-			if !strings.HasPrefix(item.Name, prefix) {
-				continue
-			}
-			if err := del(ctx, item.Name); err != nil {
-				return err
-			}
-			deleted++
-		}
-		if deleted == 0 {
-			return nil
-		}
+func (o *Overlay) deleteWhere(ctx context.Context, entity, prefix string) error {
+	filter := fmt.Sprintf(`name contains "%s" limit none`, prefix)
+	if _, err := o.runZiti(ctx, "edge", "delete", entity, "where", filter); err != nil {
+		return fmt.Errorf("delete %s where %s: %w", entity, filter, err)
 	}
+	return nil
 }

--- a/tests/integration/url_enrollment_test.go
+++ b/tests/integration/url_enrollment_test.go
@@ -35,6 +35,7 @@ func TestUrlEnrollment(t *testing.T) {
 	requireUrlEnrollmentPrecondition(t)
 	t.Run("withValidControllerUrlSucceeds", testUrlEnrollmentWithValidControllerUrlSucceeds)
 	t.Run("withMalformedUrlFails", testUrlEnrollmentWithMalformedUrlFails)
+	t.Run("sameNameTwiceSecondFails", testUrlEnrollmentSameNameTwiceSecondFails)
 }
 
 func requireUrlEnrollmentPrecondition(t *testing.T) {
@@ -97,6 +98,33 @@ func testUrlEnrollmentWithValidControllerUrlSucceeds(t *testing.T) {
 	require.NoError(t, err, "identity file should be written to -I dir")
 	require.Greater(t, info.Size(), int64(0), "identity file should be non-empty")
 	t.Logf("URL-enrolled identity file written: %s (%d bytes)", entry.Identifier, info.Size())
+}
+
+func testUrlEnrollmentSameNameTwiceSecondFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityName := identityNameFor(t)
+	controllerURL := overlay.ControllerHostPort()
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: identityName,
+		ControllerURL:    &controllerURL,
+	}
+
+	first, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "first URL AddIdentity send\n%s", zet.Logs())
+	require.True(t, first.Success, "first URL AddIdentity should succeed: error=%q\n%s", first.Error, zet.Logs())
+
+	second, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "second URL AddIdentity send\n%s", zet.Logs())
+	require.False(t, second.Success, "second URL AddIdentity should fail, got Success=true")
+	require.Contains(t, second.Error, "identity exists",
+		"expected duplicate-name error, got %q", second.Error)
+	t.Logf("second URL AddIdentity correctly rejected: %s", second.Error)
 }
 
 func testUrlEnrollmentWithMalformedUrlFails(t *testing.T) {

--- a/tests/integration/url_enrollment_test.go
+++ b/tests/integration/url_enrollment_test.go
@@ -35,6 +35,7 @@ func TestUrlEnrollment(t *testing.T) {
 	requireUrlEnrollmentPrecondition(t)
 	t.Run("withValidControllerUrlSucceeds", testUrlEnrollmentWithValidControllerUrlSucceeds)
 	t.Run("withMalformedUrlFails", testUrlEnrollmentWithMalformedUrlFails)
+	t.Run("withNonZitiEndpointFails", testUrlEnrollmentWithNonZitiEndpointFails)
 	t.Run("sameNameTwiceSecondFails", testUrlEnrollmentSameNameTwiceSecondFails)
 }
 
@@ -125,6 +126,27 @@ func testUrlEnrollmentSameNameTwiceSecondFails(t *testing.T) {
 	require.Contains(t, second.Error, "identity exists",
 		"expected duplicate-name error, got %q", second.Error)
 	t.Logf("second URL AddIdentity correctly rejected: %s", second.Error)
+}
+
+func testUrlEnrollmentWithNonZitiEndpointFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityName := identityNameFor(t)
+	nonZitiURL := "https://example.com"
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: identityName,
+		ControllerURL:    &nonZitiURL,
+	}
+
+	resp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "URL AddIdentity send\n%s", zet.Logs())
+	require.False(t, resp.Success, "non-Ziti URL %q should be rejected, got Success=true\n%s", nonZitiURL, zet.Logs())
+	t.Logf("non-Ziti URL correctly rejected: code=%d error=%q", resp.Code, resp.Error)
 }
 
 func testUrlEnrollmentWithMalformedUrlFails(t *testing.T) {

--- a/tests/integration/url_enrollment_test.go
+++ b/tests/integration/url_enrollment_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/openziti/ziti-tunnel-sdk-c/tests/integration/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUrlEnrollment(t *testing.T) {
+	requireUrlEnrollmentPrecondition(t)
+	t.Run("withValidControllerUrlSucceeds", testUrlEnrollmentWithValidControllerUrlSucceeds)
+	t.Run("withMalformedUrlFails", testUrlEnrollmentWithMalformedUrlFails)
+}
+
+func requireUrlEnrollmentPrecondition(t *testing.T) {
+	t.Helper()
+	hostport := fmt.Sprintf("localhost:%d", overlay.ControllerPort)
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 2 * time.Second}, "tcp", hostport, nil)
+	if err != nil {
+		caPath := filepath.Join(overlayHome, "pki", "root-ca", "certs", "root-ca.cert")
+		var install, cleanup string
+		switch runtime.GOOS {
+		case "windows":
+			install = fmt.Sprintf(`Import-Certificate -FilePath "%s" -CertStoreLocation Cert:\LocalMachine\Root`, caPath)
+			cleanup = fmt.Sprintf(`$c = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 "%s"; Get-ChildItem Cert:\LocalMachine\Root | ? Thumbprint -eq $c.Thumbprint | Remove-Item`, caPath)
+		case "darwin":
+			install = fmt.Sprintf(`sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain %s`, caPath)
+			cleanup = fmt.Sprintf(`sudo security delete-certificate -Z $(openssl x509 -in %s -noout -fingerprint -sha1 | sed 's/.*=//' | tr -d ':') /Library/Keychains/System.keychain`, caPath)
+		case "linux":
+			install = fmt.Sprintf(`sudo cp %s /usr/local/share/ca-certificates/ziti-test.crt && sudo update-ca-certificates`, caPath)
+			cleanup = `sudo rm /usr/local/share/ca-certificates/ziti-test.crt && sudo update-ca-certificates --fresh`
+		default:
+			t.Skipf("URL tests need the CA at %s in OS trust (no install instructions for %s)", caPath, runtime.GOOS)
+			return
+		}
+		t.Skipf(`URL tests need the test overlay's CA in OS trust.
+
+  Install:
+  %s
+
+  Cleanup when done:
+  %s`, install, cleanup)
+	}
+	_ = conn.Close()
+}
+
+// testUrlEnrollmentWithValidControllerUrlSucceeds exercises the "URL + no enroll-to mode" path.
+func testUrlEnrollmentWithValidControllerUrlSucceeds(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityName := identityNameFor(t)
+	controllerURL := overlay.ControllerHostPort()
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: identityName,
+		ControllerURL:    &controllerURL,
+	}
+
+	resp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "URL AddIdentity send\n%s", zet.Logs())
+	require.True(t, resp.Success, "URL AddIdentity failed: error=%q code=%d\n%s", resp.Error, resp.Code, zet.Logs())
+
+	status, err := client.GetTunnelStatus(ctx)
+	require.NoError(t, err, "Status after URL AddIdentity\n%s", zet.Logs())
+	entry := status.FindIdentity(identityName)
+	require.NotNil(t, entry, "identity %q not found in Status after URL AddIdentity", identityName)
+	info, err := os.Stat(entry.Identifier)
+	require.NoError(t, err, "identity file should be written to -I dir")
+	require.Greater(t, info.Size(), int64(0), "identity file should be non-empty")
+	t.Logf("URL-enrolled identity file written: %s (%d bytes)", entry.Identifier, info.Size())
+}
+
+func testUrlEnrollmentWithMalformedUrlFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	identityName := identityNameFor(t)
+	badURL := "not-a-url"
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: identityName,
+		ControllerURL:    &badURL,
+	}
+
+	resp, err := client.AddIdentity(ctx, identityData)
+	require.NoError(t, err, "URL AddIdentity send\n%s", zet.Logs())
+	require.False(t, resp.Success, "malformed URL %q should be rejected, got Success=true\n%s", badURL, zet.Logs())
+	t.Logf("malformed URL correctly rejected: code=%d error=%q", resp.Code, resp.Error)
+}

--- a/tests/integration/url_enrollment_test.go
+++ b/tests/integration/url_enrollment_test.go
@@ -18,12 +18,7 @@ package integration_test
 
 import (
 	"context"
-	"crypto/tls"
-	"fmt"
-	"net"
 	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -32,44 +27,12 @@ import (
 )
 
 func TestUrlEnrollment(t *testing.T) {
-	requireUrlEnrollmentPrecondition(t)
+	overlay.RequireCATrusted(t)
 	t.Run("withValidControllerUrlSucceeds", testUrlEnrollmentWithValidControllerUrlSucceeds)
 	t.Run("withMalformedUrlFails", testUrlEnrollmentWithMalformedUrlFails)
 	t.Run("withNonZitiEndpointFails", testUrlEnrollmentWithNonZitiEndpointFails)
 	t.Run("sameNameTwiceSecondFails", testUrlEnrollmentSameNameTwiceSecondFails)
 	t.Run("afterJwtSameNameFails", testUrlEnrollmentAfterJwtSameNameFails)
-}
-
-func requireUrlEnrollmentPrecondition(t *testing.T) {
-	t.Helper()
-	hostport := fmt.Sprintf("localhost:%d", overlay.ControllerPort)
-	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 2 * time.Second}, "tcp", hostport, nil)
-	if err != nil {
-		caPath := filepath.Join(overlayHome, "pki", "root-ca", "certs", "root-ca.cert")
-		var install, cleanup string
-		switch runtime.GOOS {
-		case "windows":
-			install = fmt.Sprintf(`Import-Certificate -FilePath "%s" -CertStoreLocation Cert:\LocalMachine\Root`, caPath)
-			cleanup = fmt.Sprintf(`$c = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 "%s"; Get-ChildItem Cert:\LocalMachine\Root | ? Thumbprint -eq $c.Thumbprint | Remove-Item`, caPath)
-		case "darwin":
-			install = fmt.Sprintf(`sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain %s`, caPath)
-			cleanup = fmt.Sprintf(`sudo security delete-certificate -Z $(openssl x509 -in %s -noout -fingerprint -sha1 | sed 's/.*=//' | tr -d ':') /Library/Keychains/System.keychain`, caPath)
-		case "linux":
-			install = fmt.Sprintf(`sudo cp %s /usr/local/share/ca-certificates/ziti-test.crt && sudo update-ca-certificates`, caPath)
-			cleanup = `sudo rm /usr/local/share/ca-certificates/ziti-test.crt && sudo update-ca-certificates --fresh`
-		default:
-			t.Skipf("URL tests need the CA at %s in OS trust (no install instructions for %s)", caPath, runtime.GOOS)
-			return
-		}
-		t.Skipf(`URL tests need the test overlay's CA in OS trust.
-
-  Install:
-  %s
-
-  Cleanup when done:
-  %s`, install, cleanup)
-	}
-	_ = conn.Close()
 }
 
 // testUrlEnrollmentWithValidControllerUrlSucceeds exercises the "URL + no enroll-to mode" path.

--- a/tests/integration/url_enrollment_test.go
+++ b/tests/integration/url_enrollment_test.go
@@ -37,6 +37,7 @@ func TestUrlEnrollment(t *testing.T) {
 	t.Run("withMalformedUrlFails", testUrlEnrollmentWithMalformedUrlFails)
 	t.Run("withNonZitiEndpointFails", testUrlEnrollmentWithNonZitiEndpointFails)
 	t.Run("sameNameTwiceSecondFails", testUrlEnrollmentSameNameTwiceSecondFails)
+	t.Run("afterJwtSameNameFails", testUrlEnrollmentAfterJwtSameNameFails)
 }
 
 func requireUrlEnrollmentPrecondition(t *testing.T) {
@@ -126,6 +127,39 @@ func testUrlEnrollmentSameNameTwiceSecondFails(t *testing.T) {
 	require.Contains(t, second.Error, "identity exists",
 		"expected duplicate-name error, got %q", second.Error)
 	t.Logf("second URL AddIdentity correctly rejected: %s", second.Error)
+}
+
+func testUrlEnrollmentAfterJwtSameNameFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	identityName := identityNameFor(t)
+	jwt, err := overlay.CreateIdentityJWT(ctx, identityName)
+	require.NoError(t, err, "mint JWT via overlay")
+	require.NotEmpty(t, jwt)
+
+	client, err := testutil.DialIPC(ctx)
+	require.NoError(t, err, "dial ZET IPC pipe")
+	t.Cleanup(func() { _ = client.Close() })
+
+	jwtIdentityData := testutil.AddIdentityData{
+		IdentityFilename: identityName,
+		JwtContent:       &jwt,
+	}
+	first, err := client.AddIdentity(ctx, jwtIdentityData)
+	require.NoError(t, err, "first JWT AddIdentity send\n%s", zet.Logs())
+	require.True(t, first.Success, "first JWT AddIdentity should succeed: error=%q\n%s", first.Error, zet.Logs())
+
+	controllerURL := overlay.ControllerHostPort()
+	urlIdentityData := testutil.AddIdentityData{
+		IdentityFilename: identityName,
+		ControllerURL:    &controllerURL,
+	}
+	second, err := client.AddIdentity(ctx, urlIdentityData)
+	require.NoError(t, err, "second URL AddIdentity send\n%s", zet.Logs())
+	require.False(t, second.Success, "URL AddIdentity should fail when name already enrolled via JWT, got Success=true")
+	require.Contains(t, second.Error, "identity exists", "expected duplicate-name error, got %q", second.Error)
+	t.Logf("URL AddIdentity correctly rejected after JWT enroll: %s", second.Error)
 }
 
 func testUrlEnrollmentWithNonZitiEndpointFails(t *testing.T) {


### PR DESCRIPTION
## URL enrollment
- Adds integration tests for `AddIdentity` via controller URL: happy path, malformed URL, valid non-Ziti endpoint, and duplicate-name rejection
- Reworks `TestMain` to take a persistent `-overlay-home` so the test overlay's PKI survives across runs and can be installed into OS trust.
- When the test overlay's CA is not in OS trust, the URL tests skip with copy-paste install/cleanup commands for Linux, macOS, and Windows.
- Wires CI to seed the PKI via `ziti edge quickstart` and install the CA into OS trust before running the integration suite.

## External auth
- Adds an integration test that drives the controller's built-in OIDC PKCE flow end-to-end against a URL-enrolled identity bound to an `ext-jwt-signer`-backed auth policy.
- Adds a `testutil` OIDC driver (`DiscoverOIDCJWKS`, `DriveControllerOIDC`) that walks `/oidc/authorize` -> `/oidc/login/username` -> `/oidc/authorize/callback` -> ZET's loopback listener with no browser.
- Adds `Overlay` helpers for the ext-jwt-signer / auth-policy / externalId-identity lifecycle, plus `IdentityID` lookup and `PurgeAuthPolicies` / `PurgeExtJwtSigners` to extend the existing "Test"-prefix purge.
- Adds an IPC `GetExternalAuth` helper that parses the `ExternalAuth` response, and a `NeedsExtAuth` field on `IdentityStatus`.