### PR TITLE
nix: fix Darwin build by guarding systemd-only paths behind stdenv.isLinux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,22 +250,10 @@ jobs:
 
   nix-build:
     name: Build Nix Binary
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Build Ziti Edge Tunnel
-        run: |
-          nix build
-          ./result/bin/ziti-edge-tunnel version
-
-  nix-build-darwin:
-    name: Build Darwin Nix Binary on MacOS arm64
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/cmake.yml
 
   docker-deployments:
-    needs: [ call-cmake-build ]
+    needs: [call-cmake-build]
     name: Exercise CMake Artifacts
     runs-on: ubuntu-latest
     steps:
@@ -116,7 +116,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests (${{ matrix.os.name }} / ziti ${{ matrix.ziti-channel.label }})
-    needs: [ call-cmake-build, resolve-ziti-versions ]
+    needs: [call-cmake-build, resolve-ziti-versions]
     strategy:
       fail-fast: false
       matrix:
@@ -251,6 +251,21 @@ jobs:
   nix-build:
     name: Build Nix Binary
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build Ziti Edge Tunnel
+        run: |
+          nix build
+          ./result/bin/ziti-edge-tunnel version
+
+  nix-build-darwin:
+    name: Build Darwin Nix Binary on MacOS arm64
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/cmake.yml
 
   docker-deployments:
-    needs: [call-cmake-build]
+    needs: [ call-cmake-build ]
     name: Exercise CMake Artifacts
     runs-on: ubuntu-latest
     steps:
@@ -116,7 +116,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests (${{ matrix.os.name }} / ziti ${{ matrix.ziti-channel.label }})
-    needs: [call-cmake-build, resolve-ziti-versions]
+    needs: [ call-cmake-build, resolve-ziti-versions ]
     strategy:
       fail-fast: false
       matrix:

--- a/flake.nix
+++ b/flake.nix
@@ -20,9 +20,7 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          default = pkgs.callPackage ./nix/packages/ziti-edge-tunnel.nix (
-            pkgs.lib.optionalAttrs pkgs.stdenv.isLinux { inherit (pkgs) systemd; }
-          );
+          default = pkgs.callPackage ./nix/packages/ziti-edge-tunnel.nix { };
           ziti-edge-tunnel = self.packages.${system}.default;
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,9 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          default = pkgs.callPackage ./nix/packages/ziti-edge-tunnel.nix { };
+          default = pkgs.callPackage ./nix/packages/ziti-edge-tunnel.nix (
+            pkgs.lib.optionalAttrs pkgs.stdenv.isLinux { inherit (pkgs) systemd; }
+          );
           ziti-edge-tunnel = self.packages.${system}.default;
         }
       );

--- a/nix/packages/ziti-edge-tunnel.nix
+++ b/nix/packages/ziti-edge-tunnel.nix
@@ -12,7 +12,7 @@
   pkg-config,
   protobufc,
   stdenv,
-  systemd ? null,
+  systemd,
   versionCheckHook,
   zlib,
 }:

--- a/nix/packages/ziti-edge-tunnel.nix
+++ b/nix/packages/ziti-edge-tunnel.nix
@@ -12,7 +12,7 @@
   pkg-config,
   protobufc,
   stdenv,
-  systemd,
+  systemd ? null,
   versionCheckHook,
   zlib,
 }:
@@ -63,8 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ZSTurUxd5tsnK/cCEynKLjSoaJUCOJQNLZ9RE5Mf3oU=";
   };
 
-  postPatch = ''
-    # Patch hardcoded paths to systemd tools
+  postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace programs/ziti-edge-tunnel/netif_driver/linux/resolvers.h \
       --replace '"/usr/bin/busctl"' '"${systemd}/bin/busctl"' \
       --replace '"/usr/bin/resolvectl"' '"${systemd}/bin/resolvectl"' \
@@ -116,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
     let
       systemdDir = "../programs/ziti-edge-tunnel/package/systemd";
     in
-    ''
+    lib.optionalString stdenv.isLinux ''
       # Install templated systemd unit files for non-NixOS Linux distros
       install -Dm644 -t $out/lib/systemd/system \
         ${systemdDir}/ziti-edge-tunnel.service.in
@@ -140,6 +139,30 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace $out/share/ziti-edge-tunnel/ziti-edge-tunnel.sh \
         --replace-fail '@ZITI_IDENTITY_DIR@' '/opt/openziti/etc/identities' \
         --replace-fail '@CPACK_BIN_DIR@/@SYSTEMD_SERVICE_NAME@' "$out/bin/ziti-edge-tunnel"
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/Library/LaunchDaemons
+      cat > $out/Library/LaunchDaemons/io.openziti.ziti-edge-tunnel.plist <<EOF
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>io.openziti.ziti-edge-tunnel</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>$out/bin/ziti-edge-tunnel</string>
+          <string>run</string>
+          <string>--identity-dir</string>
+          <string>/opt/openziti/etc/identities</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+      </dict>
+      </plist>
+      EOF
     '';
 
   doInstallCheck = true;

--- a/nix/packages/ziti-edge-tunnel.nix
+++ b/nix/packages/ziti-edge-tunnel.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = lib.optionalString stdenv.isLinux ''
+    # Patch hardcoded paths to systemd tools
     substituteInPlace programs/ziti-edge-tunnel/netif_driver/linux/resolvers.h \
       --replace '"/usr/bin/busctl"' '"${systemd}/bin/busctl"' \
       --replace '"/usr/bin/resolvectl"' '"${systemd}/bin/resolvectl"' \


### PR DESCRIPTION
Guard postPatch and postInstall systemd steps behind lib.optionalString stdenv.isLinux;

I used AI to assist in the LaunchDaemon plist for Darwin under lib.optionalString stdenv.isDarwin.

Added nix build Github action runner for macos on arm64