### PR TITLE
Add nightly integration tests against ziti main

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,45 +85,22 @@ jobs:
           if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
           echo "ZET_BIN=$base/zet-artifact/$ZET_BIN_NAME" >> "$GITHUB_ENV"
 
-      # CI resolves ziti and passes ZITI_BIN; the test scripts run against any ziti.
+      # CI resolves ziti via openziti's setup-cli action; downstream tests run against any ziti.
+      # TEMP: pinned to the CLBRITTON2 fork to validate the action pre-merge; point at openziti/ziti before merge.
       - name: Resolve ziti
-        shell: bash
+        uses: CLBRITTON2/ziti/setup-cli@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZITI_VERSION: ${{ inputs.ziti-version }}
+        with:
+          version: ${{ (inputs.ziti-version == '' || inputs.ziti-version == 'main') && 'stable' || inputs.ziti-version }}
+          ref: ${{ inputs.ziti-version == 'main' && 'main' || '' }}
+
+      # setup-cli puts ziti on PATH; the test scripts consume ZITI_BIN.
+      - name: Export ZITI_BIN from setup-cli
+        shell: bash
         run: |
-          set -euo pipefail
           ext=""; [ "$RUNNER_OS" = "Windows" ] && ext=".exe"
-          if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
-          if [ "$ZITI_VERSION" = "main" ]; then
-            # nightly tests run against ziti main
-            out="$base/ziti-main$ext"
-            git clone --depth 1 https://github.com/openziti/ziti.git ziti-src
-            ( cd ziti-src
-              # ziti main needs a newer go than the test module; let go fetch its toolchain
-              export GOTOOLCHAIN=auto
-              stamp="v$(tr -d '[:space:]' < version).0-main"
-              go build -ldflags "-X $(go list -m)/common/version.Version=$stamp" -o "$out" ./ziti )
-          else
-            case "$RUNNER_OS" in
-              Linux)   pattern="ziti-linux-amd64-*.tar.gz" ;;
-              macOS)   pattern="ziti-darwin-arm64-*.tar.gz" ;;
-              Windows) pattern="ziti-windows-amd64-*.zip" ;;
-            esac
-            ver="$ZITI_VERSION"
-            if [ -z "$ver" ]; then
-              ver=$(gh release list --repo openziti/ziti --limit 50 --json tagName,isDraft,isPrerelease \
-                | jq -r '.[] | select(.isDraft==false and .isPrerelease==false) | .tagName' | sort -V | tail -n1)
-            fi
-            mkdir -p ziti-dl
-            ( cd ziti-dl
-              gh release download --repo openziti/ziti "$ver" --pattern "$pattern" --clobber
-              if [ "$RUNNER_OS" = "Windows" ]; then unzip -o ./*.zip; else tar -xzf ./*.tar.gz; fi )
-            rel=$(cd ziti-dl && find . -type f -name "ziti$ext" | head -n1)
-            out="$base/ziti-dl/${rel#./}"
-            chmod +x "$out" || true
-          fi
-          echo "ZITI_BIN=$out" >> "$GITHUB_ENV"
+          echo "ZITI_BIN=${{ runner.temp }}/ziti-cli/bin/ziti$ext" >> "$GITHUB_ENV"
 
       - name: Run integration tests (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,166 @@
+# callable workflow's jobs appear in the calling workflow's run, so clicking this workflow in GitHub shows no runs
+name: Callable Integration Tests
+
+on:
+  workflow_call:
+    inputs:
+      ziti-version:
+        description: "ziti release tag to download (ignored when build-ziti-from-main is true)"
+        type: string
+        default: ""
+      build-ziti-from-main:
+        description: "build openziti/ziti @ main from source instead of downloading a release"
+        type: boolean
+        default: false
+      label:
+        description: "label for the run name and artifact/log names (e.g. latest, lts, main)"
+        type: string
+        required: true
+      idp-version:
+        description: "dex IdP version tag; empty = script default"
+        type: string
+        default: ""
+      zet1-version:
+        description: "ziti-edge-tunnel release tag for zetA; empty = the binary built by cmake"
+        type: string
+        default: ""
+      zet2-version:
+        description: "ziti-edge-tunnel release tag for zetB; empty = same binary as zetA"
+        type: string
+        default: ""
+
+jobs:
+  integration-tests:
+    name: ziti ${{ inputs.label }} (${{ matrix.os.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: Linux x64
+            runner: ubuntu-latest
+            artifact: linux-x64
+            zet-zip: ziti-edge-tunnel-Linux_x86_64.zip
+            zet-bin: ziti-edge-tunnel
+            core-dir: /tmp/cores
+          - name: macOS arm64
+            runner: macos-15
+            artifact: macOS-arm64
+            zet-zip: ziti-edge-tunnel-Darwin_arm64.zip
+            zet-bin: ziti-edge-tunnel
+            core-dir: /cores
+          - name: Windows x64
+            runner: windows-2022
+            artifact: windows-x64-mingw
+            zet-zip: ziti-edge-tunnel-Windows_x86_64.zip
+            zet-bin: ziti-edge-tunnel.exe
+            core-dir: ""
+    runs-on: ${{ matrix.os.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tests/integration/go.mod
+          cache-dependency-path: tests/integration/go.sum
+
+      # Built by the caller's cmake job; artifacts are shared within the run.
+      - name: Download CMake Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.os.artifact }}
+          path: ./zet-artifact
+          digest-mismatch: error
+
+      - name: Extract built ZET binary from artifact
+        shell: bash
+        env:
+          ZET_ZIP: ${{ matrix.os.zet-zip }}
+          ZET_BIN_NAME: ${{ matrix.os.zet-bin }}
+        run: |
+          set -euo pipefail
+          unzip -o "zet-artifact/$ZET_ZIP" -d zet-artifact
+          chmod +x "zet-artifact/$ZET_BIN_NAME" || true
+          # On Windows the consumer is PowerShell, which can't resolve an MSYS
+          # /d/a/... path; pwd -W emits a Windows path it accepts.
+          if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
+          echo "ZET_BIN=$base/zet-artifact/$ZET_BIN_NAME" >> "$GITHUB_ENV"
+
+      - name: Run integration tests (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_HOME: ${{ runner.temp }}
+          ZITI_VERSION: ${{ inputs.ziti-version }}
+          ZITI_FROM_MAIN: ${{ inputs.build-ziti-from-main && '1' || '' }}
+          IDP_VERSION: ${{ inputs.idp-version }}
+          ZET1_VERSION: ${{ inputs.zet1-version }}
+          ZET2_VERSION: ${{ inputs.zet2-version }}
+        run: ./tests/integration/scripts/run-ci.sh --install-cert
+
+      - name: Run integration tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_HOME: ${{ runner.temp }}
+          ZITI_VERSION: ${{ inputs.ziti-version }}
+          ZITI_FROM_MAIN: ${{ inputs.build-ziti-from-main && '1' || '' }}
+          IDP_VERSION: ${{ inputs.idp-version }}
+          ZET1_VERSION: ${{ inputs.zet1-version }}
+          ZET2_VERSION: ${{ inputs.zet2-version }}
+        run: .\tests\integration\scripts\run-ci.ps1 -InstallCert
+
+      - name: Log core file backtraces
+        if: ${{ failure() && matrix.os.core-dir != '' }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          cores=("${{ matrix.os.core-dir }}"/core.*)
+          if [ ${#cores[@]} -eq 0 ]; then
+            echo "No core files found in ${{ matrix.os.core-dir }}"
+            exit 0
+          fi
+          # Core files are owned by root (ZET runs as root); use sudo to read them.
+          if [ "$(uname -s)" = "Linux" ]; then
+            sudo apt-get install -y --no-install-recommends gdb >/dev/null
+            for core in "${cores[@]}"; do
+              echo "::group::Backtrace: $core"
+              sudo gdb -batch \
+                -ex "set pagination off" \
+                -ex "thread apply all bt full" \
+                "$ZET_BIN" "$core" 2>&1 || true
+              echo "::endgroup::"
+            done
+          elif [ "$(uname -s)" = "Darwin" ]; then
+            for core in "${cores[@]}"; do
+              echo "::group::Backtrace: $core"
+              sudo lldb -c "$core" "$ZET_BIN" -b \
+                -o "thread backtrace all" \
+                -o "quit" 2>&1 || true
+              echo "::endgroup::"
+            done
+          fi
+
+      - name: Upload core files
+        if: ${{ failure() && matrix.os.core-dir != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: cores-${{ matrix.os.name }}-ziti-${{ inputs.label }}
+          path: ${{ matrix.os.core-dir }}/core.*
+          if-no-files-found: ignore
+
+      - name: Upload integration test logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-logs-${{ matrix.os.name }}-ziti-${{ inputs.label }}
+          path: |
+            ${{ runner.temp }}/zets/logs/*.log
+            ${{ runner.temp }}/overlay/quickstart-logs/*.log
+            ${{ runner.temp }}/idp/logs/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   integration-tests:
-    name: ziti ${{ inputs.label }} (${{ matrix.os.name }})
+    name: ${{ matrix.os.name }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -86,21 +86,13 @@ jobs:
           echo "ZET_BIN=$base/zet-artifact/$ZET_BIN_NAME" >> "$GITHUB_ENV"
 
       # CI resolves ziti via openziti's setup-cli action; downstream tests run against any ziti.
-      # TEMP: pinned to the CLBRITTON2 fork to validate the action pre-merge; point at openziti/ziti before merge.
       - name: Resolve ziti
-        uses: CLBRITTON2/ziti/setup-cli@main
+        uses: openziti/ziti/setup-cli@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           version: ${{ (inputs.ziti-version == '' || inputs.ziti-version == 'main') && 'stable' || inputs.ziti-version }}
           ref: ${{ inputs.ziti-version == 'main' && 'main' || '' }}
-
-      # setup-cli puts ziti on PATH; the test scripts consume ZITI_BIN.
-      - name: Export ZITI_BIN from setup-cli
-        shell: bash
-        run: |
-          ext=""; [ "$RUNNER_OS" = "Windows" ] && ext=".exe"
-          echo "ZITI_BIN=${{ runner.temp }}/ziti-cli/bin/ziti$ext" >> "$GITHUB_ENV"
 
       - name: Run integration tests (Linux/macOS)
         if: runner.os != 'Windows'
@@ -108,6 +100,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEST_HOME: ${{ runner.temp }}
+          ZITI_BIN: ${{ runner.temp }}/ziti-cli/bin/ziti
           IDP_VERSION: ${{ inputs.idp-version }}
           ZET1_VERSION: ${{ inputs.zet1-version }}
           ZET2_VERSION: ${{ inputs.zet2-version }}
@@ -119,6 +112,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEST_HOME: ${{ runner.temp }}
+          ZITI_BIN: ${{ runner.temp }}/ziti-cli/bin/ziti.exe
           IDP_VERSION: ${{ inputs.idp-version }}
           ZET1_VERSION: ${{ inputs.zet1-version }}
           ZET2_VERSION: ${{ inputs.zet2-version }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,13 +5,9 @@ on:
   workflow_call:
     inputs:
       ziti-version:
-        description: "ziti release tag to download (ignored when build-ziti-from-main is true)"
+        description: "ziti release tag to download, or 'main' to build openziti/ziti @ main from source"
         type: string
         default: ""
-      build-ziti-from-main:
-        description: "build openziti/ziti @ main from source instead of downloading a release"
-        type: boolean
-        default: false
       label:
         description: "label for the run name and artifact/log names (e.g. latest, lts, main)"
         type: string
@@ -89,14 +85,52 @@ jobs:
           if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
           echo "ZET_BIN=$base/zet-artifact/$ZET_BIN_NAME" >> "$GITHUB_ENV"
 
+      # CI resolves ziti and passes ZITI_BIN; the test scripts run against any ziti.
+      - name: Resolve ziti
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZITI_VERSION: ${{ inputs.ziti-version }}
+        run: |
+          set -euo pipefail
+          ext=""; [ "$RUNNER_OS" = "Windows" ] && ext=".exe"
+          if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
+          if [ "$ZITI_VERSION" = "main" ]; then
+            # nightly tests run against ziti main
+            out="$base/ziti-main$ext"
+            git clone --depth 1 https://github.com/openziti/ziti.git ziti-src
+            ( cd ziti-src
+              # ziti main needs a newer go than the test module; let go fetch its toolchain
+              export GOTOOLCHAIN=auto
+              stamp="v$(tr -d '[:space:]' < version).0-main"
+              go build -ldflags "-X $(go list -m)/common/version.Version=$stamp" -o "$out" ./ziti )
+          else
+            case "$RUNNER_OS" in
+              Linux)   pattern="ziti-linux-amd64-*.tar.gz" ;;
+              macOS)   pattern="ziti-darwin-arm64-*.tar.gz" ;;
+              Windows) pattern="ziti-windows-amd64-*.zip" ;;
+            esac
+            ver="$ZITI_VERSION"
+            if [ -z "$ver" ]; then
+              ver=$(gh release list --repo openziti/ziti --limit 50 --json tagName,isDraft,isPrerelease \
+                | jq -r '.[] | select(.isDraft==false and .isPrerelease==false) | .tagName' | sort -V | tail -n1)
+            fi
+            mkdir -p ziti-dl
+            ( cd ziti-dl
+              gh release download --repo openziti/ziti "$ver" --pattern "$pattern" --clobber
+              if [ "$RUNNER_OS" = "Windows" ]; then unzip -o ./*.zip; else tar -xzf ./*.tar.gz; fi )
+            rel=$(cd ziti-dl && find . -type f -name "ziti$ext" | head -n1)
+            out="$base/ziti-dl/${rel#./}"
+            chmod +x "$out" || true
+          fi
+          echo "ZITI_BIN=$out" >> "$GITHUB_ENV"
+
       - name: Run integration tests (Linux/macOS)
         if: runner.os != 'Windows'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEST_HOME: ${{ runner.temp }}
-          ZITI_VERSION: ${{ inputs.ziti-version }}
-          ZITI_FROM_MAIN: ${{ inputs.build-ziti-from-main && '1' || '' }}
           IDP_VERSION: ${{ inputs.idp-version }}
           ZET1_VERSION: ${{ inputs.zet1-version }}
           ZET2_VERSION: ${{ inputs.zet2-version }}
@@ -108,8 +142,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEST_HOME: ${{ runner.temp }}
-          ZITI_VERSION: ${{ inputs.ziti-version }}
-          ZITI_FROM_MAIN: ${{ inputs.build-ziti-from-main && '1' || '' }}
           IDP_VERSION: ${{ inputs.idp-version }}
           ZET1_VERSION: ${{ inputs.zet1-version }}
           ZET2_VERSION: ${{ inputs.zet2-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,138 +115,20 @@ jobs:
           echo "channels=$channels" >> "$GITHUB_OUTPUT"
 
   integration-tests:
-    name: Integration Tests (${{ matrix.os.name }} / ziti ${{ matrix.ziti-channel.label }})
+    name: Integration Tests
     needs: [ call-cmake-build, resolve-ziti-versions ]
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - name: Linux x64
-            runner: ubuntu-latest
-            artifact: linux-x64
-            zet-zip: ziti-edge-tunnel-Linux_x86_64.zip
-            zet-bin: ziti-edge-tunnel
-            core-dir: /tmp/cores
-          - name: macOS arm64
-            runner: macos-15
-            artifact: macOS-arm64
-            zet-zip: ziti-edge-tunnel-Darwin_arm64.zip
-            zet-bin: ziti-edge-tunnel
-            core-dir: /cores
-          - name: Windows x64
-            runner: windows-2022
-            artifact: windows-x64-mingw
-            zet-zip: ziti-edge-tunnel-Windows_x86_64.zip
-            zet-bin: ziti-edge-tunnel.exe
-            core-dir: ""
         ziti-channel: ${{ fromJSON(needs.resolve-ziti-versions.outputs.channels) }}
-    runs-on: ${{ matrix.os.runner }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: tests/integration/go.mod
-          cache-dependency-path: tests/integration/go.sum
-
-      - name: Download CMake Artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ matrix.os.artifact }}
-          path: ./zet-artifact
-          digest-mismatch: error
-
-      - name: Extract built ZET binary from artifact
-        shell: bash
-        env:
-          ZET_ZIP: ${{ matrix.os.zet-zip }}
-          ZET_BIN_NAME: ${{ matrix.os.zet-bin }}
-        run: |
-          set -euo pipefail
-          unzip -o "zet-artifact/$ZET_ZIP" -d zet-artifact
-          chmod +x "zet-artifact/$ZET_BIN_NAME" || true
-          # On Windows the consumer is PowerShell, which can't resolve an MSYS
-          # /d/a/... path; pwd -W emits a Windows path it accepts.
-          if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
-          echo "ZET_BIN=$base/zet-artifact/$ZET_BIN_NAME" >> "$GITHUB_ENV"
-
-      - name: Run integration tests (Linux/macOS)
-        if: runner.os != 'Windows'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TEST_HOME: ${{ runner.temp }}
-          ZITI_VERSION: ${{ matrix.ziti-channel.tag }}
-          IDP_VERSION: ${{ inputs.idp_version }}
-          ZET1_VERSION: ${{ inputs.zet1_version }}
-          ZET2_VERSION: ${{ inputs.zet2_version }}
-        run: ./tests/integration/scripts/run-ci.sh --install-cert
-
-      - name: Run integration tests (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TEST_HOME: ${{ runner.temp }}
-          ZITI_VERSION: ${{ matrix.ziti-channel.tag }}
-          IDP_VERSION: ${{ inputs.idp_version }}
-          ZET1_VERSION: ${{ inputs.zet1_version }}
-          ZET2_VERSION: ${{ inputs.zet2_version }}
-        run: .\tests\integration\scripts\run-ci.ps1 -InstallCert
-
-      - name: Log core file backtraces
-        if: ${{ failure() && matrix.os.core-dir != '' }}
-        shell: bash
-        run: |
-          shopt -s nullglob
-          cores=("${{ matrix.os.core-dir }}"/core.*)
-          if [ ${#cores[@]} -eq 0 ]; then
-            echo "No core files found in ${{ matrix.os.core-dir }}"
-            exit 0
-          fi
-          # Core files are owned by root (ZET runs as root); use sudo to read them.
-          if [ "$(uname -s)" = "Linux" ]; then
-            sudo apt-get install -y --no-install-recommends gdb >/dev/null
-            for core in "${cores[@]}"; do
-              echo "::group::Backtrace: $core"
-              sudo gdb -batch \
-                -ex "set pagination off" \
-                -ex "thread apply all bt full" \
-                "$ZET_BIN" "$core" 2>&1 || true
-              echo "::endgroup::"
-            done
-          elif [ "$(uname -s)" = "Darwin" ]; then
-            for core in "${cores[@]}"; do
-              echo "::group::Backtrace: $core"
-              sudo lldb -c "$core" "$ZET_BIN" -b \
-                -o "thread backtrace all" \
-                -o "quit" 2>&1 || true
-              echo "::endgroup::"
-            done
-          fi
-
-      - name: Upload core files
-        if: ${{ failure() && matrix.os.core-dir != '' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: cores-${{ matrix.os.name }}-ziti-${{ matrix.ziti-channel.label }}
-          path: ${{ matrix.os.core-dir }}/core.*
-          if-no-files-found: ignore
-
-      - name: Upload integration test logs
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: integration-logs-${{ matrix.os.name }}-ziti-${{ matrix.ziti-channel.label }}
-          path: |
-            ${{ runner.temp }}/zets/logs/*.log
-            ${{ runner.temp }}/overlay/quickstart-logs/*.log
-            ${{ runner.temp }}/idp/logs/*.log
-          if-no-files-found: ignore
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      ziti-version: ${{ matrix.ziti-channel.tag }}
+      label: ${{ matrix.ziti-channel.label }}
+      idp-version: ${{ inputs.idp_version }}
+      zet1-version: ${{ inputs.zet1_version }}
+      zet2-version: ${{ inputs.zet2_version }}
+    secrets: inherit
 
   nix-build:
     name: Build Nix Binary

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,7 @@ jobs:
           echo "channels=$channels" >> "$GITHUB_OUTPUT"
 
   integration-tests:
-    name: Integration Tests
+    name: Integration Tests (${{ matrix.ziti-channel.label }} ${{ matrix.ziti-channel.tag }})
     needs: [ call-cmake-build, resolve-ziti-versions ]
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,6 @@ jobs:
     needs: [ call-cmake-build ]
     uses: ./.github/workflows/integration-tests.yml
     with:
-      build-ziti-from-main: true
+      ziti-version: main
       label: main
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
-  # TEMP: validates the from-main path on the PR; remove before merge
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+  # TEMP: validates the from-main path on the PR; remove before merge
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,25 @@
+name: Nightly Integration Tests (ziti main)
+
+# Runs ZET integration tests against ziti main
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  call-cmake-build:
+    name: Call CMake Build
+    uses: ./.github/workflows/cmake.yml
+
+  integration-tests:
+    name: Integration Tests
+    needs: [ call-cmake-build ]
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      build-ziti-from-main: true
+      label: main
+    secrets: inherit

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -197,8 +197,10 @@ Each external-auth test logs in as its own IdP user; the user's email is the con
 | `test_ext_auth_unknown_identity@test.com` | login succeeds, controller deliberately has no matching identity |
 | `test_ext_auth_multi_default@test.com` | multi-signer, default auth policy |
 | `test_ext_auth_multi_named@test.com` | multi-signer, named auth policy |
-| `test_ext_auth_cert_happy@test.com` | enroll-to-cert (also the both-flows rerun) |
-| `test_ext_auth_token_happy@test.com` | enroll-to-token (also the both-flows rerun) |
+| `test_ext_auth_cert_happy@test.com` | enroll-to-cert happy path |
+| `test_ext_auth_token_happy@test.com` | enroll-to-token happy path |
+| `test_ext_auth_cert_both@test.com` | both-flows-enabled, cert enrollment |
+| `test_ext_auth_token_both@test.com` | both-flows-enabled, token enrollment |
 | `test_ext_auth_cert_then_none@test.com` | cross-mode rejection |
 | `test_ext_auth_cert_then_token@test.com` | cross-mode rejection |
 | `test_ext_auth_token_then_cert@test.com` | cross-mode rejection |

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -239,4 +239,4 @@ ZET_BIN=/path/to/ziti-edge-tunnel ./scripts/run-ci.sh
 $env:ZET_BIN = "C:\path\to\ziti-edge-tunnel.exe"; .\scripts\run-ci.ps1
 ```
 
-They honor `TEST_HOME`, `ZITI_VERSION`, `IDP_VERSION`, `ZET1_VERSION`, `ZET2_VERSION`, and a `--install-cert` / `-InstallCert` flag that installs the overlay CA for the run and removes it afterward. Without that flag they leave your trust store untouched.
+They honor `TEST_HOME`, `ZITI_BIN`, `ZITI_FROM_MAIN`, `ZITI_VERSION`, `IDP_VERSION`, `ZET1_VERSION`, `ZET2_VERSION`, and a `--install-cert` / `-InstallCert` flag that installs the overlay CA for the run and removes it afterward. Without that flag they leave your trust store untouched. Set `ZITI_FROM_MAIN=1` to build and test against `openziti/ziti` main instead of a release (what the nightly CI job does); a preset `ZITI_BIN` wins over both.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -229,14 +229,14 @@ Set `autoTrustCa: true` (quickstart mode) and the harness handles it: install af
 
 ## Reproducing CI
 
-`scripts/run-ci.sh` (and `run-ci.ps1` on Windows) do the whole thing end to end the way CI does: download `ziti`, build dex, seed PKI, write a config, and run the suite.
+`scripts/run-ci.sh` (and `run-ci.ps1` on Windows) do the whole thing end to end the way CI does: build dex, seed PKI, write a config, and run the suite against the ziti and ZET binaries you point them at.
 
 ```bash
-ZET_BIN=/path/to/ziti-edge-tunnel ./scripts/run-ci.sh
+ZET_BIN=/path/to/ziti-edge-tunnel ZITI_BIN=/path/to/ziti ./scripts/run-ci.sh
 ```
 
 ```powershell
-$env:ZET_BIN = "C:\path\to\ziti-edge-tunnel.exe"; .\scripts\run-ci.ps1
+$env:ZET_BIN = "C:\path\to\ziti-edge-tunnel.exe"; $env:ZITI_BIN = "C:\path\to\ziti.exe"; .\scripts\run-ci.ps1
 ```
 
-They honor `TEST_HOME`, `ZITI_BIN`, `ZITI_FROM_MAIN`, `ZITI_VERSION`, `IDP_VERSION`, `ZET1_VERSION`, `ZET2_VERSION`, and a `--install-cert` / `-InstallCert` flag that installs the overlay CA for the run and removes it afterward. Without that flag they leave your trust store untouched. Set `ZITI_FROM_MAIN=1` to build and test against `openziti/ziti` main instead of a release (what the nightly CI job does); a preset `ZITI_BIN` wins over both.
+They require `ZET_BIN` and `ZITI_BIN` and run against whatever those point at. Obtaining ziti is a CI concern: the workflow downloads a release (or builds `openziti/ziti` main for the nightly) and passes `ZITI_BIN` in. They also honor `TEST_HOME`, `IDP_VERSION`, `ZET1_VERSION`, `ZET2_VERSION`, and a `--install-cert` / `-InstallCert` flag that installs the overlay CA for the run and removes it afterward. Without that flag they leave your trust store untouched.

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -199,11 +199,7 @@ func (c *extAuthContext) enrollToNoneMultipleSignersNamedPolicyCompletes(t *test
 
 func (c *extAuthContext) enrollToCertCompletes(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		idName := "test_ext_auth_cert_happy"
-		t.Cleanup(func() { c.deleteIdentityByExternalId(idName) })
-
-		identifier := c.completeEnrollToCert(t, idName)
-		t.Cleanup(func() { c.zet.RemoveIdentity(t, identifier) })
+		c.completeEnrollToCert(t, "test_ext_auth_cert_happy")
 	})
 }
 
@@ -215,10 +211,6 @@ func (c *extAuthContext) createIdentityData(name string, mode testutil.EnrollMod
 		EnrollMode:       &mode,
 		Provider:         &c.workingSigner.name,
 	}
-}
-
-func (c *extAuthContext) deleteIdentityByExternalId(idName string) {
-	_ = c.overlay.PurgeIdentitiesByExternalId(idName + "@test.com")
 }
 
 // beginEnrollment sends AddIdentity and returns the enrollment URL the IdP flow
@@ -247,11 +239,7 @@ func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string 
 
 func (c *extAuthContext) enrollToTokenCompletes(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		idName := "test_ext_auth_token_happy"
-		t.Cleanup(func() { c.deleteIdentityByExternalId(idName) })
-
-		identifier := c.completeEnrollToToken(t, idName)
-		t.Cleanup(func() { c.zet.RemoveIdentity(t, identifier) })
+		c.completeEnrollToToken(t, "test_ext_auth_token_happy")
 	})
 }
 
@@ -277,8 +265,12 @@ func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) string
 }
 
 func (c *extAuthContext) bothEnrollFlowsCompleteWhenBothEnabled(t *testing.T) {
-	t.Run("enrollToCertCompletes", c.enrollToCertCompletes)
-	t.Run("enrollToTokenCompletes", c.enrollToTokenCompletes)
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.completeEnrollToCert(t, "test_ext_auth_cert_both")
+	})
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.completeEnrollToToken(t, "test_ext_auth_token_both")
+	})
 }
 
 func (c *extAuthContext) enrollToNoneThenCertRejected(t *testing.T) {

--- a/tests/integration/scripts/run-ci.ps1
+++ b/tests/integration/scripts/run-ci.ps1
@@ -3,15 +3,11 @@ Run the integration test suite end-to-end the same way CI does on Windows.
 Lets a local dev reproduce a CI failure with one command.
 
 Required input:
-  $env:ZET_BIN  Absolute path to a built ziti-edge-tunnel.exe.
+  $env:ZET_BIN   Absolute path to a built ziti-edge-tunnel.exe.
+  $env:ZITI_BIN  Absolute path to a ziti binary. CI obtains it (a release or a main build).
 
 Optional input:
   $env:TEST_HOME      Working dir for overlay, logs, caches. Defaults to a temp dir.
-  $env:ZITI_BIN       Prebuilt ziti binary to use as-is, skipping the release
-                      download. Wins over ZITI_FROM_MAIN and ZITI_VERSION.
-  $env:ZITI_FROM_MAIN Build openziti/ziti @ main from source (stamped 2.x) instead
-                      of downloading a release. Wins over ZITI_VERSION.
-  $env:ZITI_VERSION   ziti release tag to download (default: newest non-prerelease).
   $env:IDP_VERSION    dex version tag (default: fetch-dex.sh's pinned version).
   $env:ZET1_VERSION   If set, downloads this ZET release and uses it as ZET_BIN.
   $env:ZET2_VERSION   If set, downloads this ZET release and uses it as ZET_BIN_B.
@@ -21,7 +17,7 @@ Flags:
                 it on exit. Off by default so the script does not mutate a normal
                 user's trust store.
 
-Requires: go, gh, git. Run as Administrator when using -InstallCert, because
+Requires: go, gh. Run as Administrator when using -InstallCert, because
 installing the test overlay CA into Cert:\LocalMachine\Root requires it.
 #>
 
@@ -37,8 +33,14 @@ if (-not $env:ZET_BIN) {
 if (-not (Test-Path $env:ZET_BIN)) {
     Write-Error "ZET_BIN=$($env:ZET_BIN) does not exist"
 }
+if (-not $env:ZITI_BIN) {
+    Write-Error "ZITI_BIN must point to a ziti binary"
+}
+if (-not (Test-Path $env:ZITI_BIN)) {
+    Write-Error "ZITI_BIN=$($env:ZITI_BIN) does not exist"
+}
 
-foreach ($tool in @("go", "gh", "git")) {
+foreach ($tool in @("go", "gh")) {
     if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
         Write-Error "missing required tool: $tool"
     }
@@ -53,42 +55,8 @@ Write-Host "TEST_HOME=$testHome"
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
 
-# ---- Resolve ziti CLI -------------------------------------------------------
-# Three ways to get the ziti used as both controller and management CLI, in order
-# of precedence: a preset ZITI_BIN, a source build of main, or a release download.
-if ($env:ZITI_BIN) {
-    if (-not (Test-Path $env:ZITI_BIN)) { Write-Error "ZITI_BIN=$($env:ZITI_BIN) does not exist" }
-    $zitiBin = $env:ZITI_BIN
-} elseif ($env:ZITI_FROM_MAIN) {
-    # build from a checkout; `go install @main` rejects ziti's go.mod replace
-    # directives. Stamp the version line so probeZitiVersion sees 2.x, not v0.0.0.
-    $zitiSrc = Join-Path $testHome "ziti-src"
-    $zitiBin = Join-Path $testHome "ziti-main.exe"
-    if (Test-Path $zitiSrc) { Remove-Item -Recurse -Force $zitiSrc }
-    git clone --depth 1 https://github.com/openziti/ziti.git $zitiSrc
-    if ($LASTEXITCODE -ne 0) { Write-Error "git clone failed (exit $LASTEXITCODE)" }
-    Push-Location $zitiSrc
-    $stamp = "v$((Get-Content version -Raw).Trim()).0-main"
-    $modPath = (go list -m).Trim()
-    go build -ldflags "-X $modPath/common/version.Version=$stamp" -o $zitiBin ./ziti
-    Pop-Location
-    if ($LASTEXITCODE -ne 0) { Write-Error "ziti build failed (exit $LASTEXITCODE)" }
-} else {
-    $zitiVersion = $env:ZITI_VERSION
-    if (-not $zitiVersion) {
-        $releases = gh release list --repo openziti/ziti --limit 50 --json tagName,isDraft,isPrerelease | ConvertFrom-Json
-        $zitiVersion = ($releases | Where-Object { -not $_.isDraft -and -not $_.isPrerelease } | ForEach-Object tagName | Sort-Object { [version]($_ -replace '^v','') } | Select-Object -Last 1)
-    }
-    Write-Host "Using ziti $zitiVersion"
-    $zitiDir = Join-Path $testHome "ziti-cli"
-    New-Item -ItemType Directory -Path $zitiDir -Force | Out-Null
-    Push-Location $zitiDir
-    gh release download --repo openziti/ziti $zitiVersion --pattern "ziti-windows-amd64-*.zip" --clobber
-    $zitiZip = (Get-ChildItem -Filter "*.zip" | Select-Object -First 1).FullName
-    Expand-Archive -Path $zitiZip -DestinationPath . -Force
-    $zitiBin = (Get-ChildItem -Recurse -Filter "ziti.exe" | Select-Object -First 1).FullName
-    Pop-Location
-}
+# ---- ziti CLI ---------------------------------------------------------------
+$zitiBin = $env:ZITI_BIN
 Write-Host "ZITI_BIN=$zitiBin"
 
 # ---- Build/fetch dex --------------------------------------------------------

--- a/tests/integration/scripts/run-ci.ps1
+++ b/tests/integration/scripts/run-ci.ps1
@@ -64,7 +64,9 @@ if ($env:ZITI_BIN) {
     # directives. Stamp the version line so probeZitiVersion sees 2.x, not v0.0.0.
     $zitiSrc = Join-Path $testHome "ziti-src"
     $zitiBin = Join-Path $testHome "ziti-main.exe"
+    if (Test-Path $zitiSrc) { Remove-Item -Recurse -Force $zitiSrc }
     git clone --depth 1 https://github.com/openziti/ziti.git $zitiSrc
+    if ($LASTEXITCODE -ne 0) { Write-Error "git clone failed (exit $LASTEXITCODE)" }
     Push-Location $zitiSrc
     $stamp = "v$((Get-Content version -Raw).Trim()).0-main"
     $modPath = (go list -m).Trim()

--- a/tests/integration/scripts/run-ci.ps1
+++ b/tests/integration/scripts/run-ci.ps1
@@ -7,6 +7,10 @@ Required input:
 
 Optional input:
   $env:TEST_HOME      Working dir for overlay, logs, caches. Defaults to a temp dir.
+  $env:ZITI_BIN       Prebuilt ziti binary to use as-is, skipping the release
+                      download. Wins over ZITI_FROM_MAIN and ZITI_VERSION.
+  $env:ZITI_FROM_MAIN Build openziti/ziti @ main from source (stamped 2.x) instead
+                      of downloading a release. Wins over ZITI_VERSION.
   $env:ZITI_VERSION   ziti release tag to download (default: newest non-prerelease).
   $env:IDP_VERSION    dex version tag (default: fetch-dex.sh's pinned version).
   $env:ZET1_VERSION   If set, downloads this ZET release and uses it as ZET_BIN.
@@ -49,23 +53,40 @@ Write-Host "TEST_HOME=$testHome"
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
 
-# ---- Resolve ziti version ---------------------------------------------------
-$zitiVersion = $env:ZITI_VERSION
-if (-not $zitiVersion) {
-    $releases = gh release list --repo openziti/ziti --limit 50 --json tagName,isDraft,isPrerelease | ConvertFrom-Json
-    $zitiVersion = ($releases | Where-Object { -not $_.isDraft -and -not $_.isPrerelease } | ForEach-Object tagName | Sort-Object { [version]($_ -replace '^v','') } | Select-Object -Last 1)
+# ---- Resolve ziti CLI -------------------------------------------------------
+# Three ways to get the ziti used as both controller and management CLI, in order
+# of precedence: a preset ZITI_BIN, a source build of main, or a release download.
+if ($env:ZITI_BIN) {
+    if (-not (Test-Path $env:ZITI_BIN)) { Write-Error "ZITI_BIN=$($env:ZITI_BIN) does not exist" }
+    $zitiBin = $env:ZITI_BIN
+} elseif ($env:ZITI_FROM_MAIN) {
+    # build from a checkout; `go install @main` rejects ziti's go.mod replace
+    # directives. Stamp the version line so probeZitiVersion sees 2.x, not v0.0.0.
+    $zitiSrc = Join-Path $testHome "ziti-src"
+    $zitiBin = Join-Path $testHome "ziti-main.exe"
+    git clone --depth 1 https://github.com/openziti/ziti.git $zitiSrc
+    Push-Location $zitiSrc
+    $stamp = "v$((Get-Content version -Raw).Trim()).0-main"
+    $modPath = (go list -m).Trim()
+    go build -ldflags "-X $modPath/common/version.Version=$stamp" -o $zitiBin ./ziti
+    Pop-Location
+    if ($LASTEXITCODE -ne 0) { Write-Error "ziti build failed (exit $LASTEXITCODE)" }
+} else {
+    $zitiVersion = $env:ZITI_VERSION
+    if (-not $zitiVersion) {
+        $releases = gh release list --repo openziti/ziti --limit 50 --json tagName,isDraft,isPrerelease | ConvertFrom-Json
+        $zitiVersion = ($releases | Where-Object { -not $_.isDraft -and -not $_.isPrerelease } | ForEach-Object tagName | Sort-Object { [version]($_ -replace '^v','') } | Select-Object -Last 1)
+    }
+    Write-Host "Using ziti $zitiVersion"
+    $zitiDir = Join-Path $testHome "ziti-cli"
+    New-Item -ItemType Directory -Path $zitiDir -Force | Out-Null
+    Push-Location $zitiDir
+    gh release download --repo openziti/ziti $zitiVersion --pattern "ziti-windows-amd64-*.zip" --clobber
+    $zitiZip = (Get-ChildItem -Filter "*.zip" | Select-Object -First 1).FullName
+    Expand-Archive -Path $zitiZip -DestinationPath . -Force
+    $zitiBin = (Get-ChildItem -Recurse -Filter "ziti.exe" | Select-Object -First 1).FullName
+    Pop-Location
 }
-Write-Host "Using ziti $zitiVersion"
-
-# ---- Download ziti CLI ------------------------------------------------------
-$zitiDir = Join-Path $testHome "ziti-cli"
-New-Item -ItemType Directory -Path $zitiDir -Force | Out-Null
-Push-Location $zitiDir
-gh release download --repo openziti/ziti $zitiVersion --pattern "ziti-windows-amd64-*.zip" --clobber
-$zitiZip = (Get-ChildItem -Filter "*.zip" | Select-Object -First 1).FullName
-Expand-Archive -Path $zitiZip -DestinationPath . -Force
-$zitiBin = (Get-ChildItem -Recurse -Filter "ziti.exe" | Select-Object -First 1).FullName
-Pop-Location
 Write-Host "ZITI_BIN=$zitiBin"
 
 # ---- Build/fetch dex --------------------------------------------------------

--- a/tests/integration/scripts/run-ci.sh
+++ b/tests/integration/scripts/run-ci.sh
@@ -7,6 +7,10 @@
 #
 # Optional input:
 #   TEST_HOME      Working dir for overlay, logs, caches. Defaults to a temp dir.
+#   ZITI_BIN       Prebuilt ziti binary to use as-is, skipping the release
+#                  download. Wins over ZITI_FROM_MAIN and ZITI_VERSION.
+#   ZITI_FROM_MAIN Build openziti/ziti @ main from source (stamped 2.x) instead
+#                  of downloading a release. Wins over ZITI_VERSION.
 #   ZITI_VERSION   ziti release tag to download (default: newest non-prerelease).
 #   IDP_VERSION    dex version tag (default: fetch-dex.sh's pinned version).
 #   ZET1_VERSION   If set, downloads this ZET release and uses it as ZET_BIN.
@@ -17,7 +21,7 @@
 #                   remove it on exit. Off by default so the script does not
 #                   mutate a normal user's trust store.
 #
-# Requires:  go, gh, jq, sudo (Linux/macOS).
+# Requires:  go, gh, git, jq, curl, unzip, and sudo (Linux/macOS).
 
 set -euo pipefail
 
@@ -37,7 +41,7 @@ if [ ! -x "$ZET_BIN" ]; then
   exit 1
 fi
 
-for tool in go gh jq curl unzip; do
+for tool in go gh git jq curl unzip; do
   command -v "$tool" >/dev/null || { echo "missing required tool: $tool" >&2; exit 1; }
 done
 
@@ -54,25 +58,38 @@ echo "TEST_HOME=$TEST_HOME"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
-# ---- Resolve ziti version ----------------------------------------------------
-if [ -z "${ZITI_VERSION:-}" ]; then
-  ZITI_VERSION=$(gh release list --repo openziti/ziti --limit 50 \
-    --json tagName,isDraft,isPrerelease \
-    | jq -r '.[] | select(.isDraft==false and .isPrerelease==false) | .tagName' \
-    | sort -V | tail -n1)
+# ---- Resolve ziti CLI --------------------------------------------------------
+# Three ways to get the ziti used as both controller and management CLI, in order
+# of precedence: a preset ZITI_BIN, a source build of main, or a release download.
+if [ -n "${ZITI_BIN:-}" ]; then
+  [ -x "$ZITI_BIN" ] || { echo "ZITI_BIN=$ZITI_BIN is not executable" >&2; exit 1; }
+elif [ -n "${ZITI_FROM_MAIN:-}" ]; then
+  # build from a checkout; `go install @main` rejects ziti's go.mod replace
+  # directives. Stamp the version line so probeZitiVersion sees 2.x, not v0.0.0.
+  ZITI_SRC="$TEST_HOME/ziti-src"
+  ZITI_BIN="$TEST_HOME/ziti-main"
+  git clone --depth 1 https://github.com/openziti/ziti.git "$ZITI_SRC"
+  ( cd "$ZITI_SRC" && go build \
+    -ldflags "-X $(go list -m)/common/version.Version=v$(tr -d '[:space:]' < version).0-main" \
+    -o "$ZITI_BIN" ./ziti )
+else
+  if [ -z "${ZITI_VERSION:-}" ]; then
+    ZITI_VERSION=$(gh release list --repo openziti/ziti --limit 50 \
+      --json tagName,isDraft,isPrerelease \
+      | jq -r '.[] | select(.isDraft==false and .isPrerelease==false) | .tagName' \
+      | sort -V | tail -n1)
+  fi
+  echo "Using ziti $ZITI_VERSION"
+  ZITI_DIR="$TEST_HOME/ziti-cli"
+  mkdir -p "$ZITI_DIR"
+  (
+    cd "$ZITI_DIR"
+    gh release download --repo openziti/ziti "$ZITI_VERSION" --pattern "$ZITI_PATTERN" --clobber
+    for archive in *.tar.gz; do [ -e "$archive" ] && tar -xzf "$archive"; done
+  )
+  ZITI_BIN=$(find "$ZITI_DIR" -type f -name ziti | head -n1)
+  chmod +x "$ZITI_BIN"
 fi
-echo "Using ziti $ZITI_VERSION"
-
-# ---- Download ziti CLI -------------------------------------------------------
-ZITI_DIR="$TEST_HOME/ziti-cli"
-mkdir -p "$ZITI_DIR"
-(
-  cd "$ZITI_DIR"
-  gh release download --repo openziti/ziti "$ZITI_VERSION" --pattern "$ZITI_PATTERN" --clobber
-  for archive in *.tar.gz; do [ -e "$archive" ] && tar -xzf "$archive"; done
-)
-ZITI_BIN=$(find "$ZITI_DIR" -type f -name ziti | head -n1)
-chmod +x "$ZITI_BIN"
 echo "ZITI_BIN=$ZITI_BIN"
 
 # ---- Build/fetch dex ---------------------------------------------------------

--- a/tests/integration/scripts/run-ci.sh
+++ b/tests/integration/scripts/run-ci.sh
@@ -68,6 +68,7 @@ elif [ -n "${ZITI_FROM_MAIN:-}" ]; then
   # directives. Stamp the version line so probeZitiVersion sees 2.x, not v0.0.0.
   ZITI_SRC="$TEST_HOME/ziti-src"
   ZITI_BIN="$TEST_HOME/ziti-main"
+  rm -rf "$ZITI_SRC"
   git clone --depth 1 https://github.com/openziti/ziti.git "$ZITI_SRC"
   ( cd "$ZITI_SRC" && go build \
     -ldflags "-X $(go list -m)/common/version.Version=v$(tr -d '[:space:]' < version).0-main" \

--- a/tests/integration/scripts/run-ci.sh
+++ b/tests/integration/scripts/run-ci.sh
@@ -3,15 +3,11 @@
 # local dev reproduce a CI failure with one command.
 #
 # Required input:
-#   ZET_BIN  Absolute path to a built ziti-edge-tunnel binary.
+#   ZET_BIN   Absolute path to a built ziti-edge-tunnel binary.
+#   ZITI_BIN  Absolute path to a ziti binary. CI obtains it (a release or a main build).
 #
 # Optional input:
 #   TEST_HOME      Working dir for overlay, logs, caches. Defaults to a temp dir.
-#   ZITI_BIN       Prebuilt ziti binary to use as-is, skipping the release
-#                  download. Wins over ZITI_FROM_MAIN and ZITI_VERSION.
-#   ZITI_FROM_MAIN Build openziti/ziti @ main from source (stamped 2.x) instead
-#                  of downloading a release. Wins over ZITI_VERSION.
-#   ZITI_VERSION   ziti release tag to download (default: newest non-prerelease).
 #   IDP_VERSION    dex version tag (default: fetch-dex.sh's pinned version).
 #   ZET1_VERSION   If set, downloads this ZET release and uses it as ZET_BIN.
 #   ZET2_VERSION   If set, downloads this ZET release and uses it as ZET_BIN_B.
@@ -21,7 +17,7 @@
 #                   remove it on exit. Off by default so the script does not
 #                   mutate a normal user's trust store.
 #
-# Requires:  go, gh, git, jq, curl, unzip, and sudo (Linux/macOS).
+# Requires:  go, gh, jq, curl, unzip, and sudo (Linux/macOS).
 
 set -euo pipefail
 
@@ -41,14 +37,14 @@ if [ ! -x "$ZET_BIN" ]; then
   exit 1
 fi
 
-for tool in go gh git jq curl unzip; do
+for tool in go gh jq curl unzip; do
   command -v "$tool" >/dev/null || { echo "missing required tool: $tool" >&2; exit 1; }
 done
 
 case "$(uname -s)-$(uname -m)" in
-  Linux-x86_64)   ZITI_PATTERN="ziti-linux-amd64-*.tar.gz"; ZET_ZIP="ziti-edge-tunnel-Linux_x86_64.zip";  ZET_BIN_NAME="ziti-edge-tunnel" ;;
-  Darwin-arm64)   ZITI_PATTERN="ziti-darwin-arm64-*.tar.gz"; ZET_ZIP="ziti-edge-tunnel-Darwin_arm64.zip"; ZET_BIN_NAME="ziti-edge-tunnel" ;;
-  Darwin-x86_64)  ZITI_PATTERN="ziti-darwin-amd64-*.tar.gz"; ZET_ZIP="ziti-edge-tunnel-Darwin_x86_64.zip"; ZET_BIN_NAME="ziti-edge-tunnel" ;;
+  Linux-x86_64)   ZET_ZIP="ziti-edge-tunnel-Linux_x86_64.zip";  ZET_BIN_NAME="ziti-edge-tunnel" ;;
+  Darwin-arm64)   ZET_ZIP="ziti-edge-tunnel-Darwin_arm64.zip"; ZET_BIN_NAME="ziti-edge-tunnel" ;;
+  Darwin-x86_64)  ZET_ZIP="ziti-edge-tunnel-Darwin_x86_64.zip"; ZET_BIN_NAME="ziti-edge-tunnel" ;;
   *) echo "unsupported os/arch: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
 esac
 
@@ -58,39 +54,9 @@ echo "TEST_HOME=$TEST_HOME"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
-# ---- Resolve ziti CLI --------------------------------------------------------
-# Three ways to get the ziti used as both controller and management CLI, in order
-# of precedence: a preset ZITI_BIN, a source build of main, or a release download.
-if [ -n "${ZITI_BIN:-}" ]; then
-  [ -x "$ZITI_BIN" ] || { echo "ZITI_BIN=$ZITI_BIN is not executable" >&2; exit 1; }
-elif [ -n "${ZITI_FROM_MAIN:-}" ]; then
-  # build from a checkout; `go install @main` rejects ziti's go.mod replace
-  # directives. Stamp the version line so probeZitiVersion sees 2.x, not v0.0.0.
-  ZITI_SRC="$TEST_HOME/ziti-src"
-  ZITI_BIN="$TEST_HOME/ziti-main"
-  rm -rf "$ZITI_SRC"
-  git clone --depth 1 https://github.com/openziti/ziti.git "$ZITI_SRC"
-  ( cd "$ZITI_SRC" && go build \
-    -ldflags "-X $(go list -m)/common/version.Version=v$(tr -d '[:space:]' < version).0-main" \
-    -o "$ZITI_BIN" ./ziti )
-else
-  if [ -z "${ZITI_VERSION:-}" ]; then
-    ZITI_VERSION=$(gh release list --repo openziti/ziti --limit 50 \
-      --json tagName,isDraft,isPrerelease \
-      | jq -r '.[] | select(.isDraft==false and .isPrerelease==false) | .tagName' \
-      | sort -V | tail -n1)
-  fi
-  echo "Using ziti $ZITI_VERSION"
-  ZITI_DIR="$TEST_HOME/ziti-cli"
-  mkdir -p "$ZITI_DIR"
-  (
-    cd "$ZITI_DIR"
-    gh release download --repo openziti/ziti "$ZITI_VERSION" --pattern "$ZITI_PATTERN" --clobber
-    for archive in *.tar.gz; do [ -e "$archive" ] && tar -xzf "$archive"; done
-  )
-  ZITI_BIN=$(find "$ZITI_DIR" -type f -name ziti | head -n1)
-  chmod +x "$ZITI_BIN"
-fi
+# ---- ziti CLI ----------------------------------------------------------------
+: "${ZITI_BIN:?ZITI_BIN must point to a ziti binary}"
+[ -x "$ZITI_BIN" ] || { echo "ZITI_BIN=$ZITI_BIN is not executable" >&2; exit 1; }
 echo "ZITI_BIN=$ZITI_BIN"
 
 # ---- Build/fetch dex ---------------------------------------------------------

--- a/tests/integration/testdata/dex-config.yaml
+++ b/tests/integration/testdata/dex-config.yaml
@@ -52,6 +52,14 @@ staticPasswords:
     hash: *password
     username: test_ext_auth_token_happy
     userID: test_ext_auth_token_happy
+  - email: test_ext_auth_cert_both@test.com
+    hash: *password
+    username: test_ext_auth_cert_both
+    userID: test_ext_auth_cert_both
+  - email: test_ext_auth_token_both@test.com
+    hash: *password
+    username: test_ext_auth_token_both
+    userID: test_ext_auth_token_both
   - email: test_ext_auth_cert_then_none@test.com
     hash: *password
     username: test_ext_auth_cert_then_none


### PR DESCRIPTION
Extracts the integration-tests job into a reusable workflow and adds a nightly job that builds ziti from main and runs the suite against it