### PR TITLE
Add integration tests for MFA recovery-code commands

### DIFF
--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -45,6 +45,7 @@ func TestRemoveMFA(t *testing.T) {
 func TestMFARecoveryCodes(t *testing.T) {
 	t.Run("getMfaCodesReturnsValidCodes", getMfaCodesReturnsValidCodes)
 	t.Run("recoveryRejectsOldCodeAfterRegeneration", recoveryRejectsOldCodeAfterRegeneration)
+	t.Run("recoveryRejectsAfterAllCodesExhausted", recoveryRejectsAfterAllCodesExhausted)
 }
 
 func enrollCompletesWithTotpRequiredPolicy(t *testing.T) {
@@ -218,6 +219,30 @@ func getMfaCodesReturnsValidCodes(t *testing.T) {
 		getResp.AssertSuccess()
 
 		require.ElementsMatch(t, enrollment.RecoveryCodes, getResp.Data.RecoveryCodes)
+	})
+}
+
+func recoveryRejectsAfterAllCodesExhausted(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, 2*time.Minute, func(t *testing.T) {
+		idName := "test_mfa_exhaust_recovery_codes"
+		enrollment, _ := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
+
+		for _, code := range enrollment.RecoveryCodes {
+			state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
+			state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+
+			submitResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, code)
+			submitResp.AssertSuccess()
+
+			updatedEvent := state.zetClient.WaitForIdentityEvent(t, "updated", idName)
+			updatedEvent.AssertMfaAuthenticated()
+		}
+
+		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
+		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+
+		exhaustedResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, enrollment.RecoveryCodes[0])
+		exhaustedResp.AssertFail(500, "the token provided was invalid")
 	})
 }
 

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -51,6 +51,9 @@ func TestMFARecoveryCodes(t *testing.T) {
 
 func enrollCompletesWithTotpRequiredPolicy(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
+		if state.overlay.ZitiMajor < 2 {
+			t.Skipf("MFA TOTP enrollment with TOTP-required auth policy requires ziti 2.0+; controller is v%d.%d (openziti/ziti#3496)", state.overlay.ZitiMajor, state.overlay.ZitiMinor)
+		}
 		name := "test_mfa_enable_totp_policy"
 		added := testutil.FetchAndEnrollJwt(t, state.overlay, state.zetClient, name)
 		require.False(t, added.Id.MfaEnabled, "identity:added MfaEnabled=%t before EnableMFA", added.Id.MfaEnabled)

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -45,7 +45,7 @@ func TestRemoveMFA(t *testing.T) {
 func TestMFARecoveryCodes(t *testing.T) {
 	t.Run("getMfaCodesReturnsValidCodes", getMfaCodesReturnsValidCodes)
 	t.Run("getMfaCodesRejectsInvalidTotp", getMfaCodesRejectsInvalidTotp)
-	t.Run("recoveryRejectsOldCodeAfterRegeneration", recoveryRejectsOldCodeAfterRegeneration)
+	t.Run("generateMfaCodesReplacesOldSet", generateMfaCodesReplacesOldSet)
 	t.Run("recoveryFailsAfterAllCodesExhausted", recoveryFailsAfterAllCodesExhausted)
 }
 
@@ -216,6 +216,7 @@ func getMfaCodesReturnsValidCodes(t *testing.T) {
 		getResp := state.zetClient.GetMFACodes(t, enrollment.Identifier, code)
 		getResp.AssertSuccess()
 
+		require.Equal(t, enrollment.Identifier, getResp.Data.Identifier)
 		require.ElementsMatch(t, enrollment.RecoveryCodes, getResp.Data.RecoveryCodes)
 	})
 }
@@ -252,7 +253,7 @@ func recoveryFailsAfterAllCodesExhausted(t *testing.T) {
 	})
 }
 
-func recoveryRejectsOldCodeAfterRegeneration(t *testing.T) {
+func generateMfaCodesReplacesOldSet(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		idName := "test_mfa_regenerate_codes"
 		enrollment, secret := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
@@ -262,8 +263,17 @@ func recoveryRejectsOldCodeAfterRegeneration(t *testing.T) {
 		genResp := state.zetClient.GenerateMFACodes(t, enrollment.Identifier, code)
 		genResp.AssertSuccess()
 
-		triggerReauthChallenge(t, enrollment.Identifier, idName)
+		getResp := state.zetClient.GetMFACodes(t, enrollment.Identifier, code)
+		getResp.AssertSuccess()
+		newCode := getResp.Data.RecoveryCodes[0]
 
+		triggerReauthChallenge(t, enrollment.Identifier, idName)
+		newResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, newCode)
+		newResp.AssertSuccess()
+		updatedEvent := state.zetClient.WaitForIdentityEvent(t, "updated", idName)
+		updatedEvent.AssertMfaAuthenticated()
+
+		triggerReauthChallenge(t, enrollment.Identifier, idName)
 		reuseResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, oldCode)
 		reuseResp.AssertFail(500, "the token provided was invalid")
 	})

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -32,6 +32,7 @@ func TestMFAEnrollment(t *testing.T) {
 func TestMFAReauthentication(t *testing.T) {
 	t.Run("acceptsValidTotp", reauthAcceptsValidTotp)
 	t.Run("acceptsRecoveryCode", reauthAcceptsRecoveryCode)
+	t.Run("rejectsRecoveryCodeReuse", reauthRejectsRecoveryCodeReuse)
 	t.Run("rejectsInvalidTotp", reauthRejectsInvalidTotp)
 }
 
@@ -125,6 +126,29 @@ func reauthAcceptsRecoveryCode(t *testing.T) {
 
 		authStatusEvent := state.zetClient.WaitForMfaEvent(t, "mfa_auth_status", idName)
 		authStatusEvent.AssertSuccess()
+	})
+}
+
+func reauthRejectsRecoveryCodeReuse(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		idName := "test_mfa_reauth_reused_recovery_code"
+		enrollment, _ := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
+		recoveryCode := enrollment.RecoveryCodes[0]
+
+		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
+		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+
+		firstResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, recoveryCode)
+		firstResp.AssertSuccess()
+
+		updatedEvent := state.zetClient.WaitForIdentityEvent(t, "updated", idName)
+		updatedEvent.AssertMfaAuthenticated()
+
+		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
+		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+
+		reuseResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, recoveryCode)
+		reuseResp.AssertFail(500, "the token provided was invalid")
 	})
 }
 

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -44,6 +44,7 @@ func TestRemoveMFA(t *testing.T) {
 
 func TestMFARecoveryCodes(t *testing.T) {
 	t.Run("getMfaCodesReturnsValidCodes", getMfaCodesReturnsValidCodes)
+	t.Run("getMfaCodesRejectsInvalidTotp", getMfaCodesRejectsInvalidTotp)
 	t.Run("recoveryRejectsOldCodeAfterRegeneration", recoveryRejectsOldCodeAfterRegeneration)
 	t.Run("recoveryFailsAfterAllCodesExhausted", recoveryFailsAfterAllCodesExhausted)
 }
@@ -216,6 +217,16 @@ func getMfaCodesReturnsValidCodes(t *testing.T) {
 		getResp.AssertSuccess()
 
 		require.ElementsMatch(t, enrollment.RecoveryCodes, getResp.Data.RecoveryCodes)
+	})
+}
+
+func getMfaCodesRejectsInvalidTotp(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		idName := "test_mfa_get_codes_invalid"
+		enrollment, _ := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
+
+		getResp := state.zetClient.GetMFACodes(t, enrollment.Identifier, "000000")
+		getResp.AssertFail(500, "the token provided was invalid")
 	})
 }
 

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -270,6 +270,10 @@ func generateMfaCodesReplacesOldSet(t *testing.T) {
 		getResp.AssertSuccess()
 		newCode := getResp.Data.RecoveryCodes[0]
 
+		for _, c := range getResp.Data.RecoveryCodes {
+			require.NotContains(t, enrollment.RecoveryCodes, c)
+		}
+
 		triggerReauthChallenge(t, enrollment.Identifier, idName)
 		newResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, newCode)
 		newResp.AssertSuccess()

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -24,14 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnableMFA(t *testing.T) {
-	t.Run("acceptsJwtEnrolledIdentity", acceptsJwtEnrolledIdentity)
-	t.Run("acceptsTotpRequiredAuthPolicy", acceptsTotpRequiredAuthPolicy)
-}
-
-func TestVerifyMFA(t *testing.T) {
-	// Happy path is tested throughout this suite - that's why there's only a reject case
-	t.Run("rejectsInvalidTotp", verifyRejectsInvalidTotp)
+func TestMFAEnrollment(t *testing.T) {
+	t.Run("completesWithTotpRequiredPolicy", enrollCompletesWithTotpRequiredPolicy)
+	t.Run("rejectsInvalidTotp", enrollRejectsInvalidTotp)
 }
 
 func TestMFAReauthentication(t *testing.T) {
@@ -46,29 +41,47 @@ func TestRemoveMFA(t *testing.T) {
 	t.Run("rejectsInvalidTotp", removeRejectsInvalidTotp)
 }
 
-func acceptsJwtEnrolledIdentity(t *testing.T) {
+func enrollCompletesWithTotpRequiredPolicy(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		enrollment, _ := testutil.EnrollAndEnableMFA(t, state.overlay, state.zetClient, "test_mfa_enable_jwt")
+		name := "test_mfa_enable_totp_policy"
+		added := testutil.FetchAndEnrollJwt(t, state.overlay, state.zetClient, name)
+		require.False(t, added.Id.MfaEnabled, "identity:added MfaEnabled=%t before EnableMFA", added.Id.MfaEnabled)
 
-		require.False(t, enrollment.IsVerified, "EnableMFA Data.IsVerified should be false before verify_mfa")
+		state.zetClient.WaitForMfaEvent(t, "enrollment_required", name)
+
+		enableResp := state.zetClient.EnableMFA(t, added.Id.Identifier)
+		enableResp.AssertSuccess()
+		require.NotEmpty(t, enableResp.Data.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
+		require.NotEmpty(t, enableResp.Data.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
+		require.False(t, enableResp.Data.IsVerified, "EnableMFA Data.IsVerified should be false before verify_mfa")
+
+		challengeEvent := state.zetClient.WaitForMfaEvent(t, "enrollment_challenge", name)
+		challengeEvent.AssertSuccess()
+
+		secret := testutil.ParseTOTPSecret(t, enableResp.Data.ProvisioningUrl)
+		code := testutil.GenerateTOTP(t, secret, time.Now())
+
+		verifyResp := state.zetClient.VerifyMFA(t, added.Id.Identifier, code)
+		verifyResp.AssertSuccess()
+
+		updatedEvent := state.zetClient.WaitForIdentityEvent(t, "updated", name)
+		updatedEvent.AssertMfaAuthenticated()
+
+		verificationEvent := state.zetClient.WaitForMfaEvent(t, "enrollment_verification", name)
+		verificationEvent.AssertSuccess()
 	})
 }
 
-func acceptsTotpRequiredAuthPolicy(t *testing.T) {
+func enrollRejectsInvalidTotp(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		t.Skip("Tracking https://github.com/openziti/desktop-edge-win/issues/947 and https://openziti.discourse.group/t/enrolling-mfa-totp-from-zdew-fails/5482 - EnableMFA fails with 'failed to authenticate' for identities bound to TOTP-required auth policies")
+		name := "test_mfa_verify_invalid_totp"
+		added := testutil.FetchAndEnrollJwt(t, state.overlay, state.zetClient, name)
+		state.zetClient.WaitForControllerEvent(t, "connected", name)
 
-		enrollment, _ := testutil.EnrollAndEnableMFA(t, state.overlay, state.zetClient, "test_mfa_enable_totp_policy")
+		enableResp := state.zetClient.EnableMFA(t, added.Id.Identifier)
+		enableResp.AssertSuccess()
 
-		require.False(t, enrollment.IsVerified, "EnableMFA Data.IsVerified should be false before verify_mfa")
-	})
-}
-
-func verifyRejectsInvalidTotp(t *testing.T) {
-	testutil.RunWithTimeout(t, func(t *testing.T) {
-		enrollment, _ := testutil.EnrollAndEnableMFA(t, state.overlay, state.zetClient, "test_mfa_verify_invalid_totp")
-
-		verifyResp := state.zetClient.VerifyMFA(t, enrollment.Identifier, "000000")
+		verifyResp := state.zetClient.VerifyMFA(t, added.Id.Identifier, "000000")
 		verifyResp.AssertFail(500, "the token provided was invalid")
 	})
 }

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -45,7 +45,7 @@ func TestRemoveMFA(t *testing.T) {
 func TestMFARecoveryCodes(t *testing.T) {
 	t.Run("getMfaCodesReturnsValidCodes", getMfaCodesReturnsValidCodes)
 	t.Run("recoveryRejectsOldCodeAfterRegeneration", recoveryRejectsOldCodeAfterRegeneration)
-	t.Run("recoveryRejectsAfterAllCodesExhausted", recoveryRejectsAfterAllCodesExhausted)
+	t.Run("recoveryFailsAfterAllCodesExhausted", recoveryFailsAfterAllCodesExhausted)
 }
 
 func enrollCompletesWithTotpRequiredPolicy(t *testing.T) {
@@ -93,14 +93,17 @@ func enrollRejectsInvalidTotp(t *testing.T) {
 	})
 }
 
+func triggerReauthChallenge(t *testing.T, identifier, idName string) {
+	state.zetClient.DisableEnableIdentity(t, identifier)
+	state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+}
+
 func reauthAcceptsValidTotp(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		idName := "test_mfa_reauth_valid_totp"
 		enrollment, secret := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
-		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
-
-		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+		triggerReauthChallenge(t, enrollment.Identifier, idName)
 
 		code := testutil.GenerateTOTP(t, secret, time.Now())
 
@@ -120,9 +123,7 @@ func reauthAcceptsRecoveryCode(t *testing.T) {
 		idName := "test_mfa_reauth_recovery_code"
 		enrollment, _ := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
-		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
-
-		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+		triggerReauthChallenge(t, enrollment.Identifier, idName)
 
 		submitResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, enrollment.RecoveryCodes[0])
 		submitResp.AssertSuccess()
@@ -141,8 +142,7 @@ func reauthRejectsRecoveryCodeReuse(t *testing.T) {
 		enrollment, _ := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 		recoveryCode := enrollment.RecoveryCodes[0]
 
-		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
-		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+		triggerReauthChallenge(t, enrollment.Identifier, idName)
 
 		firstResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, recoveryCode)
 		firstResp.AssertSuccess()
@@ -150,8 +150,7 @@ func reauthRejectsRecoveryCodeReuse(t *testing.T) {
 		updatedEvent := state.zetClient.WaitForIdentityEvent(t, "updated", idName)
 		updatedEvent.AssertMfaAuthenticated()
 
-		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
-		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+		triggerReauthChallenge(t, enrollment.Identifier, idName)
 
 		reuseResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, recoveryCode)
 		reuseResp.AssertFail(500, "the token provided was invalid")
@@ -163,9 +162,7 @@ func reauthRejectsInvalidTotp(t *testing.T) {
 		idName := "test_mfa_reauth_invalid_totp"
 		enrollment, _ := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
-		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
-
-		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+		triggerReauthChallenge(t, enrollment.Identifier, idName)
 
 		submitResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, "000000")
 		submitResp.AssertFail(500, "the token provided was invalid")
@@ -222,14 +219,13 @@ func getMfaCodesReturnsValidCodes(t *testing.T) {
 	})
 }
 
-func recoveryRejectsAfterAllCodesExhausted(t *testing.T) {
-	testutil.RunWithTimeoutOf(t, 2*time.Minute, func(t *testing.T) {
+func recoveryFailsAfterAllCodesExhausted(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
 		idName := "test_mfa_exhaust_recovery_codes"
 		enrollment, _ := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
 		for _, code := range enrollment.RecoveryCodes {
-			state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
-			state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+			triggerReauthChallenge(t, enrollment.Identifier, idName)
 
 			submitResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, code)
 			submitResp.AssertSuccess()
@@ -238,8 +234,7 @@ func recoveryRejectsAfterAllCodesExhausted(t *testing.T) {
 			updatedEvent.AssertMfaAuthenticated()
 		}
 
-		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
-		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+		triggerReauthChallenge(t, enrollment.Identifier, idName)
 
 		exhaustedResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, enrollment.RecoveryCodes[0])
 		exhaustedResp.AssertFail(500, "the token provided was invalid")
@@ -256,8 +251,7 @@ func recoveryRejectsOldCodeAfterRegeneration(t *testing.T) {
 		genResp := state.zetClient.GenerateMFACodes(t, enrollment.Identifier, code)
 		genResp.AssertSuccess()
 
-		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
-		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+		triggerReauthChallenge(t, enrollment.Identifier, idName)
 
 		reuseResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, oldCode)
 		reuseResp.AssertFail(500, "the token provided was invalid")

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -25,21 +25,25 @@ import (
 )
 
 func TestMFAEnrollment(t *testing.T) {
-	t.Run("completesWithTotpRequiredPolicy", enrollCompletesWithTotpRequiredPolicy)
-	t.Run("rejectsInvalidTotp", enrollRejectsInvalidTotp)
+	t.Run("enrollCompletesWithTotpRequiredPolicy", enrollCompletesWithTotpRequiredPolicy)
+	t.Run("enrollRejectsInvalidTotp", enrollRejectsInvalidTotp)
 }
 
 func TestMFAReauthentication(t *testing.T) {
-	t.Run("acceptsValidTotp", reauthAcceptsValidTotp)
-	t.Run("acceptsRecoveryCode", reauthAcceptsRecoveryCode)
-	t.Run("rejectsRecoveryCodeReuse", reauthRejectsRecoveryCodeReuse)
-	t.Run("rejectsInvalidTotp", reauthRejectsInvalidTotp)
+	t.Run("reauthAcceptsValidTotp", reauthAcceptsValidTotp)
+	t.Run("reauthAcceptsRecoveryCode", reauthAcceptsRecoveryCode)
+	t.Run("reauthRejectsRecoveryCodeReuse", reauthRejectsRecoveryCodeReuse)
+	t.Run("reauthRejectsInvalidTotp", reauthRejectsInvalidTotp)
 }
 
 func TestRemoveMFA(t *testing.T) {
-	t.Run("acceptsValidTotp", removeAcceptsValidTotp)
-	t.Run("acceptsRecoveryCode", removeAcceptsRecoveryCode)
-	t.Run("rejectsInvalidTotp", removeRejectsInvalidTotp)
+	t.Run("removeAcceptsValidTotp", removeAcceptsValidTotp)
+	t.Run("removeAcceptsRecoveryCode", removeAcceptsRecoveryCode)
+	t.Run("removeRejectsInvalidTotp", removeRejectsInvalidTotp)
+}
+
+func TestMFARecoveryCodes(t *testing.T) {
+	t.Run("recoveryRejectsOldCodeAfterRegeneration", recoveryRejectsOldCodeAfterRegeneration)
 }
 
 func enrollCompletesWithTotpRequiredPolicy(t *testing.T) {
@@ -200,5 +204,23 @@ func removeRejectsInvalidTotp(t *testing.T) {
 
 		removeResp := state.zetClient.RemoveMFA(t, enrollment.Identifier, "000000")
 		removeResp.AssertFail(500, "the token provided was invalid")
+	})
+}
+
+func recoveryRejectsOldCodeAfterRegeneration(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		idName := "test_mfa_regenerate_codes"
+		enrollment, secret := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
+		oldCode := enrollment.RecoveryCodes[0]
+
+		code := testutil.GenerateTOTP(t, secret, time.Now())
+		genResp := state.zetClient.GenerateMFACodes(t, enrollment.Identifier, code)
+		genResp.AssertSuccess()
+
+		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
+		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
+
+		reuseResp := state.zetClient.SubmitMFA(t, enrollment.Identifier, oldCode)
+		reuseResp.AssertFail(500, "the token provided was invalid")
 	})
 }

--- a/tests/integration/mfa_test.go
+++ b/tests/integration/mfa_test.go
@@ -43,6 +43,7 @@ func TestRemoveMFA(t *testing.T) {
 }
 
 func TestMFARecoveryCodes(t *testing.T) {
+	t.Run("getMfaCodesReturnsValidCodes", getMfaCodesReturnsValidCodes)
 	t.Run("recoveryRejectsOldCodeAfterRegeneration", recoveryRejectsOldCodeAfterRegeneration)
 }
 
@@ -204,6 +205,19 @@ func removeRejectsInvalidTotp(t *testing.T) {
 
 		removeResp := state.zetClient.RemoveMFA(t, enrollment.Identifier, "000000")
 		removeResp.AssertFail(500, "the token provided was invalid")
+	})
+}
+
+func getMfaCodesReturnsValidCodes(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		idName := "test_mfa_get_codes"
+		enrollment, secret := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
+
+		code := testutil.GenerateTOTP(t, secret, time.Now())
+		getResp := state.zetClient.GetMFACodes(t, enrollment.Identifier, code)
+		getResp.AssertSuccess()
+
+		require.ElementsMatch(t, enrollment.RecoveryCodes, getResp.Data.RecoveryCodes)
 	})
 }
 

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -73,6 +73,12 @@
       "enrollment": { "ott": true }
     },
     {
+      "name": "test_mfa_regenerate_codes",
+      "isAdmin": false,
+      "authPolicy": "@Default",
+      "enrollment": { "ott": true }
+    },
+    {
       "name": "test_mfa_remove_valid_totp",
       "isAdmin": false,
       "authPolicy": "@Default",

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -73,6 +73,12 @@
       "enrollment": { "ott": true }
     },
     {
+      "name": "test_mfa_get_codes",
+      "isAdmin": false,
+      "authPolicy": "@Default",
+      "enrollment": { "ott": true }
+    },
+    {
       "name": "test_mfa_regenerate_codes",
       "isAdmin": false,
       "authPolicy": "@Default",

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -85,6 +85,12 @@
       "enrollment": { "ott": true }
     },
     {
+      "name": "test_mfa_exhaust_recovery_codes",
+      "isAdmin": false,
+      "authPolicy": "@Default",
+      "enrollment": { "ott": true }
+    },
+    {
       "name": "test_mfa_remove_valid_totp",
       "isAdmin": false,
       "authPolicy": "@Default",

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -37,21 +37,9 @@
       "externalId": "test_restart_ext@test.com"
     },
     {
-      "name": "test_mfa_enable_jwt",
-      "isAdmin": false,
-      "authPolicy": "@Default",
-      "enrollment": { "ott": true }
-    },
-    {
       "name": "test_mfa_enable_totp_policy",
       "isAdmin": false,
       "authPolicy": "@test_mfa_totp_policy",
-      "enrollment": { "ott": true }
-    },
-    {
-      "name": "test_mfa_verify_valid_totp",
-      "isAdmin": false,
-      "authPolicy": "@Default",
       "enrollment": { "ott": true }
     },
     {

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -61,6 +61,12 @@
       "enrollment": { "ott": true }
     },
     {
+      "name": "test_mfa_reauth_reused_recovery_code",
+      "isAdmin": false,
+      "authPolicy": "@Default",
+      "enrollment": { "ott": true }
+    },
+    {
       "name": "test_mfa_reauth_invalid_totp",
       "isAdmin": false,
       "authPolicy": "@Default",

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -79,6 +79,12 @@
       "enrollment": { "ott": true }
     },
     {
+      "name": "test_mfa_get_codes_invalid",
+      "isAdmin": false,
+      "authPolicy": "@Default",
+      "enrollment": { "ott": true }
+    },
+    {
       "name": "test_mfa_regenerate_codes",
       "isAdmin": false,
       "authPolicy": "@Default",

--- a/tests/integration/testutil/common.go
+++ b/tests/integration/testutil/common.go
@@ -59,10 +59,20 @@ func FetchAndEnrollJwt(t *testing.T, overlay *Overlay, zet *ZET, name string) Id
 	return identityEvent
 }
 
-// EnrollAndEnableMFA enrolls the pre-imported identity on zet, waits for the
-// controller to connect, sends EnableMFA, and returns the enrollment plus the
-// TOTP secret parsed from its provisioning URL. The enrollment is not yet verified.
-func EnrollAndEnableMFA(t *testing.T, overlay *Overlay, zet *ZET, name string) (MFAEnrollment, string) {
+// ParseTOTPSecret extracts the base32 TOTP secret from an otpauth provisioning URL.
+func ParseTOTPSecret(t *testing.T, provisioningURL string) string {
+	parsed, err := url.Parse(provisioningURL)
+	require.NoError(t, err, "parse provisioning URL")
+	secret := parsed.Query().Get("secret")
+	require.NotEmpty(t, secret, "provisioning url missing secret param")
+	return secret
+}
+
+// EnrollAndVerifyMFA enrolls the pre-imported identity on zet, enables MFA, and
+// completes enrollment with a valid TOTP, asserting the VerifyMFA response and
+// the mfa:enrollment_verification event report success. Returns the enrollment
+// and its TOTP secret.
+func EnrollAndVerifyMFA(t *testing.T, overlay *Overlay, zet *ZET, name string) (MFAEnrollment, string) {
 	added := FetchAndEnrollJwt(t, overlay, zet, name)
 	require.False(t, added.Id.MfaEnabled, "identity:added MfaEnabled=%t before EnableMFA", added.Id.MfaEnabled)
 	zet.WaitForControllerEvent(t, "connected", name)
@@ -71,26 +81,14 @@ func EnrollAndEnableMFA(t *testing.T, overlay *Overlay, zet *ZET, name string) (
 	enableResp.AssertSuccess()
 	require.NotEmpty(t, enableResp.Data.ProvisioningUrl, "EnableMFA Data.ProvisioningUrl should be non-empty")
 	require.NotEmpty(t, enableResp.Data.RecoveryCodes, "EnableMFA Data.RecoveryCodes should be non-empty")
+	require.False(t, enableResp.Data.IsVerified, "EnableMFA Data.IsVerified should be false before verify_mfa")
 	enrollment := enableResp.Data
+	enrollment.Identifier = added.Id.Identifier
 
 	challengeEvent := zet.WaitForMfaEvent(t, "enrollment_challenge", name)
 	challengeEvent.AssertSuccess()
 
-	parsed, err := url.Parse(enrollment.ProvisioningUrl)
-	require.NoError(t, err, "parse provisioning URL")
-	secret := parsed.Query().Get("secret")
-	require.NotEmpty(t, secret, "provisioning url missing secret param")
-
-	enrollment.Identifier = added.Id.Identifier
-	return enrollment, secret
-}
-
-// EnrollAndVerifyMFA enables MFA via EnrollAndEnableMFA and completes enrollment
-// with a valid TOTP, asserting both the VerifyMFA response and the
-// mfa:enrollment_verification event report success.
-func EnrollAndVerifyMFA(t *testing.T, overlay *Overlay, zet *ZET, name string) (MFAEnrollment, string) {
-	enrollment, secret := EnrollAndEnableMFA(t, overlay, zet, name)
-
+	secret := ParseTOTPSecret(t, enrollment.ProvisioningUrl)
 	code := GenerateTOTP(t, secret, time.Now())
 
 	verifyResp := zet.VerifyMFA(t, enrollment.Identifier, code)

--- a/tests/integration/testutil/ipc.go
+++ b/tests/integration/testutil/ipc.go
@@ -389,13 +389,13 @@ func (c *CommandsClient) GenerateMFACodes(t *testing.T, identifier, code string)
 	return resp
 }
 
-func (c *CommandsClient) GetMFACodes(t *testing.T, identifier, code string) *ServiceResponse {
+func (c *CommandsClient) GetMFACodes(t *testing.T, identifier, code string) *MFARecoveryCodesResponse {
 	f := MFAFunction{
 		ServiceFunction: NewServiceFunction("GetMFACodes"),
 		Data:            NewMFAData(identifier, code),
 	}
 	t.Logf("sending GetMFACodes for %q", identifier)
-	resp, err := send[MFAFunction, ServiceResponse](&c.IPCClient, f)
+	resp, err := send[MFAFunction, MFARecoveryCodesResponse](&c.IPCClient, f)
 	require.NoError(t, err, "failed to send GetMFACodes\n%s", c.LogPath)
 	resp.t = t
 	return resp

--- a/tests/integration/testutil/ipc_types.go
+++ b/tests/integration/testutil/ipc_types.go
@@ -274,6 +274,12 @@ type MFAEnrollmentResponse struct {
 	Data MFAEnrollment `json:"Data"`
 }
 
+// MFARecoveryCodesResponse is returned by GetMFACodes. Data carries the current recovery codes.
+type MFARecoveryCodesResponse struct {
+	ServiceResponse
+	Data MFARecoveryCodes `json:"Data"`
+}
+
 // ---------------------------------------------------------------------------
 // Inner Data shapes referenced by typed responses.
 // ---------------------------------------------------------------------------
@@ -339,6 +345,11 @@ type MFAEnrollment struct {
 	IsVerified      bool     `json:"IsVerified"`
 	ProvisioningUrl string   `json:"ProvisioningUrl"`
 	RecoveryCodes   []string `json:"RecoveryCodes"`
+}
+
+type MFARecoveryCodes struct {
+	Identifier    string   `json:"Identifier"`
+	RecoveryCodes []string `json:"RecoveryCodes"`
 }
 
 // ExtAuth is the parsed payload of an ExternalAuth response (and the

--- a/tests/integration/testutil/ipc_types.go
+++ b/tests/integration/testutil/ipc_types.go
@@ -388,8 +388,8 @@ type ControllerEvent struct {
 	Identifier string `json:"Identifier"`
 }
 
-// MfaEvent fires on Op:"mfa" (enrollment_challenge, enrollment_verification,
-// mfa_auth_status, auth_challenge, enrollment_remove).
+// MfaEvent fires on Op:"mfa" (enrollment_required, enrollment_challenge,
+// enrollment_verification, mfa_auth_status, auth_challenge, enrollment_remove).
 type MfaEvent struct {
 	ActionEvent
 	Identifier      string   `json:"Identifier"`


### PR DESCRIPTION
- Adds integration coverage for get_mfa_codes, generate_mfa_codes, and recovery-code exhaustion. 
- Includes MFA test name and helper cleanup 
