### PR TITLE
Add cross-mode re-enroll rejection tests for external auth

### DIFF
--- a/docker/docker.test.bash
+++ b/docker/docker.test.bash
@@ -151,13 +151,18 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-ziti edge login \
+# the controller may reject the admin login briefly after startup, so retry a few times
+ATTEMPTS=5
+until ziti edge login \
 ${ZITI_CTRL_ADVERTISED_ADDRESS}:${ZITI_CTRL_ADVERTISED_PORT} \
 --ca=/home/ziggy/quickstart/pki/root-ca/certs/root-ca.cert \
 --username=admin \
 --password=${ZITI_PWD} \
---timeout=1 \
---verbose
+--timeout=5
+do
+    (( --ATTEMPTS )) || { echo "ERROR: ziti edge login failed" >&2; exit 1; }
+    sleep 2
+done
 
 ziti edge create identity "httpbin-client" \
     --jwt-output-file /tmp/httpbin-client.ott.jwt \

--- a/tests/integration/add_identity_test.go
+++ b/tests/integration/add_identity_test.go
@@ -56,7 +56,7 @@ func testAddIdentityWithJwtSucceeds(t *testing.T) {
 		require.True(t, resp.Success(), "AddIdentity failed: error=%q code=%d\n%s", resp.Error, resp.Code, state.zetClient.LogPath())
 
 		event := events.WaitForIdentityEvent(t, "added", identityName)
-		require.True(t, event.Id.Active, "identity:added Active=%t, want true", event.Id.Active)
+		require.True(t, event.Id.Active, "identity:added Active=%t", event.Id.Active)
 		require.NotEmpty(t, event.Id.Identifier, "identity:added Identifier empty")
 
 		testutil.AssertValidJwtEnrolledIdentityFile(t, event.Id.Identifier)

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -127,78 +127,6 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 	t.Run("testEnrollToCertThenNoneRejected", c.testEnrollToCertThenNoneRejected)
 }
 
-func (c *extAuthContext) testEnrollToCertCompletes(t *testing.T) {
-	testutil.RunTestWithTimeout(t, func(t *testing.T) {
-		name := testutil.IdentityName(t)
-		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
-
-		c.completeEnrollToCert(t, name)
-	})
-}
-
-// completeEnrollToCert drives a full enroll-to-cert flow for name and returns the
-// resulting identifier. The working signer must already have EnrollToCert enabled.
-func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string {
-	controllerBase := c.overlay.ControllerHostPort()
-	mode := testutil.EnrollModeCert
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		ControllerURL:    &controllerBase,
-		EnrollMode:       &mode,
-		Provider:         &c.workingSigner.name,
-	}
-	addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
-	require.True(t, addResp.Success(), "AddIdentity (enroll to cert) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
-	require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to cert) response has empty URL")
-
-	c.idp.DriveIdPFlow(t, addResp.Data.URL)
-
-	added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
-	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to cert IdP login flow, want true", added.Id.Active)
-	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to cert IdP login flow, want false", added.Id.NeedsExtAuth)
-	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeCert)
-	t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to cert IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
-	return added.Id.Identifier
-}
-
-func (c *extAuthContext) testEnrollToTokenCompletes(t *testing.T) {
-	testutil.RunTestWithTimeout(t, func(t *testing.T) {
-		name := testutil.IdentityName(t)
-		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
-
-		controllerBase := c.overlay.ControllerHostPort()
-		mode := testutil.EnrollModeToken
-		identityData := testutil.AddIdentityData{
-			IdentityFilename: name,
-			ControllerURL:    &controllerBase,
-			EnrollMode:       &mode,
-			Provider:         &c.workingSigner.name,
-		}
-		addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
-		require.True(t, addResp.Success(), "AddIdentity (enroll to token) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
-		require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to token) response has empty URL")
-
-		c.idp.DriveIdPFlow(t, addResp.Data.URL)
-
-		identityEvent := c.zet.Events.WaitForIdentityEvent(t, "needs_ext_login", name)
-		require.True(t, identityEvent.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t after enroll to token IdP login flow, want true", identityEvent.Id.NeedsExtAuth)
-		authURL := c.zet.Commands.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name, c.zet.LogPath())
-
-		c.idp.DriveIdPFlow(t, authURL)
-
-		added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
-		require.True(t, added.Id.Active, "identity:added Active=%t after enroll to token IdP login flow, want true", added.Id.Active)
-		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to token IdP login flow, want false", added.Id.NeedsExtAuth)
-		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeToken)
-		t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to token IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
-	})
-}
-
-func (c *extAuthContext) testBothEnrollFlowsCompleteWhenBothEnabled(t *testing.T) {
-	t.Run("testEnrollToCertCompletes", c.testEnrollToCertCompletes)
-	t.Run("testEnrollToTokenCompletes", c.testEnrollToTokenCompletes)
-}
-
 func (c *extAuthContext) testEnrollToNoneCompletes(t *testing.T) {
 	testutil.RunTestWithTimeout(t, func(t *testing.T) {
 		name := testutil.IdentityName(t)
@@ -324,6 +252,78 @@ func (c *extAuthContext) addEnrollToNoneIdentity(t *testing.T, name string) test
 	t.Logf("identity:needs_ext_login Identifier=%s NeedsExtAuth=%t", identityEvent.Id.Identifier, identityEvent.Id.NeedsExtAuth)
 
 	return identityEvent
+}
+
+func (c *extAuthContext) testEnrollToCertCompletes(t *testing.T) {
+	testutil.RunTestWithTimeout(t, func(t *testing.T) {
+		name := testutil.IdentityName(t)
+		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+
+		c.completeEnrollToCert(t, name)
+	})
+}
+
+// completeEnrollToCert drives a full enroll-to-cert flow for name and returns the
+// resulting identifier. The working signer must already have EnrollToCert enabled.
+func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string {
+	controllerBase := c.overlay.ControllerHostPort()
+	mode := testutil.EnrollModeCert
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		ControllerURL:    &controllerBase,
+		EnrollMode:       &mode,
+		Provider:         &c.workingSigner.name,
+	}
+	addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
+	require.True(t, addResp.Success(), "AddIdentity (enroll to cert) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
+	require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to cert) response has empty URL")
+
+	c.idp.DriveIdPFlow(t, addResp.Data.URL)
+
+	added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
+	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to cert IdP login flow, want true", added.Id.Active)
+	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to cert IdP login flow, want false", added.Id.NeedsExtAuth)
+	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeCert)
+	t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to cert IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
+	return added.Id.Identifier
+}
+
+func (c *extAuthContext) testEnrollToTokenCompletes(t *testing.T) {
+	testutil.RunTestWithTimeout(t, func(t *testing.T) {
+		name := testutil.IdentityName(t)
+		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+
+		controllerBase := c.overlay.ControllerHostPort()
+		mode := testutil.EnrollModeToken
+		identityData := testutil.AddIdentityData{
+			IdentityFilename: name,
+			ControllerURL:    &controllerBase,
+			EnrollMode:       &mode,
+			Provider:         &c.workingSigner.name,
+		}
+		addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
+		require.True(t, addResp.Success(), "AddIdentity (enroll to token) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
+		require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to token) response has empty URL")
+
+		c.idp.DriveIdPFlow(t, addResp.Data.URL)
+
+		identityEvent := c.zet.Events.WaitForIdentityEvent(t, "needs_ext_login", name)
+		require.True(t, identityEvent.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t after enroll to token IdP login flow, want true", identityEvent.Id.NeedsExtAuth)
+		authURL := c.zet.Commands.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name, c.zet.LogPath())
+
+		c.idp.DriveIdPFlow(t, authURL)
+
+		added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
+		require.True(t, added.Id.Active, "identity:added Active=%t after enroll to token IdP login flow, want true", added.Id.Active)
+		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to token IdP login flow, want false", added.Id.NeedsExtAuth)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeToken)
+		t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to token IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
+	})
+}
+
+func (c *extAuthContext) testBothEnrollFlowsCompleteWhenBothEnabled(t *testing.T) {
+	t.Run("testEnrollToCertCompletes", c.testEnrollToCertCompletes)
+	t.Run("testEnrollToTokenCompletes", c.testEnrollToTokenCompletes)
 }
 
 func (c *extAuthContext) testEnrollToNoneThenCertRejected(t *testing.T) {

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -122,6 +122,8 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 
 	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollToToken: true})
 	t.Run("testBothEnrollFlowsCompleteWhenBothEnabled", c.testBothEnrollFlowsCompleteWhenBothEnabled)
+
+	t.Run("testEnrollToNoneThenCertRejected", c.testEnrollToNoneThenCertRejected)
 }
 
 func (c *extAuthContext) testEnrollToCertCompletes(t *testing.T) {
@@ -314,4 +316,32 @@ func (c *extAuthContext) addEnrollToNoneIdentity(t *testing.T, name string) test
 	t.Logf("identity:needs_ext_login Identifier=%s NeedsExtAuth=%t", identityEvent.Id.Identifier, identityEvent.Id.NeedsExtAuth)
 
 	return identityEvent
+}
+
+func (c *extAuthContext) testEnrollToNoneThenCertRejected(t *testing.T) {
+	testutil.RunTestWithTimeout(t, func(t *testing.T) {
+		name := testutil.IdentityName(t)
+
+		enrollToNone := testutil.ExtJwtSignerSpec{}
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, enrollToNone)
+		identityEvent := c.addEnrollToNoneIdentity(t, name)
+
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
+
+		controllerBase := c.overlay.ControllerHostPort()
+		mode := testutil.EnrollModeCert
+		identityData := testutil.AddIdentityData{
+			IdentityFilename: name,
+			ControllerURL:    &controllerBase,
+			EnrollMode:       &mode,
+			Provider:         &c.workingSigner.name,
+		}
+		addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
+		require.False(t, addResp.Success(), "cert AddIdentity with same name should fail after a pending none enrollment\n%s", c.zet.LogPath())
+		require.Equal(t, 500, addResp.Code, "expected Code=500, got %d", addResp.Code)
+		require.Contains(t, addResp.Error, "identity exists with the same name", "expected name-collision error, got %q", addResp.Error)
+		// Ensure the identity file wasn't overwritten
+		testutil.AssertValidUrlEnrolledIdentityFile(t, identityEvent.Id.Identifier, testutil.EnrollModeNone)
+		t.Logf("cert AddIdentity rejected: code=%d error=%q", addResp.Code, addResp.Error)
+	})
 }

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -126,6 +126,7 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 	t.Run("testEnrollToNoneThenCertRejected", c.testEnrollToNoneThenCertRejected)
 	t.Run("testEnrollToCertThenNoneRejected", c.testEnrollToCertThenNoneRejected)
 	t.Run("testEnrollToCertThenTokenRejected", c.testEnrollToCertThenTokenRejected)
+	t.Run("testEnrollToTokenThenCertRejected", c.testEnrollToTokenThenCertRejected)
 }
 
 func (c *extAuthContext) testEnrollToNoneCompletes(t *testing.T) {
@@ -294,32 +295,39 @@ func (c *extAuthContext) testEnrollToTokenCompletes(t *testing.T) {
 		name := testutil.IdentityName(t)
 		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
 
-		controllerBase := c.overlay.ControllerHostPort()
-		mode := testutil.EnrollModeToken
-		identityData := testutil.AddIdentityData{
-			IdentityFilename: name,
-			ControllerURL:    &controllerBase,
-			EnrollMode:       &mode,
-			Provider:         &c.workingSigner.name,
-		}
-		addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
-		require.True(t, addResp.Success(), "AddIdentity (enroll to token) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
-		require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to token) response has empty URL")
-
-		c.idp.DriveIdPFlow(t, addResp.Data.URL)
-
-		identityEvent := c.zet.Events.WaitForIdentityEvent(t, "needs_ext_login", name)
-		require.True(t, identityEvent.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t after enroll to token IdP login flow, want true", identityEvent.Id.NeedsExtAuth)
-		authURL := c.zet.Commands.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name, c.zet.LogPath())
-
-		c.idp.DriveIdPFlow(t, authURL)
-
-		added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
-		require.True(t, added.Id.Active, "identity:added Active=%t after enroll to token IdP login flow, want true", added.Id.Active)
-		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to token IdP login flow, want false", added.Id.NeedsExtAuth)
-		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeToken)
-		t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to token IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
+		c.completeEnrollToToken(t, name)
 	})
+}
+
+// completeEnrollToToken drives a full enroll-to-token flow for name and returns the
+// resulting identifier. The working signer must already have EnrollToToken enabled.
+func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) string {
+	controllerBase := c.overlay.ControllerHostPort()
+	mode := testutil.EnrollModeToken
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		ControllerURL:    &controllerBase,
+		EnrollMode:       &mode,
+		Provider:         &c.workingSigner.name,
+	}
+	addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
+	require.True(t, addResp.Success(), "AddIdentity (enroll to token) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
+	require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to token) response has empty URL")
+
+	c.idp.DriveIdPFlow(t, addResp.Data.URL)
+
+	identityEvent := c.zet.Events.WaitForIdentityEvent(t, "needs_ext_login", name)
+	require.True(t, identityEvent.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t after enroll to token IdP login flow, want true", identityEvent.Id.NeedsExtAuth)
+	authURL := c.zet.Commands.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name, c.zet.LogPath())
+
+	c.idp.DriveIdPFlow(t, authURL)
+
+	added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
+	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to token IdP login flow, want true", added.Id.Active)
+	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to token IdP login flow, want false", added.Id.NeedsExtAuth)
+	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeToken)
+	t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to token IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
+	return added.Id.Identifier
 }
 
 func (c *extAuthContext) testBothEnrollFlowsCompleteWhenBothEnabled(t *testing.T) {
@@ -392,6 +400,30 @@ func (c *extAuthContext) testEnrollToCertThenTokenRejected(t *testing.T) {
 		addResp := testutil.AddIdentity(t, c.zet.Commands, enrollToTokenIdentity)
 		c.assertIdentityExistsSameName(t, addResp)
 		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeCert)
+	})
+}
+
+func (c *extAuthContext) testEnrollToTokenThenCertRejected(t *testing.T) {
+	testutil.RunTestWithTimeout(t, func(t *testing.T) {
+		name := testutil.IdentityName(t)
+		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
+		identifier := c.completeEnrollToToken(t, name)
+
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
+
+		controllerBase := c.overlay.ControllerHostPort()
+		mode := testutil.EnrollModeCert
+		enrollToCertIdentity := testutil.AddIdentityData{
+			IdentityFilename: name,
+			ControllerURL:    &controllerBase,
+			EnrollMode:       &mode,
+			Provider:         &c.workingSigner.name,
+		}
+		addResp := testutil.AddIdentity(t, c.zet.Commands, enrollToCertIdentity)
+		c.assertIdentityExistsSameName(t, addResp)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeToken)
 	})
 }
 

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -265,17 +265,20 @@ func (c *extAuthContext) testEnrollToCertCompletes(t *testing.T) {
 	})
 }
 
-// completeEnrollToCert drives a full enroll-to-cert flow for name and returns the
-// resulting identifier. The working signer must already have EnrollToCert enabled.
-func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string {
+func (c *extAuthContext) createIdentityData(name string, mode testutil.EnrollMode) testutil.AddIdentityData {
 	controllerBase := c.overlay.ControllerHostPort()
-	mode := testutil.EnrollModeCert
-	identityData := testutil.AddIdentityData{
+	return testutil.AddIdentityData{
 		IdentityFilename: name,
 		ControllerURL:    &controllerBase,
 		EnrollMode:       &mode,
 		Provider:         &c.workingSigner.name,
 	}
+}
+
+// completeEnrollToCert drives a full enroll-to-cert flow for name and returns the
+// resulting identifier. The working signer must already have EnrollToCert enabled.
+func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string {
+	identityData := c.createIdentityData(name, testutil.EnrollModeCert)
 	addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
 	require.True(t, addResp.Success(), "AddIdentity (enroll to cert) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
 	require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to cert) response has empty URL")
@@ -302,14 +305,7 @@ func (c *extAuthContext) testEnrollToTokenCompletes(t *testing.T) {
 // completeEnrollToToken drives a full enroll-to-token flow for name and returns the
 // resulting identifier. The working signer must already have EnrollToToken enabled.
 func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) string {
-	controllerBase := c.overlay.ControllerHostPort()
-	mode := testutil.EnrollModeToken
-	identityData := testutil.AddIdentityData{
-		IdentityFilename: name,
-		ControllerURL:    &controllerBase,
-		EnrollMode:       &mode,
-		Provider:         &c.workingSigner.name,
-	}
+	identityData := c.createIdentityData(name, testutil.EnrollModeToken)
 	addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
 	require.True(t, addResp.Success(), "AddIdentity (enroll to token) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
 	require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to token) response has empty URL")
@@ -344,14 +340,7 @@ func (c *extAuthContext) testEnrollToNoneThenCertRejected(t *testing.T) {
 		identityEvent := c.addEnrollToNoneIdentity(t, name)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
-		controllerBase := c.overlay.ControllerHostPort()
-		mode := testutil.EnrollModeCert
-		enrollToCertIdentity := testutil.AddIdentityData{
-			IdentityFilename: name,
-			ControllerURL:    &controllerBase,
-			EnrollMode:       &mode,
-			Provider:         &c.workingSigner.name,
-		}
+		enrollToCertIdentity := c.createIdentityData(name, testutil.EnrollModeCert)
 		addResp := testutil.AddIdentity(t, c.zet.Commands, enrollToCertIdentity)
 		c.assertIdentityExistsSameName(t, addResp)
 		testutil.AssertValidUrlEnrolledIdentityFile(t, identityEvent.Id.Identifier, testutil.EnrollModeNone)
@@ -389,14 +378,7 @@ func (c *extAuthContext) testEnrollToCertThenTokenRejected(t *testing.T) {
 		identifier := c.completeEnrollToCert(t, name)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
-		controllerBase := c.overlay.ControllerHostPort()
-		mode := testutil.EnrollModeToken
-		enrollToTokenIdentity := testutil.AddIdentityData{
-			IdentityFilename: name,
-			ControllerURL:    &controllerBase,
-			EnrollMode:       &mode,
-			Provider:         &c.workingSigner.name,
-		}
+		enrollToTokenIdentity := c.createIdentityData(name, testutil.EnrollModeToken)
 		addResp := testutil.AddIdentity(t, c.zet.Commands, enrollToTokenIdentity)
 		c.assertIdentityExistsSameName(t, addResp)
 		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeCert)
@@ -412,15 +394,7 @@ func (c *extAuthContext) testEnrollToTokenThenCertRejected(t *testing.T) {
 		identifier := c.completeEnrollToToken(t, name)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
-
-		controllerBase := c.overlay.ControllerHostPort()
-		mode := testutil.EnrollModeCert
-		enrollToCertIdentity := testutil.AddIdentityData{
-			IdentityFilename: name,
-			ControllerURL:    &controllerBase,
-			EnrollMode:       &mode,
-			Provider:         &c.workingSigner.name,
-		}
+		enrollToCertIdentity := c.createIdentityData(name, testutil.EnrollModeCert)
 		addResp := testutil.AddIdentity(t, c.zet.Commands, enrollToCertIdentity)
 		c.assertIdentityExistsSameName(t, addResp)
 		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeToken)

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -124,6 +124,7 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 	t.Run("testBothEnrollFlowsCompleteWhenBothEnabled", c.testBothEnrollFlowsCompleteWhenBothEnabled)
 
 	t.Run("testEnrollToNoneThenCertRejected", c.testEnrollToNoneThenCertRejected)
+	t.Run("testEnrollToCertThenNoneRejected", c.testEnrollToCertThenNoneRejected)
 }
 
 func (c *extAuthContext) testEnrollToCertCompletes(t *testing.T) {
@@ -131,26 +132,33 @@ func (c *extAuthContext) testEnrollToCertCompletes(t *testing.T) {
 		name := testutil.IdentityName(t)
 		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
 
-		controllerBase := c.overlay.ControllerHostPort()
-		mode := testutil.EnrollModeCert
-		identityData := testutil.AddIdentityData{
-			IdentityFilename: name,
-			ControllerURL:    &controllerBase,
-			EnrollMode:       &mode,
-			Provider:         &c.workingSigner.name,
-		}
-		addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
-		require.True(t, addResp.Success(), "AddIdentity (enroll to cert) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
-		require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to cert) response has empty URL")
-
-		c.idp.DriveIdPFlow(t, addResp.Data.URL)
-
-		added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
-		require.True(t, added.Id.Active, "identity:added Active=%t after enroll to cert IdP login flow, want true", added.Id.Active)
-		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to cert IdP login flow, want false", added.Id.NeedsExtAuth)
-		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeCert)
-		t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to cert IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
+		c.completeEnrollToCert(t, name)
 	})
+}
+
+// completeEnrollToCert drives a full enroll-to-cert flow for name and returns the
+// resulting identifier. The working signer must already have EnrollToCert enabled.
+func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string {
+	controllerBase := c.overlay.ControllerHostPort()
+	mode := testutil.EnrollModeCert
+	identityData := testutil.AddIdentityData{
+		IdentityFilename: name,
+		ControllerURL:    &controllerBase,
+		EnrollMode:       &mode,
+		Provider:         &c.workingSigner.name,
+	}
+	addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
+	require.True(t, addResp.Success(), "AddIdentity (enroll to cert) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
+	require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to cert) response has empty URL")
+
+	c.idp.DriveIdPFlow(t, addResp.Data.URL)
+
+	added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
+	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to cert IdP login flow, want true", added.Id.Active)
+	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to cert IdP login flow, want false", added.Id.NeedsExtAuth)
+	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeCert)
+	t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to cert IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
+	return added.Id.Identifier
 }
 
 func (c *extAuthContext) testEnrollToTokenCompletes(t *testing.T) {
@@ -327,21 +335,47 @@ func (c *extAuthContext) testEnrollToNoneThenCertRejected(t *testing.T) {
 		identityEvent := c.addEnrollToNoneIdentity(t, name)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
-
 		controllerBase := c.overlay.ControllerHostPort()
 		mode := testutil.EnrollModeCert
-		identityData := testutil.AddIdentityData{
+		enrollToCertIdentity := testutil.AddIdentityData{
 			IdentityFilename: name,
 			ControllerURL:    &controllerBase,
 			EnrollMode:       &mode,
 			Provider:         &c.workingSigner.name,
 		}
-		addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
-		require.False(t, addResp.Success(), "cert AddIdentity with same name should fail after a pending none enrollment\n%s", c.zet.LogPath())
-		require.Equal(t, 500, addResp.Code, "expected Code=500, got %d", addResp.Code)
-		require.Contains(t, addResp.Error, "identity exists with the same name", "expected name-collision error, got %q", addResp.Error)
-		// Ensure the identity file wasn't overwritten
+		addResp := testutil.AddIdentity(t, c.zet.Commands, enrollToCertIdentity)
+		c.assertIdentityExistsSameName(t, addResp)
 		testutil.AssertValidUrlEnrolledIdentityFile(t, identityEvent.Id.Identifier, testutil.EnrollModeNone)
-		t.Logf("cert AddIdentity rejected: code=%d error=%q", addResp.Code, addResp.Error)
 	})
+}
+
+func (c *extAuthContext) testEnrollToCertThenNoneRejected(t *testing.T) {
+	testutil.RunTestWithTimeout(t, func(t *testing.T) {
+		name := testutil.IdentityName(t)
+		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
+		identifier := c.completeEnrollToCert(t, name)
+
+		enrollToNone := testutil.ExtJwtSignerSpec{}
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, enrollToNone)
+
+		controllerBase := c.overlay.ControllerHostPort()
+		enrollToNoneIdentity := testutil.AddIdentityData{
+			IdentityFilename: name,
+			ControllerURL:    &controllerBase,
+		}
+		addResp := testutil.AddIdentity(t, c.zet.Commands, enrollToNoneIdentity)
+		c.assertIdentityExistsSameName(t, addResp)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeCert)
+	})
+}
+
+// assertIdentityExistsSameName asserts an AddIdentity response was rejected
+// because an identity with the same name already exists.
+func (c *extAuthContext) assertIdentityExistsSameName(t *testing.T, addResp *testutil.AddIdentityResponse) {
+	require.False(t, addResp.Success(), "AddIdentity with an existing name should fail\n%s", c.zet.LogPath())
+	require.Equal(t, 500, addResp.Code, "expected Code=500, got %d", addResp.Code)
+	require.Contains(t, addResp.Error, "identity exists with the same name", "expected name-collision error, got %q", addResp.Error)
+	t.Logf("AddIdentity rejected: code=%d error=%q", addResp.Code, addResp.Error)
 }

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -141,8 +141,8 @@ func (c *extAuthContext) testEnrollToNoneCompletes(t *testing.T) {
 		c.idp.DriveIdPFlow(t, authURL)
 
 		added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
-		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after IdP login flow, want false", added.Id.NeedsExtAuth)
-		require.True(t, added.Id.Active, "identity:added Active=%t after IdP login flow, want true", added.Id.Active)
+		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after IdP login flow", added.Id.NeedsExtAuth)
+		require.True(t, added.Id.Active, "identity:added Active=%t after IdP login flow", added.Id.Active)
 		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeNone)
 		t.Logf("identity:added reports NeedsExtAuth=%t Active=%t after IdP login flow", added.Id.NeedsExtAuth, added.Id.Active)
 	})
@@ -200,8 +200,8 @@ func (c *extAuthContext) testEnrollToNoneMultipleSignersDefaultPolicyCompletes(t
 		c.idp.DriveIdPFlow(t, authURL)
 
 		added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
-		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after multi-signer IdP login flow, want false", added.Id.NeedsExtAuth)
-		require.True(t, added.Id.Active, "identity:added Active=%t after multi-signer IdP login flow, want true", added.Id.Active)
+		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after multi-signer IdP login flow", added.Id.NeedsExtAuth)
+		require.True(t, added.Id.Active, "identity:added Active=%t after multi-signer IdP login flow", added.Id.Active)
 		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeNone)
 		t.Logf("identity:added reports NeedsExtAuth=%t Active=%t after multi-signer IdP login flow", added.Id.NeedsExtAuth, added.Id.Active)
 	})
@@ -230,8 +230,8 @@ func (c *extAuthContext) testEnrollToNoneMultipleSignersNamedPolicyCompletes(t *
 		c.idp.DriveIdPFlow(t, authURL)
 
 		added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
-		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after multi-signer IdP login flow, want false", added.Id.NeedsExtAuth)
-		require.True(t, added.Id.Active, "identity:added Active=%t after multi-signer IdP login flow, want true", added.Id.Active)
+		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after multi-signer IdP login flow", added.Id.NeedsExtAuth)
+		require.True(t, added.Id.Active, "identity:added Active=%t after multi-signer IdP login flow", added.Id.Active)
 		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeNone)
 		t.Logf("identity:added reports NeedsExtAuth=%t Active=%t after multi-signer IdP login flow", added.Id.NeedsExtAuth, added.Id.Active)
 	})
@@ -249,7 +249,7 @@ func (c *extAuthContext) addEnrollToNoneIdentity(t *testing.T, name string) test
 
 	identityEvent := c.zet.Events.WaitForIdentityEvent(t, "needs_ext_login", name)
 	require.NotEmpty(t, identityEvent.Id.Identifier, "identity:needs_ext_login Identifier empty")
-	require.True(t, identityEvent.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t, want true", identityEvent.Id.NeedsExtAuth)
+	require.True(t, identityEvent.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t", identityEvent.Id.NeedsExtAuth)
 	testutil.AssertValidUrlEnrolledIdentityFile(t, identityEvent.Id.Identifier, testutil.EnrollModeNone)
 	t.Logf("identity:needs_ext_login Identifier=%s NeedsExtAuth=%t", identityEvent.Id.Identifier, identityEvent.Id.NeedsExtAuth)
 
@@ -259,7 +259,7 @@ func (c *extAuthContext) addEnrollToNoneIdentity(t *testing.T, name string) test
 func (c *extAuthContext) testEnrollToCertCompletes(t *testing.T) {
 	testutil.RunTestWithTimeout(t, func(t *testing.T) {
 		name := testutil.IdentityName(t)
-		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+		t.Cleanup(c.deleteIdentityByExternalId)
 
 		c.completeEnrollToCert(t, name)
 	})
@@ -275,19 +275,30 @@ func (c *extAuthContext) createIdentityData(name string, mode testutil.EnrollMod
 	}
 }
 
+func (c *extAuthContext) deleteIdentityByExternalId() {
+	_ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID)
+}
+
+// beginEnrollment sends AddIdentity and returns the enrollment URL the IdP flow
+// continues at, asserting the response succeeded and carried a URL.
+func (c *extAuthContext) beginEnrollment(t *testing.T, identityData testutil.AddIdentityData) string {
+	addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
+	require.True(t, addResp.Success(), "AddIdentity should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
+	require.NotEmpty(t, addResp.Data.URL, "AddIdentity response has empty URL")
+	return addResp.Data.URL
+}
+
 // completeEnrollToCert drives a full enroll-to-cert flow for name and returns the
 // resulting identifier. The working signer must already have EnrollToCert enabled.
 func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string {
 	identityData := c.createIdentityData(name, testutil.EnrollModeCert)
-	addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
-	require.True(t, addResp.Success(), "AddIdentity (enroll to cert) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
-	require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to cert) response has empty URL")
+	authURL := c.beginEnrollment(t, identityData)
 
-	c.idp.DriveIdPFlow(t, addResp.Data.URL)
+	c.idp.DriveIdPFlow(t, authURL)
 
 	added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
-	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to cert IdP login flow, want true", added.Id.Active)
-	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to cert IdP login flow, want false", added.Id.NeedsExtAuth)
+	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to cert IdP login flow", added.Id.Active)
+	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to cert IdP login flow", added.Id.NeedsExtAuth)
 	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeCert)
 	t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to cert IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
 	return added.Id.Identifier
@@ -296,7 +307,7 @@ func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string 
 func (c *extAuthContext) testEnrollToTokenCompletes(t *testing.T) {
 	testutil.RunTestWithTimeout(t, func(t *testing.T) {
 		name := testutil.IdentityName(t)
-		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+		t.Cleanup(c.deleteIdentityByExternalId)
 
 		c.completeEnrollToToken(t, name)
 	})
@@ -306,21 +317,19 @@ func (c *extAuthContext) testEnrollToTokenCompletes(t *testing.T) {
 // resulting identifier. The working signer must already have EnrollToToken enabled.
 func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) string {
 	identityData := c.createIdentityData(name, testutil.EnrollModeToken)
-	addResp := testutil.AddIdentity(t, c.zet.Commands, identityData)
-	require.True(t, addResp.Success(), "AddIdentity (enroll to token) should succeed: error=%q\n%s", addResp.Error, c.zet.LogPath())
-	require.NotEmpty(t, addResp.Data.URL, "AddIdentity (enroll to token) response has empty URL")
+	authURL := c.beginEnrollment(t, identityData)
 
-	c.idp.DriveIdPFlow(t, addResp.Data.URL)
+	c.idp.DriveIdPFlow(t, authURL)
 
 	identityEvent := c.zet.Events.WaitForIdentityEvent(t, "needs_ext_login", name)
-	require.True(t, identityEvent.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t after enroll to token IdP login flow, want true", identityEvent.Id.NeedsExtAuth)
-	authURL := c.zet.Commands.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name, c.zet.LogPath())
+	require.True(t, identityEvent.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t after enroll to token IdP login flow", identityEvent.Id.NeedsExtAuth)
+	authURL = c.zet.Commands.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name, c.zet.LogPath())
 
 	c.idp.DriveIdPFlow(t, authURL)
 
 	added := c.zet.Events.WaitForIdentityEvent(t, "added", name)
-	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to token IdP login flow, want true", added.Id.Active)
-	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to token IdP login flow, want false", added.Id.NeedsExtAuth)
+	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to token IdP login flow", added.Id.Active)
+	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to token IdP login flow", added.Id.NeedsExtAuth)
 	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeToken)
 	t.Logf("identity:added Identifier=%s Active=%t NeedsExtAuth=%t after enroll to token IdP login flow", added.Id.Identifier, added.Id.Active, added.Id.NeedsExtAuth)
 	return added.Id.Identifier
@@ -350,7 +359,7 @@ func (c *extAuthContext) testEnrollToNoneThenCertRejected(t *testing.T) {
 func (c *extAuthContext) testEnrollToCertThenNoneRejected(t *testing.T) {
 	testutil.RunTestWithTimeout(t, func(t *testing.T) {
 		name := testutil.IdentityName(t)
-		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+		t.Cleanup(c.deleteIdentityByExternalId)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
 		identifier := c.completeEnrollToCert(t, name)
@@ -372,7 +381,7 @@ func (c *extAuthContext) testEnrollToCertThenNoneRejected(t *testing.T) {
 func (c *extAuthContext) testEnrollToCertThenTokenRejected(t *testing.T) {
 	testutil.RunTestWithTimeout(t, func(t *testing.T) {
 		name := testutil.IdentityName(t)
-		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+		t.Cleanup(c.deleteIdentityByExternalId)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
 		identifier := c.completeEnrollToCert(t, name)
@@ -388,7 +397,7 @@ func (c *extAuthContext) testEnrollToCertThenTokenRejected(t *testing.T) {
 func (c *extAuthContext) testEnrollToTokenThenCertRejected(t *testing.T) {
 	testutil.RunTestWithTimeout(t, func(t *testing.T) {
 		name := testutil.IdentityName(t)
-		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+		t.Cleanup(c.deleteIdentityByExternalId)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
 		identifier := c.completeEnrollToToken(t, name)

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -125,6 +125,7 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 
 	t.Run("testEnrollToNoneThenCertRejected", c.testEnrollToNoneThenCertRejected)
 	t.Run("testEnrollToCertThenNoneRejected", c.testEnrollToCertThenNoneRejected)
+	t.Run("testEnrollToCertThenTokenRejected", c.testEnrollToCertThenTokenRejected)
 }
 
 func (c *extAuthContext) testEnrollToNoneCompletes(t *testing.T) {
@@ -366,6 +367,29 @@ func (c *extAuthContext) testEnrollToCertThenNoneRejected(t *testing.T) {
 			ControllerURL:    &controllerBase,
 		}
 		addResp := testutil.AddIdentity(t, c.zet.Commands, enrollToNoneIdentity)
+		c.assertIdentityExistsSameName(t, addResp)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeCert)
+	})
+}
+
+func (c *extAuthContext) testEnrollToCertThenTokenRejected(t *testing.T) {
+	testutil.RunTestWithTimeout(t, func(t *testing.T) {
+		name := testutil.IdentityName(t)
+		t.Cleanup(func() { _ = c.overlay.PurgeIdentityByExternalId(c.idp.ExternalID) })
+
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
+		identifier := c.completeEnrollToCert(t, name)
+
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
+		controllerBase := c.overlay.ControllerHostPort()
+		mode := testutil.EnrollModeToken
+		enrollToTokenIdentity := testutil.AddIdentityData{
+			IdentityFilename: name,
+			ControllerURL:    &controllerBase,
+			EnrollMode:       &mode,
+			Provider:         &c.workingSigner.name,
+		}
+		addResp := testutil.AddIdentity(t, c.zet.Commands, enrollToTokenIdentity)
 		c.assertIdentityExistsSameName(t, addResp)
 		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeCert)
 	})

--- a/tests/integration/identity_on_off_test.go
+++ b/tests/integration/identity_on_off_test.go
@@ -57,7 +57,7 @@ func testIdentityOnOffTogglesActiveOff(t *testing.T) {
 		require.True(t, offResp.Success(), "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
 
 		off := events.WaitForIdentityEvent(t, "added", name)
-		require.False(t, off.Id.Active, "identity:added Active=%t after IdentityOnOff(false), want false", off.Id.Active)
+		require.False(t, off.Id.Active, "identity:added Active=%t after IdentityOnOff(false)", off.Id.Active)
 		t.Logf("identity:added reports Active=%t after IdentityOnOff(false)", off.Id.Active)
 	})
 }
@@ -91,7 +91,7 @@ func testIdentityOnOffTogglesActiveOn(t *testing.T) {
 		require.True(t, offResp.Success(), "IdentityOnOff(false) failed: error=%q code=%d", offResp.Error, offResp.Code)
 
 		off := events.WaitForIdentityEvent(t, "added", name)
-		require.False(t, off.Id.Active, "identity:added Active=%t after IdentityOnOff(false), want false", off.Id.Active)
+		require.False(t, off.Id.Active, "identity:added Active=%t after IdentityOnOff(false)", off.Id.Active)
 
 		t.Logf("sending IdentityOnOff(true) for %q", name)
 		onResp, err := client.IdentityOnOff(added.Id.Identifier, true)
@@ -99,7 +99,7 @@ func testIdentityOnOffTogglesActiveOn(t *testing.T) {
 		require.True(t, onResp.Success(), "IdentityOnOff(true) failed: error=%q code=%d", onResp.Error, onResp.Code)
 
 		on := events.WaitForIdentityEvent(t, "added", name)
-		require.True(t, on.Id.Active, "identity:added Active=%t after IdentityOnOff(true), want true", on.Id.Active)
+		require.True(t, on.Id.Active, "identity:added Active=%t after IdentityOnOff(true)", on.Id.Active)
 		t.Logf("identity:added reports Active=%t after IdentityOnOff(true)", on.Id.Active)
 	})
 }

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -113,7 +113,7 @@ func testVerifyMFAAcceptsValidTotp(t *testing.T) {
 		require.True(t, verifyResp.Success(), "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, state.zetClient.LogPath())
 
 		verifyEvt := events.WaitForMfaEvent(t, "enrollment_verification", name)
-		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA, want true", verifyEvt.Successful)
+		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA", verifyEvt.Successful)
 		t.Logf("mfa:enrollment_verification reports Successful=%t after VerifyMFA", verifyEvt.Successful)
 	})
 }
@@ -146,7 +146,7 @@ func testMFAReauthenticationAcceptsValidTotp(t *testing.T) {
 		require.NoError(t, err, "failed to send VerifyMFA\n%s", state.zetClient.LogPath())
 		require.True(t, verifyResp.Success(), "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, state.zetClient.LogPath())
 		verifyEvt := events.WaitForMfaEvent(t, "enrollment_verification", name)
-		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA, want true", verifyEvt.Successful)
+		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA", verifyEvt.Successful)
 
 		t.Logf("sending IdentityOnOff(false) for %q to drop the session", name)
 		offResp, err := enrolled.Client.IdentityOnOff(enrolled.Identifier, false)
@@ -169,7 +169,7 @@ func testMFAReauthenticationAcceptsValidTotp(t *testing.T) {
 		require.True(t, submitResp.Success(), "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, state.zetClient.LogPath())
 
 		submitEvt := events.WaitForMfaEvent(t, "mfa_auth_status", name)
-		require.True(t, submitEvt.Successful, "mfa:mfa_auth_status Successful=%t after SubmitMFA, want true", submitEvt.Successful)
+		require.True(t, submitEvt.Successful, "mfa:mfa_auth_status Successful=%t after SubmitMFA", submitEvt.Successful)
 		t.Logf("mfa:mfa_auth_status reports Successful=%t after SubmitMFA", submitEvt.Successful)
 	})
 }
@@ -187,7 +187,7 @@ func testMFAReauthenticationAcceptsRecoveryCode(t *testing.T) {
 		require.NoError(t, err, "failed to send VerifyMFA\n%s", state.zetClient.LogPath())
 		require.True(t, verifyResp.Success(), "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, state.zetClient.LogPath())
 		verifyEvt := events.WaitForMfaEvent(t, "enrollment_verification", name)
-		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA, want true", verifyEvt.Successful)
+		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA", verifyEvt.Successful)
 
 		t.Logf("sending IdentityOnOff(false) for %q to drop the session", name)
 		offResp, err := enrolled.Client.IdentityOnOff(enrolled.Identifier, false)
@@ -207,7 +207,7 @@ func testMFAReauthenticationAcceptsRecoveryCode(t *testing.T) {
 		require.True(t, submitResp.Success(), "SubmitMFA failed: error=%q code=%d\n%s", submitResp.Error, submitResp.Code, state.zetClient.LogPath())
 
 		submitEvt := events.WaitForMfaEvent(t, "mfa_auth_status", name)
-		require.True(t, submitEvt.Successful, "mfa:mfa_auth_status Successful=%t after SubmitMFA, want true", submitEvt.Successful)
+		require.True(t, submitEvt.Successful, "mfa:mfa_auth_status Successful=%t after SubmitMFA", submitEvt.Successful)
 		t.Logf("mfa:mfa_auth_status reports Successful=%t after SubmitMFA with recovery code", submitEvt.Successful)
 	})
 }
@@ -225,7 +225,7 @@ func testMFAReauthenticationRejectsInvalidTotp(t *testing.T) {
 		require.NoError(t, err, "failed to send VerifyMFA\n%s", state.zetClient.LogPath())
 		require.True(t, verifyResp.Success(), "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, state.zetClient.LogPath())
 		verifyEvt := events.WaitForMfaEvent(t, "enrollment_verification", name)
-		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA, want true", verifyEvt.Successful)
+		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA", verifyEvt.Successful)
 
 		t.Logf("sending IdentityOnOff(false) for %q to drop the session", name)
 		offResp, err := enrolled.Client.IdentityOnOff(enrolled.Identifier, false)
@@ -262,7 +262,7 @@ func testRemoveMFAAcceptsValidTotp(t *testing.T) {
 		require.NoError(t, err, "failed to send VerifyMFA\n%s", state.zetClient.LogPath())
 		require.True(t, verifyResp.Success(), "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, state.zetClient.LogPath())
 		verifyEvt := events.WaitForMfaEvent(t, "enrollment_verification", name)
-		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA, want true", verifyEvt.Successful)
+		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA", verifyEvt.Successful)
 
 		code, err = generateTotpCode(enrolled.Secret, time.Now())
 		require.NoError(t, err, "failed to compute TOTP")
@@ -273,7 +273,7 @@ func testRemoveMFAAcceptsValidTotp(t *testing.T) {
 		require.True(t, removeResp.Success(), "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, state.zetClient.LogPath())
 
 		removeEvt := events.WaitForMfaEvent(t, "enrollment_remove", name)
-		require.True(t, removeEvt.Successful, "mfa:enrollment_remove Successful=%t after RemoveMFA, want true", removeEvt.Successful)
+		require.True(t, removeEvt.Successful, "mfa:enrollment_remove Successful=%t after RemoveMFA", removeEvt.Successful)
 		t.Logf("mfa:enrollment_remove reports Successful=%t after RemoveMFA with TOTP", removeEvt.Successful)
 	})
 }
@@ -291,7 +291,7 @@ func testRemoveMFAAcceptsRecoveryCode(t *testing.T) {
 		require.NoError(t, err, "failed to send VerifyMFA\n%s", state.zetClient.LogPath())
 		require.True(t, verifyResp.Success(), "VerifyMFA failed: error=%q code=%d\n%s", verifyResp.Error, verifyResp.Code, state.zetClient.LogPath())
 		verifyEvt := events.WaitForMfaEvent(t, "enrollment_verification", name)
-		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA, want true", verifyEvt.Successful)
+		require.True(t, verifyEvt.Successful, "mfa:enrollment_verification Successful=%t after VerifyMFA", verifyEvt.Successful)
 
 		t.Logf("sending RemoveMFA with recovery code for %q", name)
 		removeResp, err := enrolled.Client.RemoveMFA(enrolled.Identifier, enrolled.RecoveryCodes[0])
@@ -299,7 +299,7 @@ func testRemoveMFAAcceptsRecoveryCode(t *testing.T) {
 		require.True(t, removeResp.Success(), "RemoveMFA failed: error=%q code=%d\n%s", removeResp.Error, removeResp.Code, state.zetClient.LogPath())
 
 		removeEvt := events.WaitForMfaEvent(t, "enrollment_remove", name)
-		require.True(t, removeEvt.Successful, "mfa:enrollment_remove Successful=%t after RemoveMFA, want true", removeEvt.Successful)
+		require.True(t, removeEvt.Successful, "mfa:enrollment_remove Successful=%t after RemoveMFA", removeEvt.Successful)
 		t.Logf("mfa:enrollment_remove reports Successful=%t after RemoveMFA with recovery code", removeEvt.Successful)
 	})
 }

--- a/tests/integration/url_enrollment_test.go
+++ b/tests/integration/url_enrollment_test.go
@@ -51,7 +51,7 @@ func testUrlEnrollmentWithValidControllerUrlSucceeds(t *testing.T) {
 
 		event := events.WaitForIdentityEvent(t, "needs_ext_login", identityName)
 		require.NotEmpty(t, event.Id.Identifier, "identity:needs_ext_login Identifier empty")
-		require.True(t, event.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t, want true", event.Id.NeedsExtAuth)
+		require.True(t, event.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t", event.Id.NeedsExtAuth)
 
 		testutil.AssertValidUrlEnrolledIdentityFile(t, event.Id.Identifier, testutil.EnrollModeNone)
 		t.Logf("URL-enrolled identity:needs_ext_login Identifier=%s NeedsExtAuth=%t", event.Id.Identifier, event.Id.NeedsExtAuth)


### PR DESCRIPTION
## Summary
- Add four tests proving a same-name identity can't be re-enrolled under a different mode: none to cert, cert to none, cert to token, token to cert
- Extract the full enroll-to-cert and enroll-to-token flows into reusable `completeEnrollToCert` / `completeEnrollToToken` helpers so the new cross-mode tests share one path with the existing completion tests
- Move the completion-flow helpers to the bottom of the file so the suite reads top-down; no behavior change

## External auth tests
- Each follows the same shape: `UpdateExtJwtSigner` to mode A, full enroll under A, `UpdateExtJwtSigner` to mode B, `AddIdentity` with the same name under mode B, then assert rejection and that the original identity file is still valid for mode A

## Helpers
- `completeEnrollToCert` / `completeEnrollToToken` drive a full flow for a name and return the resulting identifier (working signer must already have that mode enabled)
- `createIdentityData` builds the `AddIdentityData` for a given name and `EnrollMode` against the working signer
- `assertIdentityExistsSameName` asserts the rejection: `Success() == false`, `Code` 500, error contains "identity exists with the same name"