### PR TITLE
Gate zetB and t2t tests on ZET 1.17.0 multi-tunnel support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,11 +113,10 @@ jobs:
             Windows) ZET_ZIP=ziti-edge-tunnel-Windows_x86_64.zip ;;
           esac
           fetch() {
-            # 'latest' = the release GitHub marks Latest; gh downloads it when no tag is given
-            local tag=("$1")
-            if [ "$1" = "latest" ]; then tag=(); fi
+            # 'latest' = the release GitHub marks Latest; gh downloads it when no tag is given.
+            local tag="$1"; [ "$1" = "latest" ] && tag=""
             mkdir -p "$2"
-            (cd "$2" && gh release download --repo openziti/ziti-tunnel-sdk-c "${tag[@]}" --pattern "$ZET_ZIP" --clobber && unzip -o "$ZET_ZIP")
+            (cd "$2" && gh release download --repo openziti/ziti-tunnel-sdk-c ${tag:+"$tag"} --pattern "$ZET_ZIP" --clobber && unzip -o "$ZET_ZIP")
             chmod +x "$2/$ZET_BIN_NAME" || true
           }
           # On Windows the consumer is PowerShell, which can't resolve an MSYS

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -246,32 +246,41 @@ func doSetup(state TestState) error {
 		return fmt.Errorf("wipe shared identity dir: %w", err)
 	}
 
-	log.Printf("setup: starting ZET zetA and zetB in parallel")
-	var zetClientErr, zetHostErr error
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		zetClientErr = state.zetClient.Start()
-		if zetClientErr != nil {
-			log.Printf("zet[%s]: start failed: %v; retrying once", state.zetClient.Discriminator, zetClientErr)
-			zetClientErr = state.zetClient.Start()
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		zetHostErr = state.zetHost.Start()
-		if zetHostErr != nil {
-			log.Printf("zet[%s]: start failed: %v; retrying once", state.zetHost.Discriminator, zetHostErr)
-			zetHostErr = state.zetHost.Start()
-		}
-	}()
-	wg.Wait()
-	if zetClientErr != nil {
-		return fmt.Errorf("start ziti-edge-tunnel: %w", zetClientErr)
+	// Multi-tunnel works on every OS when ZET >= 1.17.0
+	// Tests against an older ZET start only zetA and skip t2t tests.
+	if err := state.zetClient.ProbeVersion(); err != nil {
+		return fmt.Errorf("probe zetA version: %w", err)
 	}
-	if zetHostErr != nil {
-		return fmt.Errorf("start zetB: %w", zetHostErr)
+	if err := state.zetHost.ProbeVersion(); err != nil {
+		return fmt.Errorf("probe zetB version: %w", err)
+	}
+	zets := []*testutil.ZET{state.zetClient}
+	if state.zetClient.SupportsMultiTunnel() && state.zetHost.SupportsMultiTunnel() {
+		zets = append(zets, state.zetHost)
+	} else {
+		log.Printf("setup: ZET predates multi-tunnel (zetA=%s zetB=%s, need >= 1.17.0) - starting zetA, t2t tests will skip",
+			state.zetClient.Version, state.zetHost.Version)
+	}
+
+	log.Printf("setup: starting %d ZET(s)", len(zets))
+	errs := make([]error, len(zets))
+	var wg sync.WaitGroup
+	for i := range zets {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			z := zets[i]
+			if err := z.Start(); err != nil {
+				log.Printf("zet[%s]: start failed: %v; retrying once", z.Discriminator, err)
+				errs[i] = z.Start()
+			}
+		}(i)
+	}
+	wg.Wait()
+	for i := range zets {
+		if errs[i] != nil {
+			return fmt.Errorf("start zet[%s]: %w", zets[i].Discriminator, errs[i])
+		}
 	}
 
 	log.Printf("setup: starting IdP (useTestHarnessIdP=%t bin=%s issuer=%s)", state.idp.UseTestHarnessIdP, state.idp.Bin, state.idp.IssuerURL)

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -258,8 +258,7 @@ func doSetup(state TestState) error {
 	if state.zetClient.SupportsMultiTunnel() && state.zetHost.SupportsMultiTunnel() {
 		zets = append(zets, state.zetHost)
 	} else {
-		log.Printf("setup: ZET predates multi-tunnel (zetA=%s zetB=%s, need >= 1.17.0) - starting zetA, t2t tests will skip",
-			state.zetClient.Version, state.zetHost.Version)
+		log.Printf("setup: ZET predates multi-tunnel (zetA=%d.%d zetB=%d.%d, need >= 1.17.0) - starting zetA, t2t tests will skip", state.zetClient.Major, state.zetClient.Minor, state.zetHost.Major, state.zetHost.Minor)
 	}
 
 	log.Printf("setup: starting %d ZET(s)", len(zets))

--- a/tests/integration/testutil/common.go
+++ b/tests/integration/testutil/common.go
@@ -26,6 +26,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -170,4 +171,21 @@ func SetupWorkingExtJwtSigner(t *testing.T, overlay *Overlay, idp *IdP) (string,
 		Scopes:   strings.Fields(idp.Scopes),
 	})
 	return workingExtJwtSignerName, id
+}
+
+// parseVersion splits a "vX.XX.X" style version into its major and minor numbers.
+func parseVersion(version string) (int, int, error) {
+	parts := strings.Split(strings.TrimPrefix(version, "v"), ".")
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("unparsable version %q", version)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("unparsable version %q: %w", version, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("unparsable version %q: %w", version, err)
+	}
+	return major, minor, nil
 }

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -29,7 +29,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -157,24 +156,11 @@ func warnIfPortBound(port uint16) {
 }
 
 func probeZitiVersion(zitiBin string) (int, int, error) {
-	out, err := exec.Command(zitiBin, "--version").Output()
+	version, err := exec.Command(zitiBin, "--version").Output()
 	if err != nil {
 		return 0, 0, fmt.Errorf("run %s --version: %w", zitiBin, err)
 	}
-	version := strings.TrimPrefix(strings.TrimSpace(string(out)), "v")
-	parts := strings.Split(version, ".")
-	if len(parts) < 2 {
-		return 0, 0, fmt.Errorf("parse ziti version from %q", string(out))
-	}
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return 0, 0, fmt.Errorf("parse major from %q: %w", parts[0], err)
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, 0, fmt.Errorf("parse minor from %q: %w", parts[1], err)
-	}
-	return major, minor, nil
+	return parseVersion(strings.TrimSpace(string(version)))
 }
 
 func (o *Overlay) ControllerHostPort() string {

--- a/tests/integration/testutil/zet.go
+++ b/tests/integration/testutil/zet.go
@@ -52,6 +52,8 @@ type ZET struct {
 	// TlsuvDebug, if > 0, sets the TLSUV_DEBUG env var (0=off..6=trace) for
 	// debugging TLS handshake / cert chain issues.
 	TlsuvDebug int
+	// Version is this binary's reported version set by ProbeVersion.
+	Version string
 
 	cmd     *exec.Cmd
 	stdout  *syncBuffer
@@ -170,6 +172,40 @@ func (z *ZET) Stop() {
 		}
 	}
 	log.Fatalf("ZET pid %d did not exit within 60s of Kill; orphan likely, aborting test run", pid)
+}
+
+// ProbeVersion runs `ziti-edge-tunnel version` and records the reported version.
+func (z *ZET) ProbeVersion() error {
+	out, err := exec.Command(z.BinPath, "version").Output()
+	if err != nil {
+		return fmt.Errorf("run %s version: %w", z.BinPath, err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if v := strings.TrimSpace(line); strings.HasPrefix(v, "v") {
+			z.Version = v
+			return nil
+		}
+	}
+	return fmt.Errorf("no version line in %q from %s version", string(out), z.BinPath)
+}
+
+// SupportsMultiTunnel reports whether this ZET can run beside a second ZET on the same host.
+// Multi-tunnel works on every OS when ZET >= 1.17.0
+// An unparsable version is treated as unsupported. Requires version number set by ProbeVersion()
+func (z *ZET) SupportsMultiTunnel() bool {
+	parts := strings.Split(strings.TrimPrefix(z.Version, "v"), ".")
+	if len(parts) < 2 {
+		return false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	return major > 1 || (major == 1 && minor >= 17)
 }
 
 // Restart stops the process and starts it again against the same identity dir.

--- a/tests/integration/testutil/zet.go
+++ b/tests/integration/testutil/zet.go
@@ -52,8 +52,9 @@ type ZET struct {
 	// TlsuvDebug, if > 0, sets the TLSUV_DEBUG env var (0=off..6=trace) for
 	// debugging TLS handshake / cert chain issues.
 	TlsuvDebug int
-	// Version is this binary's reported version set by ProbeVersion.
-	Version string
+	// Major and Minor are this binary's version, set by ProbeVersion.
+	Major int
+	Minor int
 
 	cmd     *exec.Cmd
 	stdout  *syncBuffer
@@ -182,7 +183,10 @@ func (z *ZET) ProbeVersion() error {
 	}
 	for _, line := range strings.Split(string(out), "\n") {
 		if v := strings.TrimSpace(line); strings.HasPrefix(v, "v") {
-			z.Version = v
+			z.Major, z.Minor, err = parseVersion(v)
+			if err != nil {
+				return fmt.Errorf("%s version: %w", z.BinPath, err)
+			}
 			return nil
 		}
 	}
@@ -190,22 +194,9 @@ func (z *ZET) ProbeVersion() error {
 }
 
 // SupportsMultiTunnel reports whether this ZET can run beside a second ZET on the same host.
-// Multi-tunnel works on every OS when ZET >= 1.17.0
-// An unparsable version is treated as unsupported. Requires version number set by ProbeVersion()
+// Multi-tunnel works on every OS when ZET >= 1.17.0. Requires version set by ProbeVersion.
 func (z *ZET) SupportsMultiTunnel() bool {
-	parts := strings.Split(strings.TrimPrefix(z.Version, "v"), ".")
-	if len(parts) < 2 {
-		return false
-	}
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return false
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return false
-	}
-	return major > 1 || (major == 1 && minor >= 17)
+	return z.Major > 1 || (z.Major == 1 && z.Minor >= 17)
 }
 
 // Restart stops the process and starts it again against the same identity dir.

--- a/tests/integration/tunneler_to_tunneler_test.go
+++ b/tests/integration/tunneler_to_tunneler_test.go
@@ -29,12 +29,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// requireMultiTunnel skips when either ZET predates multi-tunnel support
+func requireMultiTunnel(t *testing.T) {
+	if state.zetClient.SupportsMultiTunnel() && state.zetHost.SupportsMultiTunnel() {
+		return
+	}
+	t.Skipf("multi-tunnel requires ZET >= 1.17.0; zetA=%s zetB=%s", state.zetClient.Version, state.zetHost.Version)
+}
+
 // TestTunnelerToTunnelerTCP exercises the TCP data plane with two run-mode ZETs.
 // One ZET intercepts the client-side TCP connection; the other hosts the service
 // and forwards to a local echo backend.
 //
 // Requires root/CAP_NET_ADMIN — both ZETs open TUN devices.
 func TestTunnelerToTunnelerTCP(t *testing.T) {
+	requireMultiTunnel(t)
 	t.Run("zetA_intercepts_zetB_hosts", func(t *testing.T) {
 		testT2TTCP(t, state.zetClient, state.zetHost, "100.64.0.10", 21000)
 	})
@@ -47,6 +56,7 @@ func TestTunnelerToTunnelerTCP(t *testing.T) {
 //
 // Requires root/CAP_NET_ADMIN — both ZETs open TUN devices.
 func TestTunnelerToTunnelerUDP(t *testing.T) {
+	requireMultiTunnel(t)
 	t.Run("zetA_intercepts_zetB_hosts", func(t *testing.T) {
 		testT2TUDP(t, state.zetClient, state.zetHost, "100.64.0.11", 22000)
 	})

--- a/tests/integration/tunneler_to_tunneler_test.go
+++ b/tests/integration/tunneler_to_tunneler_test.go
@@ -34,7 +34,7 @@ func requireMultiTunnel(t *testing.T) {
 	if state.zetClient.SupportsMultiTunnel() && state.zetHost.SupportsMultiTunnel() {
 		return
 	}
-	t.Skipf("multi-tunnel requires ZET >= 1.17.0; zetA=%s zetB=%s", state.zetClient.Version, state.zetHost.Version)
+	t.Skipf("multi-tunnel requires ZET >= 1.17.0; zetA=%d.%d zetB=%d.%d", state.zetClient.Major, state.zetClient.Minor, state.zetHost.Major, state.zetHost.Minor)
 }
 
 // TestTunnelerToTunnelerTCP exercises the TCP data plane with two run-mode ZETs.


### PR DESCRIPTION
Multi-tunnel tests for Windows + Linux + Mac need ZET 1.17.0+, so the harness now probes the ZET version, starts only zetA against older builds, and skips the tunneler-to-tunneler tests. 
In general, the test suite requires ZET 1.16.0+ to avoid changing the commands that start Zet A/B based on version