### PR TITLE
Make integration tests callable by other repos against released or built binaries

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,8 @@
 # callable workflow's jobs appear in the calling workflow's run, so clicking this workflow in GitHub shows no runs
+#
+# The ZET/Ziti binaries under test come from exactly one source each:
+#   ziti: ziti-artifact > ziti-ref (build from source) > ziti-version (download a release; empty = stable)
+#   ZET:  zet1-version (download a release, 'latest' = the GitHub Latest release; empty = the cmake artifact built by the caller's run)
 name: Callable Integration Tests
 
 on:
@@ -29,11 +33,11 @@ on:
         type: string
         default: ""
       ziti-artifact:
-        description: "name prefix of per-OS artifacts (<prefix>-linux|darwin|windows) holding a ziti binary, uploaded earlier in the caller's run; overrides ziti-version"
+        description: "name suffix of per-OS artifacts ((linux|darwin|windows)-<suffix>) holding a ziti binary; overrides ziti-version"
         type: string
         default: ""
       tests-repo:
-        description: "repo to check the test suite out from, at the same commit as this workflow file; cross-repo callers set this (checkout defaults to the calling repo)"
+        description: "repo to check the test suite out from; cross-repo callers set this to the repo named in their 'uses:' line"
         type: string
         default: ""
 
@@ -50,6 +54,7 @@ jobs:
             zet-zip: ziti-edge-tunnel-Linux_x86_64.zip
             zet-bin: ziti-edge-tunnel
             ziti-os: linux
+            ziti-arch: amd64
             ziti-bin: ziti
             core-dir: /tmp/cores
           - name: macOS arm64
@@ -58,6 +63,7 @@ jobs:
             zet-zip: ziti-edge-tunnel-Darwin_arm64.zip
             zet-bin: ziti-edge-tunnel
             ziti-os: darwin
+            ziti-arch: arm64
             ziti-bin: ziti
             core-dir: /cores
           - name: Windows x64
@@ -66,6 +72,7 @@ jobs:
             zet-zip: ziti-edge-tunnel-Windows_x86_64.zip
             zet-bin: ziti-edge-tunnel.exe
             ziti-os: windows
+            ziti-arch: amd64
             ziti-bin: ziti.exe
             core-dir: ""
     runs-on: ${{ matrix.os.runner }}
@@ -143,7 +150,7 @@ jobs:
         if: inputs.ziti-artifact != ''
         uses: actions/download-artifact@v8
         with:
-          name: ${{ inputs.ziti-artifact }}-${{ matrix.os.ziti-os }}
+          name: ${{ matrix.os.ziti-os }}-${{ inputs.ziti-artifact }}
           path: ./ziti-artifact
           digest-mismatch: error
 
@@ -152,11 +159,15 @@ jobs:
         env:
           ZITI_ARTIFACT: ${{ inputs.ziti-artifact }}
           ZITI_BIN_NAME: ${{ matrix.os.ziti-bin }}
+          ZITI_ARCH: ${{ matrix.os.ziti-arch }}
         run: |
           set -euo pipefail
           if [ -n "$ZITI_ARTIFACT" ]; then
-            bin="$(find ziti-artifact -type f -name "$ZITI_BIN_NAME" | head -1)"
-            [ -n "$bin" ] || { echo "no $ZITI_BIN_NAME in artifact $ZITI_ARTIFACT-${{ matrix.os.ziti-os }}" >&2; exit 1; }
+            # multi-arch artifacts (gox layout <arch>/<os>/) need the runner's arch;
+            # fall back to any match for flat single-binary artifacts
+            bin="$(find ziti-artifact -type f -path "*${ZITI_ARCH}*" -name "$ZITI_BIN_NAME" | head -1)"
+            [ -n "$bin" ] || bin="$(find ziti-artifact -type f -name "$ZITI_BIN_NAME" | head -1)"
+            [ -n "$bin" ] || { echo "no $ZITI_BIN_NAME in artifact ${{ matrix.os.ziti-os }}-$ZITI_ARTIFACT" >&2; exit 1; }
             chmod +x "$bin" || true
             # On Windows the consumer is PowerShell, which can't resolve an MSYS
             # /d/a/... path; pwd -W emits a Windows path it accepts.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,7 +5,11 @@ on:
   workflow_call:
     inputs:
       ziti-version:
-        description: "ziti release tag to download, or 'main' to build openziti/ziti @ main from source"
+        description: "ziti release to download; anything setup-cli accepts: a tag, tag regex, 'stable', 'active-lts', 'maint-lts'; empty = stable. Ignored when ziti-ref or ziti-artifact is set"
+        type: string
+        default: ""
+      ziti-ref:
+        description: "branch, tag, or commit of openziti/ziti to build from source instead of downloading a release"
         type: string
         default: ""
       label:
@@ -73,7 +77,6 @@ jobs:
           # job_workflow_sha = the commit this workflow file was loaded from, so a
           # cross-repo caller's @ref selects the workflow and the test sources together.
           ref: ${{ inputs.tests-repo != '' && github.job_workflow_sha || '' }}
-          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -91,23 +94,7 @@ jobs:
           path: ./zet-artifact
           digest-mismatch: error
 
-      - name: Extract built ZET binary from artifact
-        if: inputs.zet1-version == ''
-        shell: bash
-        env:
-          ZET_ZIP: ${{ matrix.os.zet-zip }}
-          ZET_BIN_NAME: ${{ matrix.os.zet-bin }}
-        run: |
-          set -euo pipefail
-          unzip -o "zet-artifact/$ZET_ZIP" -d zet-artifact
-          chmod +x "zet-artifact/$ZET_BIN_NAME" || true
-          # On Windows the consumer is PowerShell, which can't resolve an MSYS
-          # /d/a/... path; pwd -W emits a Windows path it accepts.
-          if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
-          echo "ZET_BIN=$base/zet-artifact/$ZET_BIN_NAME" >> "$GITHUB_ENV"
-
-      - name: Download ZET release
-        if: inputs.zet1-version != '' || inputs.zet2-version != ''
+      - name: Set ZET_BIN
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -118,14 +105,21 @@ jobs:
         run: |
           set -euo pipefail
           fetch() {
+            # 'latest' = the release GitHub marks Latest; gh downloads it when no tag is given
+            local tag=("$1")
+            if [ "$1" = "latest" ]; then tag=(); fi
             mkdir -p "$2"
-            (cd "$2" && gh release download --repo openziti/ziti-tunnel-sdk-c "$1" --pattern "$ZET_ZIP" --clobber && unzip -o "$ZET_ZIP")
+            (cd "$2" && gh release download --repo openziti/ziti-tunnel-sdk-c "${tag[@]}" --pattern "$ZET_ZIP" --clobber && unzip -o "$ZET_ZIP")
             chmod +x "$2/$ZET_BIN_NAME" || true
           }
           # On Windows the consumer is PowerShell, which can't resolve an MSYS
           # /d/a/... path; pwd -W emits a Windows path it accepts.
           if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
-          if [ -n "$ZET1_VERSION" ]; then
+          if [ -z "$ZET1_VERSION" ]; then
+            unzip -o "zet-artifact/$ZET_ZIP" -d zet-artifact
+            chmod +x "zet-artifact/$ZET_BIN_NAME" || true
+            echo "ZET_BIN=$base/zet-artifact/$ZET_BIN_NAME" >> "$GITHUB_ENV"
+          else
             fetch "$ZET1_VERSION" zet-release-a
             echo "ZET_BIN=$base/zet-release-a/$ZET_BIN_NAME" >> "$GITHUB_ENV"
           fi
@@ -141,8 +135,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: ${{ (inputs.ziti-version == '' || inputs.ziti-version == 'main') && 'stable' || inputs.ziti-version }}
-          ref: ${{ inputs.ziti-version == 'main' && 'main' || '' }}
+          version: ${{ inputs.ziti-version == '' && 'stable' || inputs.ziti-version }}
+          ref: ${{ inputs.ziti-ref }}
 
       # Built by the caller's run; tests the exact ziti bits the caller produced.
       - name: Download ziti artifact

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,7 +64,9 @@ jobs:
           cache-dependency-path: tests/integration/go.sum
 
       # Built by the caller's cmake job; artifacts are shared within the run.
+      # When zet1-version selects a released ZET, no build artifact is needed.
       - name: Download CMake Artifact
+        if: inputs.zet1-version == ''
         uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.os.artifact }}
@@ -72,6 +74,7 @@ jobs:
           digest-mismatch: error
 
       - name: Extract built ZET binary from artifact
+        if: inputs.zet1-version == ''
         shell: bash
         env:
           ZET_ZIP: ${{ matrix.os.zet-zip }}
@@ -84,6 +87,34 @@ jobs:
           # /d/a/... path; pwd -W emits a Windows path it accepts.
           if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
           echo "ZET_BIN=$base/zet-artifact/$ZET_BIN_NAME" >> "$GITHUB_ENV"
+
+      - name: Download ZET release
+        if: inputs.zet1-version != '' || inputs.zet2-version != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZET_ZIP: ${{ matrix.os.zet-zip }}
+          ZET_BIN_NAME: ${{ matrix.os.zet-bin }}
+          ZET1_VERSION: ${{ inputs.zet1-version }}
+          ZET2_VERSION: ${{ inputs.zet2-version }}
+        run: |
+          set -euo pipefail
+          fetch() {
+            mkdir -p "$2"
+            (cd "$2" && gh release download --repo openziti/ziti-tunnel-sdk-c "$1" --pattern "$ZET_ZIP" --clobber && unzip -o "$ZET_ZIP")
+            chmod +x "$2/$ZET_BIN_NAME" || true
+          }
+          # On Windows the consumer is PowerShell, which can't resolve an MSYS
+          # /d/a/... path; pwd -W emits a Windows path it accepts.
+          if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
+          if [ -n "$ZET1_VERSION" ]; then
+            fetch "$ZET1_VERSION" zet-release-a
+            echo "ZET_BIN=$base/zet-release-a/$ZET_BIN_NAME" >> "$GITHUB_ENV"
+          fi
+          if [ -n "$ZET2_VERSION" ]; then
+            fetch "$ZET2_VERSION" zet-release-b
+            echo "ZET_BIN_B=$base/zet-release-b/$ZET_BIN_NAME" >> "$GITHUB_ENV"
+          fi
 
       # CI resolves ziti via openziti's setup-cli action; downstream tests run against any ziti.
       - name: Resolve ziti
@@ -98,24 +129,18 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEST_HOME: ${{ runner.temp }}
           ZITI_BIN: ${{ runner.temp }}/ziti-cli/bin/ziti
           IDP_VERSION: ${{ inputs.idp-version }}
-          ZET1_VERSION: ${{ inputs.zet1-version }}
-          ZET2_VERSION: ${{ inputs.zet2-version }}
         run: ./tests/integration/scripts/run-ci.sh --install-cert
 
       - name: Run integration tests (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEST_HOME: ${{ runner.temp }}
           ZITI_BIN: ${{ runner.temp }}/ziti-cli/bin/ziti.exe
           IDP_VERSION: ${{ inputs.idp-version }}
-          ZET1_VERSION: ${{ inputs.zet1-version }}
-          ZET2_VERSION: ${{ inputs.zet2-version }}
         run: .\tests\integration\scripts\run-ci.ps1 -InstallCert
 
       - name: Log core file backtraces

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,15 +1,25 @@
-# callable workflow's jobs appear in the calling workflow's run, so clicking this workflow in GitHub shows no runs
+# Reusable workflow other repos can call to test their own ziti/ZET build with this suite.
 #
-# The ZET/Ziti binaries under test come from:
-#   ziti: ziti-artifact > ziti-ref (build from source) > ziti-version (download a release; empty = stable)
-#   ZET:  zet1-version (download a release, 'latest' = the GitHub Latest release; empty = the cmake artifact built by the caller's run)
+# Inputs that pick the binaries to test:
+#   - ziti-artifact: test a ziti binary built by another job in a calling run (e.g. in another repo)
+#   - ziti-version: a release to download, one of:
+#       - 'stable' (default): the latest stable release
+#       - 'active-lts' or 'maint-lts': the latest release on that LTS line
+#       - a tag or tag-regex (like 'v1.6'): the latest release matching it
+#   - ziti-ref: a branch, tag, or commit to build from source instead of downloading a release
+#   - zetA-version: which ZET to test, one of:
+#       - empty (default): the ziti-edge-tunnel built by a cmake job in the calling run.
+#         Cross-repo callers (tests-repo set) have no such job, so they must set this.
+#       - 'latest': the release GitHub marks Latest
+#       - a tag: a specified release
+#   - zetB-version: ZET for the host-side tunneler, same options (empty reuses zetA)
 name: Callable Integration Tests
 
 on:
   workflow_call:
     inputs:
       ziti-version:
-        description: "ziti release to download; anything setup-cli accepts: a tag, tag regex, 'stable', 'active-lts', 'maint-lts'; empty = stable. Ignored when ziti-ref or ziti-artifact is set"
+        description: "ziti release to download: a tag, tag-regex, 'stable', 'active-lts', or 'maint-lts'. Empty = stable. Ignored when ziti-ref or ziti-artifact is set"
         type: string
         default: ""
       ziti-ref:
@@ -17,23 +27,23 @@ on:
         type: string
         default: ""
       label:
-        description: "label for the run name and artifact/log names (e.g. latest, lts, main)"
+        description: "label appended to this run's uploaded core/log artifact names (e.g. latest, lts, main)"
         type: string
         required: true
       idp-version:
         description: "dex IdP version tag; empty = script default"
         type: string
         default: ""
-      zet1-version:
-        description: "ziti-edge-tunnel release tag for zetA, or 'latest' for the release GitHub marks Latest; empty = the binary built by cmake"
+      zetA-version:
+        description: "ziti-edge-tunnel release tag for zetA, or 'latest' for the release GitHub marks Latest; empty = the binary built by cmake. Required when tests-repo is set"
         type: string
         default: ""
-      zet2-version:
+      zetB-version:
         description: "ziti-edge-tunnel release tag for zetB, or 'latest'; empty = same binary as zetA"
         type: string
         default: ""
       ziti-artifact:
-        description: "name suffix of per-OS artifacts ((linux|darwin|windows)-<suffix>) holding a ziti binary; overrides ziti-version"
+        description: "run-id suffix of a per-OS ziti artifact the calling run uploaded, downloaded as <os>-<suffix> (e.g. release-<run_id>). Overrides ziti-version"
         type: string
         default: ""
       tests-repo:
@@ -50,30 +60,18 @@ jobs:
         os:
           - name: Linux x64
             runner: ubuntu-latest
-            artifact: linux-x64
-            zet-zip: ziti-edge-tunnel-Linux_x86_64.zip
-            zet-bin: ziti-edge-tunnel
+            zet-build: linux-x64
             ziti-os: linux
-            ziti-arch: amd64
-            ziti-bin: ziti
             core-dir: /tmp/cores
           - name: macOS arm64
             runner: macos-15
-            artifact: macOS-arm64
-            zet-zip: ziti-edge-tunnel-Darwin_arm64.zip
-            zet-bin: ziti-edge-tunnel
+            zet-build: macOS-arm64
             ziti-os: darwin
-            ziti-arch: arm64
-            ziti-bin: ziti
             core-dir: /cores
           - name: Windows x64
             runner: windows-2022
-            artifact: windows-x64-mingw
-            zet-zip: ziti-edge-tunnel-Windows_x86_64.zip
-            zet-bin: ziti-edge-tunnel.exe
+            zet-build: windows-x64-mingw
             ziti-os: windows
-            ziti-arch: amd64
-            ziti-bin: ziti.exe
             core-dir: ""
     runs-on: ${{ matrix.os.runner }}
     steps:
@@ -91,13 +89,12 @@ jobs:
           go-version-file: tests/integration/go.mod
           cache-dependency-path: tests/integration/go.sum
 
-      # Built by the caller's cmake job; artifacts are shared within the run.
-      # When zet1-version selects a released ZET, no build artifact is needed.
-      - name: Download CMake Artifact
-        if: inputs.zet1-version == ''
+      # Built by the calling run's cmake job. When zetA-version is a released ZET, no build artifact is needed.
+      - name: Download ZET build
+        if: inputs.zetA-version == ''
         uses: actions/download-artifact@v8
         with:
-          name: ${{ matrix.os.artifact }}
+          name: ${{ matrix.os.zet-build }}
           path: ./zet-artifact
           digest-mismatch: error
 
@@ -105,12 +102,16 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZET_ZIP: ${{ matrix.os.zet-zip }}
-          ZET_BIN_NAME: ${{ matrix.os.zet-bin }}
-          ZET1_VERSION: ${{ inputs.zet1-version }}
-          ZET2_VERSION: ${{ inputs.zet2-version }}
+          ZETA_VERSION: ${{ inputs.zetA-version }}
+          ZETB_VERSION: ${{ inputs.zetB-version }}
         run: |
           set -euo pipefail
+          ZET_BIN_NAME=ziti-edge-tunnel; [ "$RUNNER_OS" = "Windows" ] && ZET_BIN_NAME=ziti-edge-tunnel.exe
+          case "$RUNNER_OS" in
+            Linux)   ZET_ZIP=ziti-edge-tunnel-Linux_x86_64.zip ;;
+            macOS)   ZET_ZIP=ziti-edge-tunnel-Darwin_arm64.zip ;;
+            Windows) ZET_ZIP=ziti-edge-tunnel-Windows_x86_64.zip ;;
+          esac
           fetch() {
             # 'latest' = the release GitHub marks Latest; gh downloads it when no tag is given
             local tag=("$1")
@@ -122,16 +123,16 @@ jobs:
           # On Windows the consumer is PowerShell, which can't resolve an MSYS
           # /d/a/... path; pwd -W emits a Windows path it accepts.
           if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
-          if [ -z "$ZET1_VERSION" ]; then
+          if [ -z "$ZETA_VERSION" ]; then
             unzip -o "zet-artifact/$ZET_ZIP" -d zet-artifact
             chmod +x "zet-artifact/$ZET_BIN_NAME" || true
             echo "ZET_BIN=$base/zet-artifact/$ZET_BIN_NAME" >> "$GITHUB_ENV"
           else
-            fetch "$ZET1_VERSION" zet-release-a
+            fetch "$ZETA_VERSION" zet-release-a
             echo "ZET_BIN=$base/zet-release-a/$ZET_BIN_NAME" >> "$GITHUB_ENV"
           fi
-          if [ -n "$ZET2_VERSION" ]; then
-            fetch "$ZET2_VERSION" zet-release-b
+          if [ -n "$ZETB_VERSION" ]; then
+            fetch "$ZETB_VERSION" zet-release-b
             echo "ZET_BIN_B=$base/zet-release-b/$ZET_BIN_NAME" >> "$GITHUB_ENV"
           fi
 
@@ -145,7 +146,7 @@ jobs:
           version: ${{ inputs.ziti-version == '' && 'stable' || inputs.ziti-version }}
           ref: ${{ inputs.ziti-ref }}
 
-      # Built by the caller's run; tests the exact ziti bits the caller produced.
+      # When ziti-artifact is set, download that prebuilt ziti (named <os>-<suffix>) from the calling run.
       - name: Download ziti artifact
         if: inputs.ziti-artifact != ''
         uses: actions/download-artifact@v8
@@ -158,23 +159,23 @@ jobs:
         shell: bash
         env:
           ZITI_ARTIFACT: ${{ inputs.ziti-artifact }}
-          ZITI_BIN_NAME: ${{ matrix.os.ziti-bin }}
-          ZITI_ARCH: ${{ matrix.os.ziti-arch }}
         run: |
           set -euo pipefail
+          bin=ziti; [ "$RUNNER_OS" = "Windows" ] && bin=ziti.exe
           if [ -n "$ZITI_ARTIFACT" ]; then
-            # multi-arch artifacts (gox layout <arch>/<os>/) need the runner's arch;
-            # fall back to any match for flat single-binary artifacts
-            bin="$(find ziti-artifact -type f -path "*${ZITI_ARCH}*" -name "$ZITI_BIN_NAME" | head -1)"
-            [ -n "$bin" ] || bin="$(find ziti-artifact -type f -name "$ZITI_BIN_NAME" | head -1)"
-            [ -n "$bin" ] || { echo "no $ZITI_BIN_NAME in artifact ${{ matrix.os.ziti-os }}-$ZITI_ARTIFACT" >&2; exit 1; }
-            chmod +x "$bin" || true
+            # multi-arch artifacts (gox layout release/<arch>/<os>/) need the runner's arch;
+            # fall back to any match for a flat single-binary artifact from another caller
+            arch=$(uname -m); [ "$arch" = "x86_64" ] && arch=amd64
+            path="$(find ziti-artifact -type f -path "*/${arch}/*" -name "$bin" | head -1)"
+            [ -n "$path" ] || path="$(find ziti-artifact -type f -name "$bin" | head -1)"
+            [ -n "$path" ] || { echo "no $bin in artifact ${{ matrix.os.ziti-os }}-$ZITI_ARTIFACT" >&2; exit 1; }
+            chmod +x "$path" || true
             # On Windows the consumer is PowerShell, which can't resolve an MSYS
             # /d/a/... path; pwd -W emits a Windows path it accepts.
             if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
-            echo "ZITI_BIN=$base/$bin" >> "$GITHUB_ENV"
+            echo "ZITI_BIN=$base/$path" >> "$GITHUB_ENV"
           else
-            echo "ZITI_BIN=$RUNNER_TEMP/ziti-cli/bin/$ZITI_BIN_NAME" >> "$GITHUB_ENV"
+            echo "ZITI_BIN=$RUNNER_TEMP/ziti-cli/bin/$bin" >> "$GITHUB_ENV"
           fi
 
       - name: Run integration tests (Linux/macOS)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,11 +17,15 @@ on:
         type: string
         default: ""
       zet1-version:
-        description: "ziti-edge-tunnel release tag for zetA; empty = the binary built by cmake"
+        description: "ziti-edge-tunnel release tag for zetA, or 'latest' for the release GitHub marks Latest; empty = the binary built by cmake"
         type: string
         default: ""
       zet2-version:
-        description: "ziti-edge-tunnel release tag for zetB; empty = same binary as zetA"
+        description: "ziti-edge-tunnel release tag for zetB, or 'latest'; empty = same binary as zetA"
+        type: string
+        default: ""
+      ziti-artifact:
+        description: "name prefix of per-OS artifacts (<prefix>-linux|darwin|windows) holding a ziti binary, uploaded earlier in the caller's run; overrides ziti-version"
         type: string
         default: ""
       tests-repo:
@@ -41,18 +45,24 @@ jobs:
             artifact: linux-x64
             zet-zip: ziti-edge-tunnel-Linux_x86_64.zip
             zet-bin: ziti-edge-tunnel
+            ziti-os: linux
+            ziti-bin: ziti
             core-dir: /tmp/cores
           - name: macOS arm64
             runner: macos-15
             artifact: macOS-arm64
             zet-zip: ziti-edge-tunnel-Darwin_arm64.zip
             zet-bin: ziti-edge-tunnel
+            ziti-os: darwin
+            ziti-bin: ziti
             core-dir: /cores
           - name: Windows x64
             runner: windows-2022
             artifact: windows-x64-mingw
             zet-zip: ziti-edge-tunnel-Windows_x86_64.zip
             zet-bin: ziti-edge-tunnel.exe
+            ziti-os: windows
+            ziti-bin: ziti.exe
             core-dir: ""
     runs-on: ${{ matrix.os.runner }}
     steps:
@@ -126,6 +136,7 @@ jobs:
 
       # CI resolves ziti via openziti's setup-cli action; downstream tests run against any ziti.
       - name: Resolve ziti
+        if: inputs.ziti-artifact == ''
         uses: openziti/ziti/setup-cli@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -133,12 +144,39 @@ jobs:
           version: ${{ (inputs.ziti-version == '' || inputs.ziti-version == 'main') && 'stable' || inputs.ziti-version }}
           ref: ${{ inputs.ziti-version == 'main' && 'main' || '' }}
 
+      # Built by the caller's run; tests the exact ziti bits the caller produced.
+      - name: Download ziti artifact
+        if: inputs.ziti-artifact != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.ziti-artifact }}-${{ matrix.os.ziti-os }}
+          path: ./ziti-artifact
+          digest-mismatch: error
+
+      - name: Set ZITI_BIN
+        shell: bash
+        env:
+          ZITI_ARTIFACT: ${{ inputs.ziti-artifact }}
+          ZITI_BIN_NAME: ${{ matrix.os.ziti-bin }}
+        run: |
+          set -euo pipefail
+          if [ -n "$ZITI_ARTIFACT" ]; then
+            bin="$(find ziti-artifact -type f -name "$ZITI_BIN_NAME" | head -1)"
+            [ -n "$bin" ] || { echo "no $ZITI_BIN_NAME in artifact $ZITI_ARTIFACT-${{ matrix.os.ziti-os }}" >&2; exit 1; }
+            chmod +x "$bin" || true
+            # On Windows the consumer is PowerShell, which can't resolve an MSYS
+            # /d/a/... path; pwd -W emits a Windows path it accepts.
+            if [ "$RUNNER_OS" = "Windows" ]; then base="$(pwd -W)"; else base="$PWD"; fi
+            echo "ZITI_BIN=$base/$bin" >> "$GITHUB_ENV"
+          else
+            echo "ZITI_BIN=$RUNNER_TEMP/ziti-cli/bin/$ZITI_BIN_NAME" >> "$GITHUB_ENV"
+          fi
+
       - name: Run integration tests (Linux/macOS)
         if: runner.os != 'Windows'
         shell: bash
         env:
           TEST_HOME: ${{ runner.temp }}
-          ZITI_BIN: ${{ runner.temp }}/ziti-cli/bin/ziti
           IDP_VERSION: ${{ inputs.idp-version }}
         run: ./tests/integration/scripts/run-ci.sh --install-cert
 
@@ -147,7 +185,6 @@ jobs:
         shell: pwsh
         env:
           TEST_HOME: ${{ runner.temp }}
-          ZITI_BIN: ${{ runner.temp }}/ziti-cli/bin/ziti.exe
           IDP_VERSION: ${{ inputs.idp-version }}
         run: .\tests\integration\scripts\run-ci.ps1 -InstallCert
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,6 @@
 # callable workflow's jobs appear in the calling workflow's run, so clicking this workflow in GitHub shows no runs
 #
-# The ZET/Ziti binaries under test come from exactly one source each:
+# The ZET/Ziti binaries under test come from:
 #   ziti: ziti-artifact > ziti-ref (build from source) > ziti-version (download a release; empty = stable)
 #   ZET:  zet1-version (download a release, 'latest' = the GitHub Latest release; empty = the cmake artifact built by the caller's run)
 name: Callable Integration Tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,6 +24,10 @@ on:
         description: "ziti-edge-tunnel release tag for zetB; empty = same binary as zetA"
         type: string
         default: ""
+      tests-repo:
+        description: "repo to check the test suite out from, at the same commit as this workflow file; cross-repo callers set this (checkout defaults to the calling repo)"
+        type: string
+        default: ""
 
 jobs:
   integration-tests:
@@ -55,6 +59,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          repository: ${{ inputs.tests-repo || github.repository }}
+          # job_workflow_sha = the commit this workflow file was loaded from, so a
+          # cross-repo caller's @ref selects the workflow and the test sources together.
+          ref: ${{ inputs.tests-repo != '' && github.job_workflow_sha || '' }}
           fetch-depth: 0
 
       - name: Set up Go

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,12 @@ on:
         description: "ziti release tag to test against (e.g. v2.0.0); blank = newest + v2.0/v1.6 matrix"
         required: false
         default: ""
-      zet1_version:
-        description: "ziti-edge-tunnel release tag for zet1/zetA; blank = build from this branch"
+      zetA_version:
+        description: "ziti-edge-tunnel release tag for zetA; blank = build from this branch"
         required: false
         default: ""
-      zet2_version:
-        description: "ziti-edge-tunnel release tag for zet2/zetB; blank = same binary as zet1"
+      zetB_version:
+        description: "ziti-edge-tunnel release tag for zetB; blank = same binary as zetA"
         required: false
         default: ""
       idp_version:
@@ -126,8 +126,8 @@ jobs:
       ziti-version: ${{ matrix.ziti-channel.tag }}
       label: ${{ matrix.ziti-channel.label }}
       idp-version: ${{ inputs.idp_version }}
-      zet1-version: ${{ inputs.zet1_version }}
-      zet2-version: ${{ inputs.zet2_version }}
+      zetA-version: ${{ inputs.zetA_version }}
+      zetB-version: ${{ inputs.zetB_version }}
     secrets: inherit
 
   nix-build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
     needs: [ call-cmake-build ]
     uses: ./.github/workflows/integration-tests.yml
     with:
-      ziti-version: main
+      ziti-ref: main
       label: main
     secrets: inherit
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -241,4 +241,8 @@ ZET_BIN=/path/to/ziti-edge-tunnel ZITI_BIN=/path/to/ziti ./scripts/run-ci.sh
 $env:ZET_BIN = "C:\path\to\ziti-edge-tunnel.exe"; $env:ZITI_BIN = "C:\path\to\ziti.exe"; .\scripts\run-ci.ps1
 ```
 
-They require `ZET_BIN` and `ZITI_BIN` and run against whatever those point at. Obtaining ziti is a CI concern: the workflow downloads a release (or builds `openziti/ziti` main for the nightly) and passes `ZITI_BIN` in. They also honor `TEST_HOME`, `IDP_VERSION`, `ZET1_VERSION`, `ZET2_VERSION`, and a `--install-cert` / `-InstallCert` flag that installs the overlay CA for the run and removes it afterward. Without that flag they leave your trust store untouched.
+They require `ZET_BIN` and `ZITI_BIN` and run against whatever those point at. Obtaining the binaries is a CI
+concern: the workflow resolves ziti (a release or a main build) and ZET (the cmake artifact or a release named by
+`zet1-version`/`zet2-version`) and passes `ZITI_BIN`, `ZET_BIN`, and optionally `ZET_BIN_B` in. They also honor
+`TEST_HOME`, `IDP_VERSION`, and a `--install-cert` / `-InstallCert` flag that installs the overlay CA for the run and
+removes it afterward. Without that flag they leave your trust store untouched.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -241,8 +241,6 @@ ZET_BIN=/path/to/ziti-edge-tunnel ZITI_BIN=/path/to/ziti ./scripts/run-ci.sh
 $env:ZET_BIN = "C:\path\to\ziti-edge-tunnel.exe"; $env:ZITI_BIN = "C:\path\to\ziti.exe"; .\scripts\run-ci.ps1
 ```
 
-They require `ZET_BIN` and `ZITI_BIN` and run against whatever those point at. Obtaining the binaries is a CI
-concern: the workflow resolves ziti (a release or a main build) and ZET (the cmake artifact or a release named by
-`zet1-version`/`zet2-version`) and passes `ZITI_BIN`, `ZET_BIN`, and optionally `ZET_BIN_B` in. They also honor
-`TEST_HOME`, `IDP_VERSION`, and a `--install-cert` / `-InstallCert` flag that installs the overlay CA for the run and
-removes it afterward. Without that flag they leave your trust store untouched.
+Point `ZET_BIN`, `ZITI_BIN`, and optionally `ZET_BIN_B` at the binaries you want to test. The scripts run against any ziti and any ZET v1.17.0 or newer.  
+In CI the workflow supplies these paths, downloading or building ziti and ZET according to its inputs (a release tag, a source ref, or a build artifact).   
+`TEST_HOME` and `IDP_VERSION` override the working directory and the dex version. `--install-cert` / `-InstallCert` installs the overlay CA into OS trust for the run and removes it on exit. Without it, tests requiring OS trust are skipped.

--- a/tests/integration/scripts/fetch-dex.ps1
+++ b/tests/integration/scripts/fetch-dex.ps1
@@ -48,7 +48,8 @@ Push-Location $srcDir
 try {
     # Force auto-toolchain so Go downloads whatever version dex's go.mod requires.
     $env:GOTOOLCHAIN = "auto"
-    & go build -o $dexExe ./cmd/dex
+    # dex stamps its version via ldflags (see its Makefile); plain go build reports DEV
+    & go build -ldflags "-X main.version=$Version" -o $dexExe ./cmd/dex
     if ($LASTEXITCODE -ne 0) { throw "go build failed (exit $LASTEXITCODE)" }
 } finally {
     Pop-Location

--- a/tests/integration/scripts/fetch-dex.sh
+++ b/tests/integration/scripts/fetch-dex.sh
@@ -56,7 +56,8 @@ echo "building $bin_name -> $dex_bin"
 (
     cd "$src_dir"
     # Force auto-toolchain so Go downloads whatever version dex's go.mod requires.
-    GOTOOLCHAIN=auto go build -o "$dex_bin" ./cmd/dex
+    # dex stamps its version via ldflags (see its Makefile); plain go build reports DEV
+    GOTOOLCHAIN=auto go build -ldflags "-X main.version=$VERSION" -o "$dex_bin" ./cmd/dex
 )
 
 echo

--- a/tests/integration/scripts/run-ci.ps1
+++ b/tests/integration/scripts/run-ci.ps1
@@ -75,6 +75,11 @@ $zetBinB = if ($env:ZET_BIN_B) { $env:ZET_BIN_B } else { $zetBin }
 Write-Host "ZET_BIN=$zetBin"
 Write-Host "ZET_BIN_B=$zetBinB"
 
+Write-Host "ziti version: $(& $zitiBin version)"
+Write-Host "zetA version: $(& $zetBin version)"
+Write-Host "zetB version: $(& $zetBinB version)"
+Write-Host "dex version:  $(& $idpBin version | Select-Object -First 1)"
+
 # ---- Seed test overlay PKI --------------------------------------------------
 # Seed at $testHome\overlay (where the test framework's own quickstart runs)
 # so its second quickstart reuses this PKI, ensuring the cert we install into

--- a/tests/integration/scripts/run-ci.ps1
+++ b/tests/integration/scripts/run-ci.ps1
@@ -3,21 +3,20 @@ Run the integration test suite end-to-end the same way CI does on Windows.
 Lets a local dev reproduce a CI failure with one command.
 
 Required input:
-  $env:ZET_BIN   Absolute path to a built ziti-edge-tunnel.exe.
+  $env:ZET_BIN   Absolute path to a ziti-edge-tunnel.exe.
   $env:ZITI_BIN  Absolute path to a ziti binary. CI obtains it (a release or a main build).
 
 Optional input:
   $env:TEST_HOME      Working dir for overlay, logs, caches. Defaults to a temp dir.
   $env:IDP_VERSION    dex version tag (default: fetch-dex.sh's pinned version).
-  $env:ZET1_VERSION   If set, downloads this ZET release and uses it as ZET_BIN.
-  $env:ZET2_VERSION   If set, downloads this ZET release and uses it as ZET_BIN_B.
+  $env:ZET_BIN_B      ziti-edge-tunnel.exe for zetB. Defaults to ZET_BIN.
 
 Flags:
   -InstallCert  Install the test overlay CA into OS trust for the run and remove
                 it on exit. Off by default so the script does not mutate a normal
                 user's trust store.
 
-Requires: go, gh. Run as Administrator when using -InstallCert, because
+Requires: go. Run as Administrator when using -InstallCert, because
 installing the test overlay CA into Cert:\LocalMachine\Root requires it.
 #>
 
@@ -40,7 +39,7 @@ if (-not (Test-Path $env:ZITI_BIN)) {
     Write-Error "ZITI_BIN=$($env:ZITI_BIN) does not exist"
 }
 
-foreach ($tool in @("go", "gh")) {
+foreach ($tool in @("go")) {
     if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
         Write-Error "missing required tool: $tool"
     }
@@ -71,29 +70,8 @@ if ($LASTEXITCODE -ne 0) { Write-Error "fetch-dex.ps1 failed (exit $LASTEXITCODE
 $idpBin = Join-Path $dexDir "dex.exe"
 Write-Host "IDP_BIN=$idpBin"
 
-# ---- Optional ZET release overrides -----------------------------------------
 $zetBin = $env:ZET_BIN
 $zetBinB = if ($env:ZET_BIN_B) { $env:ZET_BIN_B } else { $zetBin }
-$zetZip = "ziti-edge-tunnel-Windows_x86_64.zip"
-
-if ($env:ZET1_VERSION) {
-    $d = Join-Path $testHome "zet1"
-    New-Item -ItemType Directory -Path $d -Force | Out-Null
-    Push-Location $d
-    gh release download --repo openziti/ziti-tunnel-sdk-c $env:ZET1_VERSION --pattern $zetZip --clobber
-    Expand-Archive -Path (Join-Path $d $zetZip) -DestinationPath . -Force
-    $zetBin = (Get-ChildItem -Recurse -Filter "ziti-edge-tunnel.exe" | Select-Object -First 1).FullName
-    Pop-Location
-}
-if ($env:ZET2_VERSION) {
-    $d = Join-Path $testHome "zet2"
-    New-Item -ItemType Directory -Path $d -Force | Out-Null
-    Push-Location $d
-    gh release download --repo openziti/ziti-tunnel-sdk-c $env:ZET2_VERSION --pattern $zetZip --clobber
-    Expand-Archive -Path (Join-Path $d $zetZip) -DestinationPath . -Force
-    $zetBinB = (Get-ChildItem -Recurse -Filter "ziti-edge-tunnel.exe" | Select-Object -First 1).FullName
-    Pop-Location
-}
 Write-Host "ZET_BIN=$zetBin"
 Write-Host "ZET_BIN_B=$zetBinB"
 

--- a/tests/integration/scripts/run-ci.ps1
+++ b/tests/integration/scripts/run-ci.ps1
@@ -75,10 +75,10 @@ $zetBinB = if ($env:ZET_BIN_B) { $env:ZET_BIN_B } else { $zetBin }
 Write-Host "ZET_BIN=$zetBin"
 Write-Host "ZET_BIN_B=$zetBinB"
 
-Write-Host "ziti version: $(& $zitiBin version)"
-Write-Host "zetA version: $(& $zetBin version)"
-Write-Host "zetB version: $(& $zetBinB version)"
-Write-Host "dex version:  $(& $idpBin version | Select-Object -First 1)"
+Write-Host "Ziti Version: $(& $zitiBin version)"
+Write-Host "ZetA Version: $(& $zetBin version)"
+Write-Host "ZetB Version: $(& $zetBinB version)"
+Write-Host "$(& $idpBin version | Select-Object -First 1)"
 
 # ---- Seed test overlay PKI --------------------------------------------------
 # Seed at $testHome\overlay (where the test framework's own quickstart runs)

--- a/tests/integration/scripts/run-ci.sh
+++ b/tests/integration/scripts/run-ci.sh
@@ -62,10 +62,11 @@ ZET_BIN_B="${ZET_BIN_B:-$ZET_BIN}"
 echo "ZET_BIN=$ZET_BIN"
 echo "ZET_BIN_B=$ZET_BIN_B"
 
-echo "ziti version: $("$ZITI_BIN" version)"
-echo "zetA version: $("$ZET_BIN" version)"
-echo "zetB version: $("$ZET_BIN_B" version)"
-echo "dex version:  $("$IDP_BIN" version | head -1)"
+# Logging only; never let a binary that mishandles `version` abort the suite.
+echo "Ziti Version: $("$ZITI_BIN" version || true)"
+echo "ZetA Version: $("$ZET_BIN" version || true)"
+echo "ZetB Version: $("$ZET_BIN_B" version || true)"
+echo "$("$IDP_BIN" version 2>/dev/null | head -1 || true)"
 
 # ---- Create ziti group + configure core dumps --------------------------------
 case "$(uname -s)" in

--- a/tests/integration/scripts/run-ci.sh
+++ b/tests/integration/scripts/run-ci.sh
@@ -36,7 +36,7 @@ if [ ! -x "$ZET_BIN" ]; then
   exit 1
 fi
 
-for tool in go jq curl; do
+for tool in go jq curl sudo; do
   command -v "$tool" >/dev/null || { echo "missing required tool: $tool" >&2; exit 1; }
 done
 

--- a/tests/integration/scripts/run-ci.sh
+++ b/tests/integration/scripts/run-ci.sh
@@ -3,21 +3,20 @@
 # local dev reproduce a CI failure with one command.
 #
 # Required input:
-#   ZET_BIN   Absolute path to a built ziti-edge-tunnel binary.
+#   ZET_BIN   Absolute path to a ziti-edge-tunnel binary.
 #   ZITI_BIN  Absolute path to a ziti binary. CI obtains it (a release or a main build).
 #
 # Optional input:
 #   TEST_HOME      Working dir for overlay, logs, caches. Defaults to a temp dir.
 #   IDP_VERSION    dex version tag (default: fetch-dex.sh's pinned version).
-#   ZET1_VERSION   If set, downloads this ZET release and uses it as ZET_BIN.
-#   ZET2_VERSION   If set, downloads this ZET release and uses it as ZET_BIN_B.
+#   ZET_BIN_B      ziti-edge-tunnel binary for zetB. Defaults to ZET_BIN.
 #
 # Flags:
 #   --install-cert  Install the test overlay CA into OS trust for the run and
 #                   remove it on exit. Off by default so the script does not
 #                   mutate a normal user's trust store.
 #
-# Requires:  go, gh, jq, curl, unzip, and sudo (Linux/macOS).
+# Requires:  go, jq, curl, and sudo (Linux/macOS).
 
 set -euo pipefail
 
@@ -37,16 +36,9 @@ if [ ! -x "$ZET_BIN" ]; then
   exit 1
 fi
 
-for tool in go gh jq curl unzip; do
+for tool in go jq curl; do
   command -v "$tool" >/dev/null || { echo "missing required tool: $tool" >&2; exit 1; }
 done
-
-case "$(uname -s)-$(uname -m)" in
-  Linux-x86_64)   ZET_ZIP="ziti-edge-tunnel-Linux_x86_64.zip";  ZET_BIN_NAME="ziti-edge-tunnel" ;;
-  Darwin-arm64)   ZET_ZIP="ziti-edge-tunnel-Darwin_arm64.zip"; ZET_BIN_NAME="ziti-edge-tunnel" ;;
-  Darwin-x86_64)  ZET_ZIP="ziti-edge-tunnel-Darwin_x86_64.zip"; ZET_BIN_NAME="ziti-edge-tunnel" ;;
-  *) echo "unsupported os/arch: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
-esac
 
 TEST_HOME="${TEST_HOME:-$(mktemp -d -t ziti-tunnel-test.XXXXXX)}"
 mkdir -p "$TEST_HOME"
@@ -66,20 +58,7 @@ DEST="$DEX_DIR" "$REPO_ROOT/tests/integration/scripts/fetch-dex.sh"
 IDP_BIN="$DEX_DIR/dex"
 echo "IDP_BIN=$IDP_BIN"
 
-# ---- Optional ZET release overrides ------------------------------------------
 ZET_BIN_B="${ZET_BIN_B:-$ZET_BIN}"
-if [ -n "${ZET1_VERSION:-}" ]; then
-  d="$TEST_HOME/zet1"; mkdir -p "$d"
-  (cd "$d" && gh release download --repo openziti/ziti-tunnel-sdk-c "$ZET1_VERSION" --pattern "$ZET_ZIP" --clobber && unzip -o "$ZET_ZIP")
-  ZET_BIN="$d/$ZET_BIN_NAME"
-  chmod +x "$ZET_BIN"
-fi
-if [ -n "${ZET2_VERSION:-}" ]; then
-  d="$TEST_HOME/zet2"; mkdir -p "$d"
-  (cd "$d" && gh release download --repo openziti/ziti-tunnel-sdk-c "$ZET2_VERSION" --pattern "$ZET_ZIP" --clobber && unzip -o "$ZET_ZIP")
-  ZET_BIN_B="$d/$ZET_BIN_NAME"
-  chmod +x "$ZET_BIN_B"
-fi
 echo "ZET_BIN=$ZET_BIN"
 echo "ZET_BIN_B=$ZET_BIN_B"
 

--- a/tests/integration/scripts/run-ci.sh
+++ b/tests/integration/scripts/run-ci.sh
@@ -62,6 +62,11 @@ ZET_BIN_B="${ZET_BIN_B:-$ZET_BIN}"
 echo "ZET_BIN=$ZET_BIN"
 echo "ZET_BIN_B=$ZET_BIN_B"
 
+echo "ziti version: $("$ZITI_BIN" version)"
+echo "zetA version: $("$ZET_BIN" version)"
+echo "zetB version: $("$ZET_BIN_B" version)"
+echo "dex version:  $("$IDP_BIN" version | head -1)"
+
 # ---- Create ziti group + configure core dumps --------------------------------
 case "$(uname -s)" in
   Linux)


### PR DESCRIPTION
- ZET binary resolution moves out of the run-ci scripts and into the workflow
- Ziti can be sourced from a release tag, a source ref (built from source), or a build artifact
- ZET from a release tag ('latest' = GitHub Latest) or the cmake artifact built in the caller's run - note that integration tests will fail pre ZET v1.17.0: don't call 'latest' until 'latest' >= v1.17.0
- tests-repo input lets another repo run ZET integration tests