### PR TITLE
Add tests for enroll-to-cert/token claim selectors and auth policies

### DIFF
--- a/tests/integration/config.example.json
+++ b/tests/integration/config.example.json
@@ -25,7 +25,7 @@
     "clientId": "ziti-test",
     "extraClientIds": ["ziti-test-2", "ziti-test-3"],
     "audience": "ziti-test",
-    "scopes": "openid profile email",
+    "scopes": "openid profile email groups",
     "password": "password"
   }
 }

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -101,6 +101,7 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 	t.Run("enrollToTokenCompletes", c.enrollToTokenCompletes)
 	t.Run("enrollToTokenUsesNameClaimSelector", c.enrollToTokenUsesNameClaimSelector)
 	t.Run("enrollToCertUsesAttrClaimSelector", c.enrollToCertUsesAttrClaimSelector)
+	t.Run("enrollToTokenUsesAttrClaimSelector", c.enrollToTokenUsesAttrClaimSelector)
 	t.Run("bothEnrollFlowsCompleteWhenBothEnabled", c.bothEnrollFlowsCompleteWhenBothEnabled)
 	t.Run("enrollToNoneThenCertRejected", c.enrollToNoneThenCertRejected)
 	t.Run("enrollToCertThenNoneRejected", c.enrollToCertThenNoneRejected)
@@ -272,12 +273,25 @@ func (c *extAuthContext) enrollToCertUsesAttrClaimSelector(t *testing.T) {
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollAttrSelector: "/groups"})
 		idName := "test_ext_auth_attr_selector"
 		c.completeEnrollToCert(t, idName)
+		c.assertOnlyUserServiceGranted(t, idName)
+	})
+}
 
-		// The fixture grants one service to #ziti-user and another to #ziti-admin.
-		// The groups claim carries only ziti-user, so we should only see the user svc in the bulk service event
-		bulkServiceEvent := c.zet.WaitForBulkServiceEvent(t, "updated", idName)
-		require.Len(t, bulkServiceEvent.AddedServices, 1, "expected only the ziti-user service to be granted")
-		require.Equal(t, "test_ext_auth_attr_user_svc", bulkServiceEvent.AddedServices[0].Name)
+// assertOnlyUserServiceGranted checks the attribute selector put ziti-user and nothing
+// else on the identity. The fixture grants one service to #ziti-user and another to
+// #ziti-admin, so a ziti-user-only claim must yield exactly the user service.
+func (c *extAuthContext) assertOnlyUserServiceGranted(t *testing.T, idName string) {
+	bulkServiceEvent := c.zet.WaitForBulkServiceEvent(t, "updated", idName)
+	require.Len(t, bulkServiceEvent.AddedServices, 1, "expected only the ziti-user service to be granted")
+	require.Equal(t, "test_ext_auth_attr_user_svc", bulkServiceEvent.AddedServices[0].Name)
+}
+
+func (c *extAuthContext) enrollToTokenUsesAttrClaimSelector(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollAttrSelector: "/groups"})
+		idName := "test_ext_auth_token_attr_selector"
+		c.completeEnrollToToken(t, idName)
+		c.assertOnlyUserServiceGranted(t, idName)
 	})
 }
 

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package integration_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/openziti/ziti-tunnel-sdk-c/tests/integration/testutil"
@@ -59,7 +58,7 @@ func (c *extAuthContext) setupExtraExtJwtSigners(t *testing.T) {
 		ClientID: c.idp.ClientIDExtraA,
 		Audience: c.idp.Audience,
 		Claim:    "email",
-		Scopes:   strings.Fields(c.idp.Scopes),
+		Scopes:   c.idp.ScopeList(),
 	})
 
 	c.extraSignerB.name = "test_ext_auth_signer_extra_b"
@@ -70,7 +69,7 @@ func (c *extAuthContext) setupExtraExtJwtSigners(t *testing.T) {
 		ClientID: c.idp.ClientIDExtraB,
 		Audience: c.idp.Audience,
 		Claim:    "email",
-		Scopes:   strings.Fields(c.idp.Scopes),
+		Scopes:   c.idp.ScopeList(),
 	})
 }
 
@@ -97,27 +96,12 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 		return
 	}
 
-	// Enroll to cert true / enroll to token false
-	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
 	t.Run("enrollToCertCompletes", c.enrollToCertCompletes)
-
-	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollNameSelector: "/email"})
 	t.Run("enrollToCertUsesNameClaimSelector", c.enrollToCertUsesNameClaimSelector)
-
-	// Enroll to cert false / enroll to token true
-	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
 	t.Run("enrollToTokenCompletes", c.enrollToTokenCompletes)
-
-	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollNameSelector: "/email"})
 	t.Run("enrollToTokenUsesNameClaimSelector", c.enrollToTokenUsesNameClaimSelector)
-
-	attrScopes := append(strings.Fields(c.idp.Scopes), "groups")
-	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollAttrSelector: "/groups", Scopes: attrScopes})
 	t.Run("enrollToCertUsesAttrClaimSelector", c.enrollToCertUsesAttrClaimSelector)
-
-	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollToToken: true})
 	t.Run("bothEnrollFlowsCompleteWhenBothEnabled", c.bothEnrollFlowsCompleteWhenBothEnabled)
-
 	t.Run("enrollToNoneThenCertRejected", c.enrollToNoneThenCertRejected)
 	t.Run("enrollToCertThenNoneRejected", c.enrollToCertThenNoneRejected)
 	t.Run("enrollToCertThenTokenRejected", c.enrollToCertThenTokenRejected)
@@ -209,6 +193,7 @@ func (c *extAuthContext) enrollToNoneMultipleSignersNamedPolicyCompletes(t *test
 
 func (c *extAuthContext) enrollToCertCompletes(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
 		c.completeEnrollToCert(t, "test_ext_auth_cert_happy")
 	})
 }
@@ -247,6 +232,7 @@ func (c *extAuthContext) assertExpectedIdentityName(t *testing.T, enrolled testu
 
 func (c *extAuthContext) enrollToCertUsesNameClaimSelector(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollNameSelector: "/email"})
 		idName := "test_ext_auth_name_selector"
 		enrolled := c.completeEnrollToCert(t, idName)
 		c.assertExpectedIdentityName(t, enrolled, idName)
@@ -255,6 +241,7 @@ func (c *extAuthContext) enrollToCertUsesNameClaimSelector(t *testing.T) {
 
 func (c *extAuthContext) enrollToTokenCompletes(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
 		c.completeEnrollToToken(t, "test_ext_auth_token_happy")
 	})
 }
@@ -282,6 +269,7 @@ func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) testut
 
 func (c *extAuthContext) enrollToCertUsesAttrClaimSelector(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollAttrSelector: "/groups"})
 		idName := "test_ext_auth_attr_selector"
 		c.completeEnrollToCert(t, idName)
 
@@ -295,6 +283,7 @@ func (c *extAuthContext) enrollToCertUsesAttrClaimSelector(t *testing.T) {
 
 func (c *extAuthContext) enrollToTokenUsesNameClaimSelector(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollNameSelector: "/email"})
 		idName := "test_ext_auth_token_name_selector"
 		enrolled := c.completeEnrollToToken(t, idName)
 		c.assertExpectedIdentityName(t, enrolled, idName)
@@ -302,6 +291,7 @@ func (c *extAuthContext) enrollToTokenUsesNameClaimSelector(t *testing.T) {
 }
 
 func (c *extAuthContext) bothEnrollFlowsCompleteWhenBothEnabled(t *testing.T) {
+	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollToToken: true})
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		c.completeEnrollToCert(t, "test_ext_auth_cert_both")
 	})

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -101,9 +101,15 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
 	t.Run("enrollToCertCompletes", c.enrollToCertCompletes)
 
+	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollNameSelector: "/email"})
+	t.Run("enrollToCertUsesNameClaimSelector", c.enrollToCertUsesNameClaimSelector)
+
 	// Enroll to cert false / enroll to token true
 	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
 	t.Run("enrollToTokenCompletes", c.enrollToTokenCompletes)
+
+	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollNameSelector: "/email"})
+	t.Run("enrollToTokenUsesNameClaimSelector", c.enrollToTokenUsesNameClaimSelector)
 
 	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollToToken: true})
 	t.Run("bothEnrollFlowsCompleteWhenBothEnabled", c.bothEnrollFlowsCompleteWhenBothEnabled)
@@ -213,8 +219,8 @@ func (c *extAuthContext) beginEnrollment(t *testing.T, identityData testutil.Add
 }
 
 // completeEnrollToCert drives a full enroll-to-cert flow for name and returns the
-// resulting identifier. The working signer must already have EnrollToCert enabled.
-func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string {
+// identity:added event. The working signer must already have EnrollToCert enabled.
+func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) testutil.IdentityEvent {
 	identityData := testutil.NewUrlIdentityData(name, c.overlay.ControllerHostPort(), testutil.EnrollModeCert, c.workingSigner.name)
 	authURL := c.beginEnrollment(t, identityData)
 
@@ -224,7 +230,23 @@ func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) string 
 	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to cert IdP login flow", added.Id.Active)
 	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to cert IdP login flow", added.Id.NeedsExtAuth)
 	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeCert)
-	return added.Id.Identifier
+	return added
+}
+
+// Asserts a URL-enrolled identity is provisioned with the name the ext-jwt-signer's
+// --enroll-name-claims-selector flag resolves to.
+func (c *extAuthContext) assertExpectedIdentityName(t *testing.T, enrolled testutil.IdentityEvent, idName string) {
+	require.Contains(t, enrolled.Id.Name, idName)
+	provisioned := c.zet.WaitForIdentityEvent(t, "added", idName)
+	require.Equal(t, idName+"@test.com", provisioned.Id.Name)
+}
+
+func (c *extAuthContext) enrollToCertUsesNameClaimSelector(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		idName := "test_ext_auth_name_selector"
+		enrolled := c.completeEnrollToCert(t, idName)
+		c.assertExpectedIdentityName(t, enrolled, idName)
+	})
 }
 
 func (c *extAuthContext) enrollToTokenCompletes(t *testing.T) {
@@ -234,8 +256,8 @@ func (c *extAuthContext) enrollToTokenCompletes(t *testing.T) {
 }
 
 // completeEnrollToToken drives a full enroll-to-token flow for name and returns the
-// resulting identifier. The working signer must already have EnrollToToken enabled.
-func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) string {
+// identity:added event. The working signer must already have EnrollToToken enabled.
+func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) testutil.IdentityEvent {
 	identityData := testutil.NewUrlIdentityData(name, c.overlay.ControllerHostPort(), testutil.EnrollModeToken, c.workingSigner.name)
 	authURL := c.beginEnrollment(t, identityData)
 
@@ -251,7 +273,15 @@ func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) string
 	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to token IdP login flow", added.Id.Active)
 	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to token IdP login flow", added.Id.NeedsExtAuth)
 	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeToken)
-	return added.Id.Identifier
+	return added
+}
+
+func (c *extAuthContext) enrollToTokenUsesNameClaimSelector(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		idName := "test_ext_auth_token_name_selector"
+		enrolled := c.completeEnrollToToken(t, idName)
+		c.assertExpectedIdentityName(t, enrolled, idName)
+	})
 }
 
 func (c *extAuthContext) bothEnrollFlowsCompleteWhenBothEnabled(t *testing.T) {
@@ -284,7 +314,7 @@ func (c *extAuthContext) enrollToCertThenNoneRejected(t *testing.T) {
 		idName := "test_ext_auth_cert_then_none"
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
-		identifier := c.completeEnrollToCert(t, idName)
+		enrolled := c.completeEnrollToCert(t, idName)
 
 		enrollToNone := testutil.ExtJwtSignerSpec{}
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, enrollToNone)
@@ -292,7 +322,7 @@ func (c *extAuthContext) enrollToCertThenNoneRejected(t *testing.T) {
 		enrollToNoneIdentity := testutil.NewUrlIdentityData(idName, c.overlay.ControllerHostPort(), testutil.EnrollModeNone)
 		addResp := c.zet.AddIdentity(t, enrollToNoneIdentity)
 		addResp.AssertFail(500, "identity exists with the same name")
-		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeCert)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, enrolled.Id.Identifier, testutil.EnrollModeCert)
 	})
 }
 
@@ -301,13 +331,13 @@ func (c *extAuthContext) enrollToCertThenTokenRejected(t *testing.T) {
 		idName := "test_ext_auth_cert_then_token"
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
-		identifier := c.completeEnrollToCert(t, idName)
+		enrolled := c.completeEnrollToCert(t, idName)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
 		enrollToTokenIdentity := testutil.NewUrlIdentityData(idName, c.overlay.ControllerHostPort(), testutil.EnrollModeToken, c.workingSigner.name)
 		addResp := c.zet.AddIdentity(t, enrollToTokenIdentity)
 		addResp.AssertFail(500, "identity exists with the same name")
-		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeCert)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, enrolled.Id.Identifier, testutil.EnrollModeCert)
 	})
 }
 
@@ -316,12 +346,12 @@ func (c *extAuthContext) enrollToTokenThenCertRejected(t *testing.T) {
 		idName := "test_ext_auth_token_then_cert"
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
-		identifier := c.completeEnrollToToken(t, idName)
+		enrolled := c.completeEnrollToToken(t, idName)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
 		enrollToCertIdentity := testutil.NewUrlIdentityData(idName, c.overlay.ControllerHostPort(), testutil.EnrollModeCert, c.workingSigner.name)
 		addResp := c.zet.AddIdentity(t, enrollToCertIdentity)
 		addResp.AssertFail(500, "identity exists with the same name")
-		testutil.AssertValidUrlEnrolledIdentityFile(t, identifier, testutil.EnrollModeToken)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, enrolled.Id.Identifier, testutil.EnrollModeToken)
 	})
 }

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -114,25 +114,22 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 func (c *extAuthContext) enrollToNoneCompletes(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		idName := "test_ext_auth_none_happy"
-		identityEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
-		authURL := c.zet.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name)
+		idEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
+		authURL := c.zet.GetExternalAuthURL(t, idEvent.Id.Identifier, c.workingSigner.name)
 
 		c.idp.DriveIdPFlow(t, authURL, idName+"@test.com")
 
-		added := c.zet.WaitForIdentityEvent(t, "added", idName)
-		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after IdP login flow", added.Id.NeedsExtAuth)
-		require.True(t, added.Id.Active, "identity:added Active=%t after IdP login flow", added.Id.Active)
-		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeNone)
+		c.assertEnrollmentSucceeded(t, idName, testutil.EnrollModeNone)
 	})
 }
 
 func (c *extAuthContext) enrollToNoneRejectsInvalidProvider(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		idName := "test_ext_auth_invalid_provider"
-		identityEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
+		idEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
 
 		bogusProvider := c.workingSigner.name + "-bogus"
-		extAuthResp := c.zet.ExternalAuth(t, identityEvent.Id.Identifier, bogusProvider)
+		extAuthResp := c.zet.ExternalAuth(t, idEvent.Id.Identifier, bogusProvider)
 		extAuthResp.AssertFail(500, "invalid provider")
 	})
 }
@@ -144,9 +141,9 @@ func (c *extAuthContext) enrollToNoneRejectsUnknownControllerIdentity(t *testing
 		// OIDC flow at the IdP still succeeds, but the controller rejects login
 		// since nothing maps this test's user to a known identity.
 
-		identityEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
+		idEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
 
-		authURL := c.zet.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name)
+		authURL := c.zet.GetExternalAuthURL(t, idEvent.Id.Identifier, c.workingSigner.name)
 
 		c.idp.DriveIdPFlow(t, authURL, idName+"@test.com")
 
@@ -157,17 +154,14 @@ func (c *extAuthContext) enrollToNoneRejectsUnknownControllerIdentity(t *testing
 func (c *extAuthContext) enrollToNoneMultipleSignersDefaultPolicyCompletes(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		idName := "test_ext_auth_multi_default"
-		identityEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
-		require.Subset(t, identityEvent.Id.ExtAuthProviders, []string{c.workingSigner.name, c.extraSignerA.name, c.extraSignerB.name}, "identity:needs_ext_login ExtAuthProviders should contain all three signers, got %v", identityEvent.Id.ExtAuthProviders)
+		idEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
+		require.Subset(t, idEvent.Id.ExtAuthProviders, []string{c.workingSigner.name, c.extraSignerA.name, c.extraSignerB.name}, "identity:needs_ext_login ExtAuthProviders should contain all three signers, got %v", idEvent.Id.ExtAuthProviders)
 
-		authURL := c.zet.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name)
+		authURL := c.zet.GetExternalAuthURL(t, idEvent.Id.Identifier, c.workingSigner.name)
 
 		c.idp.DriveIdPFlow(t, authURL, idName+"@test.com")
 
-		added := c.zet.WaitForIdentityEvent(t, "added", idName)
-		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after multi-signer IdP login flow", added.Id.NeedsExtAuth)
-		require.True(t, added.Id.Active, "identity:added Active=%t after multi-signer IdP login flow", added.Id.Active)
-		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeNone)
+		c.assertEnrollmentSucceeded(t, idName, testutil.EnrollModeNone)
 	})
 }
 
@@ -180,17 +174,14 @@ func (c *extAuthContext) enrollToNoneMultipleSignersNamedPolicyCompletes(t *test
 
 		c.overlay.CreateIdentityWithExternalId(t, idName, idName+"@test.com", policyName)
 
-		identityEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
-		require.Subset(t, identityEvent.Id.ExtAuthProviders, []string{c.workingSigner.name, c.extraSignerA.name, c.extraSignerB.name}, "identity:needs_ext_login ExtAuthProviders should contain all three signers, got %v", identityEvent.Id.ExtAuthProviders)
+		idEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
+		require.Subset(t, idEvent.Id.ExtAuthProviders, []string{c.workingSigner.name, c.extraSignerA.name, c.extraSignerB.name}, "identity:needs_ext_login ExtAuthProviders should contain all three signers, got %v", idEvent.Id.ExtAuthProviders)
 
-		authURL := c.zet.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name)
+		authURL := c.zet.GetExternalAuthURL(t, idEvent.Id.Identifier, c.workingSigner.name)
 
 		c.idp.DriveIdPFlow(t, authURL, idName+"@test.com")
 
-		added := c.zet.WaitForIdentityEvent(t, "added", idName)
-		require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after multi-signer IdP login flow", added.Id.NeedsExtAuth)
-		require.True(t, added.Id.Active, "identity:added Active=%t after multi-signer IdP login flow", added.Id.Active)
-		testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeNone)
+		c.assertEnrollmentSucceeded(t, idName, testutil.EnrollModeNone)
 	})
 }
 
@@ -210,6 +201,16 @@ func (c *extAuthContext) beginEnrollment(t *testing.T, identityData testutil.Add
 	return addResp.Data.URL
 }
 
+// assertEnrollmentSucceeded waits for the identity:added event, asserts the identity is
+// active with no pending ext-auth, validates its on-disk file for mode, and returns it.
+func (c *extAuthContext) assertEnrollmentSucceeded(t *testing.T, idName string, mode testutil.EnrollMode) testutil.IdentityEvent {
+	idAddedEvent := c.zet.WaitForIdentityEvent(t, "added", idName)
+	require.True(t, idAddedEvent.Id.Active)
+	require.False(t, idAddedEvent.Id.NeedsExtAuth)
+	testutil.AssertValidUrlEnrolledIdentityFile(t, idAddedEvent.Id.Identifier, mode)
+	return idAddedEvent
+}
+
 // completeEnrollToCert drives a full enroll-to-cert flow for name and returns the
 // identity:added event. The working signer must already have EnrollToCert enabled.
 func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) testutil.IdentityEvent {
@@ -218,27 +219,23 @@ func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) testuti
 
 	c.idp.DriveIdPFlow(t, authURL, name+"@test.com")
 
-	added := c.zet.WaitForIdentityEvent(t, "added", name)
-	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to cert IdP login flow", added.Id.Active)
-	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to cert IdP login flow", added.Id.NeedsExtAuth)
-	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeCert)
-	return added
+	return c.assertEnrollmentSucceeded(t, name, testutil.EnrollModeCert)
 }
 
 // Asserts a URL-enrolled identity is provisioned with the name the ext-jwt-signer's
 // --enroll-name-claims-selector flag resolves to.
-func (c *extAuthContext) assertExpectedIdentityName(t *testing.T, enrolled testutil.IdentityEvent, idName string) {
-	require.Contains(t, enrolled.Id.Name, idName)
-	provisioned := c.zet.WaitForIdentityEvent(t, "added", idName)
-	require.Equal(t, idName+"@test.com", provisioned.Id.Name)
+func (c *extAuthContext) assertExpectedIdentityName(t *testing.T, idEvent testutil.IdentityEvent, idName string) {
+	require.Contains(t, idEvent.Id.Name, idName)
+	idAddedEvent := c.zet.WaitForIdentityEvent(t, "added", idName)
+	require.Equal(t, idName+"@test.com", idAddedEvent.Id.Name)
 }
 
 func (c *extAuthContext) enrollToCertUsesNameClaimSelector(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollNameSelector: "/email"})
 		idName := "test_ext_auth_name_selector"
-		enrolled := c.completeEnrollToCert(t, idName)
-		c.assertExpectedIdentityName(t, enrolled, idName)
+		idEvent := c.completeEnrollToCert(t, idName)
+		c.assertExpectedIdentityName(t, idEvent, idName)
 	})
 }
 
@@ -257,17 +254,13 @@ func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) testut
 
 	c.idp.DriveIdPFlow(t, authURL, name+"@test.com")
 
-	identityEvent := c.zet.WaitForIdentityEvent(t, "needs_ext_login", name)
-	require.True(t, identityEvent.Id.NeedsExtAuth, "identity:needs_ext_login NeedsExtAuth=%t after enroll to token IdP login flow", identityEvent.Id.NeedsExtAuth)
-	authURL = c.zet.GetExternalAuthURL(t, identityEvent.Id.Identifier, c.workingSigner.name)
+	idEvent := c.zet.WaitForIdentityEvent(t, "needs_ext_login", name)
+	require.True(t, idEvent.Id.NeedsExtAuth)
+	authURL = c.zet.GetExternalAuthURL(t, idEvent.Id.Identifier, c.workingSigner.name)
 
 	c.idp.DriveIdPFlow(t, authURL, name+"@test.com")
 
-	added := c.zet.WaitForIdentityEvent(t, "added", name)
-	require.True(t, added.Id.Active, "identity:added Active=%t after enroll to token IdP login flow", added.Id.Active)
-	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to token IdP login flow", added.Id.NeedsExtAuth)
-	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeToken)
-	return added
+	return c.assertEnrollmentSucceeded(t, name, testutil.EnrollModeToken)
 }
 
 // assertGrantedServices waits for a bulk service event and asserts the identity was
@@ -322,8 +315,8 @@ func (c *extAuthContext) enrollToTokenUsesNameClaimSelector(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollNameSelector: "/email"})
 		idName := "test_ext_auth_token_name_selector"
-		enrolled := c.completeEnrollToToken(t, idName)
-		c.assertExpectedIdentityName(t, enrolled, idName)
+		idEvent := c.completeEnrollToToken(t, idName)
+		c.assertExpectedIdentityName(t, idEvent, idName)
 	})
 }
 
@@ -343,13 +336,13 @@ func (c *extAuthContext) enrollToNoneThenCertRejected(t *testing.T) {
 
 		enrollToNone := testutil.ExtJwtSignerSpec{}
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, enrollToNone)
-		identityEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
+		idEvent := testutil.EnrollUrlIdentityToNone(t, c.overlay, c.zet, idName)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
 		enrollToCertIdentity := testutil.NewUrlIdentityData(idName, c.overlay.ControllerHostPort(), testutil.EnrollModeCert, c.workingSigner.name)
 		addResp := c.zet.AddIdentity(t, enrollToCertIdentity)
 		addResp.AssertFail(500, "identity exists with the same name")
-		testutil.AssertValidUrlEnrolledIdentityFile(t, identityEvent.Id.Identifier, testutil.EnrollModeNone)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, idEvent.Id.Identifier, testutil.EnrollModeNone)
 	})
 }
 
@@ -358,7 +351,7 @@ func (c *extAuthContext) enrollToCertThenNoneRejected(t *testing.T) {
 		idName := "test_ext_auth_cert_then_none"
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
-		enrolled := c.completeEnrollToCert(t, idName)
+		idEvent := c.completeEnrollToCert(t, idName)
 
 		enrollToNone := testutil.ExtJwtSignerSpec{}
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, enrollToNone)
@@ -366,7 +359,7 @@ func (c *extAuthContext) enrollToCertThenNoneRejected(t *testing.T) {
 		enrollToNoneIdentity := testutil.NewUrlIdentityData(idName, c.overlay.ControllerHostPort(), testutil.EnrollModeNone)
 		addResp := c.zet.AddIdentity(t, enrollToNoneIdentity)
 		addResp.AssertFail(500, "identity exists with the same name")
-		testutil.AssertValidUrlEnrolledIdentityFile(t, enrolled.Id.Identifier, testutil.EnrollModeCert)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, idEvent.Id.Identifier, testutil.EnrollModeCert)
 	})
 }
 
@@ -375,13 +368,13 @@ func (c *extAuthContext) enrollToCertThenTokenRejected(t *testing.T) {
 		idName := "test_ext_auth_cert_then_token"
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
-		enrolled := c.completeEnrollToCert(t, idName)
+		idEvent := c.completeEnrollToCert(t, idName)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
 		enrollToTokenIdentity := testutil.NewUrlIdentityData(idName, c.overlay.ControllerHostPort(), testutil.EnrollModeToken, c.workingSigner.name)
 		addResp := c.zet.AddIdentity(t, enrollToTokenIdentity)
 		addResp.AssertFail(500, "identity exists with the same name")
-		testutil.AssertValidUrlEnrolledIdentityFile(t, enrolled.Id.Identifier, testutil.EnrollModeCert)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, idEvent.Id.Identifier, testutil.EnrollModeCert)
 	})
 }
 
@@ -390,12 +383,12 @@ func (c *extAuthContext) enrollToTokenThenCertRejected(t *testing.T) {
 		idName := "test_ext_auth_token_then_cert"
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true})
-		enrolled := c.completeEnrollToToken(t, idName)
+		idEvent := c.completeEnrollToToken(t, idName)
 
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true})
 		enrollToCertIdentity := testutil.NewUrlIdentityData(idName, c.overlay.ControllerHostPort(), testutil.EnrollModeCert, c.workingSigner.name)
 		addResp := c.zet.AddIdentity(t, enrollToCertIdentity)
 		addResp.AssertFail(500, "identity exists with the same name")
-		testutil.AssertValidUrlEnrolledIdentityFile(t, enrolled.Id.Identifier, testutil.EnrollModeToken)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, idEvent.Id.Identifier, testutil.EnrollModeToken)
 	})
 }

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -102,6 +102,8 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 	t.Run("enrollToTokenUsesNameClaimSelector", c.enrollToTokenUsesNameClaimSelector)
 	t.Run("enrollToCertUsesAttrClaimSelector", c.enrollToCertUsesAttrClaimSelector)
 	t.Run("enrollToTokenUsesAttrClaimSelector", c.enrollToTokenUsesAttrClaimSelector)
+	t.Run("enrollToCertUsesMultipleAttrClaims", c.enrollToCertUsesMultipleAttrClaims)
+	t.Run("enrollToTokenUsesMultipleAttrClaims", c.enrollToTokenUsesMultipleAttrClaims)
 	t.Run("bothEnrollFlowsCompleteWhenBothEnabled", c.bothEnrollFlowsCompleteWhenBothEnabled)
 	t.Run("enrollToNoneThenCertRejected", c.enrollToNoneThenCertRejected)
 	t.Run("enrollToCertThenNoneRejected", c.enrollToCertThenNoneRejected)
@@ -268,22 +270,25 @@ func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) testut
 	return added
 }
 
+// assertGrantedServices waits for a bulk service event and asserts the identity was
+// granted the expected services. The fixture gates services on #ziti-user and
+// #ziti-admin, so the granted set reflects the attributes the selector applied.
+func (c *extAuthContext) assertGrantedServices(t *testing.T, idName string, expected ...string) {
+	bulkServiceEvent := c.zet.WaitForBulkServiceEvent(t, "updated", idName)
+	grantedServices := []string{}
+	for _, s := range bulkServiceEvent.AddedServices {
+		grantedServices = append(grantedServices, s.Name)
+	}
+	require.ElementsMatch(t, expected, grantedServices)
+}
+
 func (c *extAuthContext) enrollToCertUsesAttrClaimSelector(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollAttrSelector: "/groups"})
 		idName := "test_ext_auth_attr_selector"
 		c.completeEnrollToCert(t, idName)
-		c.assertOnlyUserServiceGranted(t, idName)
+		c.assertGrantedServices(t, idName, "test_ext_auth_attr_user_svc")
 	})
-}
-
-// assertOnlyUserServiceGranted checks the attribute selector put ziti-user and nothing
-// else on the identity. The fixture grants one service to #ziti-user and another to
-// #ziti-admin, so a ziti-user-only claim must yield exactly the user service.
-func (c *extAuthContext) assertOnlyUserServiceGranted(t *testing.T, idName string) {
-	bulkServiceEvent := c.zet.WaitForBulkServiceEvent(t, "updated", idName)
-	require.Len(t, bulkServiceEvent.AddedServices, 1, "expected only the ziti-user service to be granted")
-	require.Equal(t, "test_ext_auth_attr_user_svc", bulkServiceEvent.AddedServices[0].Name)
 }
 
 func (c *extAuthContext) enrollToTokenUsesAttrClaimSelector(t *testing.T) {
@@ -291,7 +296,25 @@ func (c *extAuthContext) enrollToTokenUsesAttrClaimSelector(t *testing.T) {
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollAttrSelector: "/groups"})
 		idName := "test_ext_auth_token_attr_selector"
 		c.completeEnrollToToken(t, idName)
-		c.assertOnlyUserServiceGranted(t, idName)
+		c.assertGrantedServices(t, idName, "test_ext_auth_attr_user_svc")
+	})
+}
+
+func (c *extAuthContext) enrollToCertUsesMultipleAttrClaims(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollAttrSelector: "/groups"})
+		idName := "test_ext_auth_multi_attr_selector"
+		c.completeEnrollToCert(t, idName)
+		c.assertGrantedServices(t, idName, "test_ext_auth_attr_user_svc", "test_ext_auth_attr_admin_svc")
+	})
+}
+
+func (c *extAuthContext) enrollToTokenUsesMultipleAttrClaims(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollAttrSelector: "/groups"})
+		idName := "test_ext_auth_token_multi_attr_selector"
+		c.completeEnrollToToken(t, idName)
+		c.assertGrantedServices(t, idName, "test_ext_auth_attr_user_svc", "test_ext_auth_attr_admin_svc")
 	})
 }
 

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -111,6 +111,10 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollNameSelector: "/email"})
 	t.Run("enrollToTokenUsesNameClaimSelector", c.enrollToTokenUsesNameClaimSelector)
 
+	attrScopes := append(strings.Fields(c.idp.Scopes), "groups")
+	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollAttrSelector: "/groups", Scopes: attrScopes})
+	t.Run("enrollToCertUsesAttrClaimSelector", c.enrollToCertUsesAttrClaimSelector)
+
 	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollToToken: true})
 	t.Run("bothEnrollFlowsCompleteWhenBothEnabled", c.bothEnrollFlowsCompleteWhenBothEnabled)
 
@@ -274,6 +278,19 @@ func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) testut
 	require.False(t, added.Id.NeedsExtAuth, "identity:added NeedsExtAuth=%t after enroll to token IdP login flow", added.Id.NeedsExtAuth)
 	testutil.AssertValidUrlEnrolledIdentityFile(t, added.Id.Identifier, testutil.EnrollModeToken)
 	return added
+}
+
+func (c *extAuthContext) enrollToCertUsesAttrClaimSelector(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		idName := "test_ext_auth_attr_selector"
+		c.completeEnrollToCert(t, idName)
+
+		// The fixture grants one service to #ziti-user and another to #ziti-admin.
+		// The groups claim carries only ziti-user, so we should only see the user svc in the bulk service event
+		bulkServiceEvent := c.zet.WaitForBulkServiceEvent(t, "updated", idName)
+		require.Len(t, bulkServiceEvent.AddedServices, 1, "expected only the ziti-user service to be granted")
+		require.Equal(t, "test_ext_auth_attr_user_svc", bulkServiceEvent.AddedServices[0].Name)
+	})
 }
 
 func (c *extAuthContext) enrollToTokenUsesNameClaimSelector(t *testing.T) {

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -104,6 +104,7 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 	t.Run("enrollToTokenUsesAttrClaimSelector", c.enrollToTokenUsesAttrClaimSelector)
 	t.Run("enrollToCertUsesMultipleAttrClaims", c.enrollToCertUsesMultipleAttrClaims)
 	t.Run("enrollToTokenUsesMultipleAttrClaims", c.enrollToTokenUsesMultipleAttrClaims)
+	t.Run("enrollToCertUsesEnrollAuthPolicy", c.enrollToCertUsesEnrollAuthPolicy)
 	t.Run("bothEnrollFlowsCompleteWhenBothEnabled", c.bothEnrollFlowsCompleteWhenBothEnabled)
 	t.Run("enrollToNoneThenCertRejected", c.enrollToNoneThenCertRejected)
 	t.Run("enrollToCertThenNoneRejected", c.enrollToCertThenNoneRejected)
@@ -308,6 +309,19 @@ func (c *extAuthContext) enrollToTokenUsesMultipleAttrClaims(t *testing.T) {
 		idName := "test_ext_auth_token_multi_attr_selector"
 		c.completeEnrollToToken(t, idName)
 		c.assertGrantedServices(t, idName, "test_ext_auth_attr_user_svc", "test_ext_auth_attr_admin_svc")
+	})
+}
+
+func (c *extAuthContext) enrollToCertUsesEnrollAuthPolicy(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollAuthPolicy: "test_mfa_totp_policy"})
+		idName := "test_ext_auth_enroll_auth_policy"
+		identityData := testutil.NewUrlIdentityData(idName, c.overlay.ControllerHostPort(), testutil.EnrollModeCert, c.workingSigner.name)
+		authURL := c.beginEnrollment(t, identityData)
+		c.idp.DriveIdPFlow(t, authURL, idName+"@test.com")
+
+		// The enroll-auth-policy requires TOTP, so the provisioned identity needs MFA enrollment
+		c.zet.WaitForMfaEvent(t, "enrollment_required", idName)
 	})
 }
 

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -105,6 +105,7 @@ func TestExternalAuthSingleSigner(t *testing.T) {
 	t.Run("enrollToCertUsesMultipleAttrClaims", c.enrollToCertUsesMultipleAttrClaims)
 	t.Run("enrollToTokenUsesMultipleAttrClaims", c.enrollToTokenUsesMultipleAttrClaims)
 	t.Run("enrollToCertUsesEnrollAuthPolicy", c.enrollToCertUsesEnrollAuthPolicy)
+	t.Run("enrollToTokenUsesEnrollAuthPolicy", c.enrollToTokenUsesEnrollAuthPolicy)
 	t.Run("bothEnrollFlowsCompleteWhenBothEnabled", c.bothEnrollFlowsCompleteWhenBothEnabled)
 	t.Run("enrollToNoneThenCertRejected", c.enrollToNoneThenCertRejected)
 	t.Run("enrollToCertThenNoneRejected", c.enrollToCertThenNoneRejected)
@@ -316,11 +317,31 @@ func (c *extAuthContext) enrollToCertUsesEnrollAuthPolicy(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollAuthPolicy: "test_mfa_totp_policy"})
 		idName := "test_ext_auth_enroll_auth_policy"
-		identityData := testutil.NewUrlIdentityData(idName, c.overlay.ControllerHostPort(), testutil.EnrollModeCert, c.workingSigner.name)
-		authURL := c.beginEnrollment(t, identityData)
-		c.idp.DriveIdPFlow(t, authURL, idName+"@test.com")
+		idEvent := c.completeEnrollToCert(t, idName)
 
-		// The enroll-auth-policy requires TOTP, so the provisioned identity needs MFA enrollment
+		// TOTP-required policy: the identity is partially-authed, needs MFA
+		c.zet.WaitForControllerEvent(t, "disconnected", idName)
+		statusEvent := c.zet.WaitForStatusEvent(t)
+		provisionedId := findIdentityInStatus(t, statusEvent, idEvent.Id.Identifier)
+		require.True(t, provisionedId.MfaNeeded)
+		require.False(t, provisionedId.MfaEnabled)
+		c.zet.WaitForMfaEvent(t, "enrollment_required", idName)
+	})
+}
+
+func (c *extAuthContext) enrollToTokenUsesEnrollAuthPolicy(t *testing.T) {
+	t.Skip("enroll to token with a TOTP required auth policy hangs on reauth: https://github.com/openziti/ziti-sdk-c/issues/1083")
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollAuthPolicy: "test_mfa_totp_policy"})
+		idName := "test_ext_auth_token_enroll_auth_policy"
+		idEvent := c.completeEnrollToToken(t, idName)
+
+		// TOTP-required policy: the identity partial-auths (disconnect), needs MFA, and is not yet enrolled
+		c.zet.WaitForControllerEvent(t, "disconnected", idName)
+		statusEvent := c.zet.WaitForStatusEvent(t)
+		provisionedId := findIdentityInStatus(t, statusEvent, idEvent.Id.Identifier)
+		require.True(t, provisionedId.MfaNeeded)
+		require.False(t, provisionedId.MfaEnabled)
 		c.zet.WaitForMfaEvent(t, "enrollment_required", idName)
 	})
 }

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -371,8 +371,8 @@ func (c *extAuthContext) enrollToTokenUsesNameClaimSelector(t *testing.T) {
 }
 
 func (c *extAuthContext) bothEnrollFlowsCompleteWhenBothEnabled(t *testing.T) {
-	c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollToToken: true})
 	testutil.RunWithTimeout(t, func(t *testing.T) {
+		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollToToken: true})
 		c.completeEnrollToCert(t, "test_ext_auth_cert_both")
 	})
 	testutil.RunWithTimeout(t, func(t *testing.T) {

--- a/tests/integration/external_auth_test.go
+++ b/tests/integration/external_auth_test.go
@@ -213,14 +213,18 @@ func (c *extAuthContext) assertEnrollmentSucceeded(t *testing.T, idName string, 
 	return idAddedEvent
 }
 
-// completeEnrollToCert drives a full enroll-to-cert flow for name and returns the
-// identity:added event. The working signer must already have EnrollToCert enabled.
-func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) testutil.IdentityEvent {
+// driveEnrollToCert runs the enroll-to-cert IdP flow for an identity. The working signer
+// must already have EnrollToCert enabled.
+func (c *extAuthContext) driveEnrollToCert(t *testing.T, name string) {
 	identityData := testutil.NewUrlIdentityData(name, c.overlay.ControllerHostPort(), testutil.EnrollModeCert, c.workingSigner.name)
 	authURL := c.beginEnrollment(t, identityData)
-
 	c.idp.DriveIdPFlow(t, authURL, name+"@test.com")
+}
 
+// completeEnrollToCert drives a full enroll-to-cert flow for an identity and returns the
+// identity:added event. The working signer must already have EnrollToCert enabled.
+func (c *extAuthContext) completeEnrollToCert(t *testing.T, name string) testutil.IdentityEvent {
+	c.driveEnrollToCert(t, name)
 	return c.assertEnrollmentSucceeded(t, name, testutil.EnrollModeCert)
 }
 
@@ -248,9 +252,10 @@ func (c *extAuthContext) enrollToTokenCompletes(t *testing.T) {
 	})
 }
 
-// completeEnrollToToken drives a full enroll-to-token flow for name and returns the
-// identity:added event. The working signer must already have EnrollToToken enabled.
-func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) testutil.IdentityEvent {
+// driveEnrollToToken runs both IdP flows of an enroll-to-token for an identity (the enrollment,
+// then the loaded identity's login) and returns the needs_ext_login event. The working signer
+// must already have EnrollToToken enabled.
+func (c *extAuthContext) driveEnrollToToken(t *testing.T, name string) testutil.IdentityEvent {
 	identityData := testutil.NewUrlIdentityData(name, c.overlay.ControllerHostPort(), testutil.EnrollModeToken, c.workingSigner.name)
 	authURL := c.beginEnrollment(t, identityData)
 
@@ -261,7 +266,13 @@ func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) testut
 	authURL = c.zet.GetExternalAuthURL(t, idEvent.Id.Identifier, c.workingSigner.name)
 
 	c.idp.DriveIdPFlow(t, authURL, name+"@test.com")
+	return idEvent
+}
 
+// completeEnrollToToken drives a full enroll-to-token flow for an identity and returns the
+// identity:added event. The working signer must already have EnrollToToken enabled.
+func (c *extAuthContext) completeEnrollToToken(t *testing.T, name string) testutil.IdentityEvent {
+	c.driveEnrollToToken(t, name)
 	return c.assertEnrollmentSucceeded(t, name, testutil.EnrollModeToken)
 }
 
@@ -313,36 +324,40 @@ func (c *extAuthContext) enrollToTokenUsesMultipleAttrClaims(t *testing.T) {
 	})
 }
 
+// Enrolls to cert under a TOTP-required auth policy.
 func (c *extAuthContext) enrollToCertUsesEnrollAuthPolicy(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToCert: true, EnrollAuthPolicy: "test_mfa_totp_policy"})
 		idName := "test_ext_auth_enroll_auth_policy"
-		idEvent := c.completeEnrollToCert(t, idName)
+		// A partial auth emits no identity:added, so drive browser flow without waiting for one.
+		c.driveEnrollToCert(t, idName)
 
-		// TOTP-required policy: the identity is partially-authed, needs MFA
-		c.zet.WaitForControllerEvent(t, "disconnected", idName)
+		// No needs_ext_login event to carry the identifier for cert, so take it from the mfa event.
 		statusEvent := c.zet.WaitForStatusEvent(t)
-		provisionedId := findIdentityInStatus(t, statusEvent, idEvent.Id.Identifier)
+		mfaEvent := c.zet.WaitForMfaEvent(t, "enrollment_required", idName)
+		provisionedId := findIdentityInStatus(t, statusEvent, mfaEvent.Identifier)
+		require.False(t, provisionedId.NeedsExtAuth)
 		require.True(t, provisionedId.MfaNeeded)
 		require.False(t, provisionedId.MfaEnabled)
-		c.zet.WaitForMfaEvent(t, "enrollment_required", idName)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, mfaEvent.Identifier, testutil.EnrollModeCert)
 	})
 }
 
+// Enrolls to token under a TOTP-required auth policy.
 func (c *extAuthContext) enrollToTokenUsesEnrollAuthPolicy(t *testing.T) {
-	t.Skip("enroll to token with a TOTP required auth policy hangs on reauth: https://github.com/openziti/ziti-sdk-c/issues/1083")
 	testutil.RunWithTimeout(t, func(t *testing.T) {
 		c.overlay.UpdateExtJwtSigner(t, c.workingSigner.name, testutil.ExtJwtSignerSpec{EnrollToToken: true, EnrollAuthPolicy: "test_mfa_totp_policy"})
 		idName := "test_ext_auth_token_enroll_auth_policy"
-		idEvent := c.completeEnrollToToken(t, idName)
+		// A partial auth emits no identity:added, so drive browser flow without waiting for one.
+		idEvent := c.driveEnrollToToken(t, idName)
 
-		// TOTP-required policy: the identity partial-auths (disconnect), needs MFA, and is not yet enrolled
-		c.zet.WaitForControllerEvent(t, "disconnected", idName)
 		statusEvent := c.zet.WaitForStatusEvent(t)
 		provisionedId := findIdentityInStatus(t, statusEvent, idEvent.Id.Identifier)
+		require.False(t, provisionedId.NeedsExtAuth)
 		require.True(t, provisionedId.MfaNeeded)
 		require.False(t, provisionedId.MfaEnabled)
 		c.zet.WaitForMfaEvent(t, "enrollment_required", idName)
+		testutil.AssertValidUrlEnrolledIdentityFile(t, idEvent.Id.Identifier, testutil.EnrollModeToken)
 	})
 }
 

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -187,6 +187,10 @@ func doSetup(state TestState) error {
 	if err := state.overlay.PurgeIdentities(); err != nil {
 		return fmt.Errorf("purge stale test identities: %w", err)
 	}
+	log.Printf("setup: purging stale auto-provisioned IdP identities")
+	if err := state.overlay.PurgeIdentitiesByExternalId("@test.com"); err != nil {
+		return fmt.Errorf("purge stale IdP test user identities: %w", err)
+	}
 	log.Printf("setup: purging stale test auth-policies")
 	if err := state.overlay.PurgeAuthPolicies(); err != nil {
 		return fmt.Errorf("purge stale test auth policies: %w", err)
@@ -194,10 +198,6 @@ func doSetup(state TestState) error {
 	log.Printf("setup: purging stale test ext-jwt-signers")
 	if err := state.overlay.PurgeExtJwtSigners(); err != nil {
 		return fmt.Errorf("purge stale test ext-jwt-signers: %w", err)
-	}
-	log.Printf("setup: purging stale auto-provisioned IdP identities")
-	if err := state.overlay.PurgeIdentitiesByExternalId("@test.com"); err != nil {
-		return fmt.Errorf("purge stale IdP test user identities: %w", err)
 	}
 	log.Printf("setup: purging stale test service-policies")
 	if err := state.overlay.PurgeServicePolicies(); err != nil {

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -191,13 +191,13 @@ func doSetup(state TestState) error {
 	if err := state.overlay.PurgeIdentitiesByExternalId("@test.com"); err != nil {
 		return fmt.Errorf("purge stale IdP test user identities: %w", err)
 	}
-	log.Printf("setup: purging stale test auth-policies")
-	if err := state.overlay.PurgeAuthPolicies(); err != nil {
-		return fmt.Errorf("purge stale test auth policies: %w", err)
-	}
 	log.Printf("setup: purging stale test ext-jwt-signers")
 	if err := state.overlay.PurgeExtJwtSigners(); err != nil {
 		return fmt.Errorf("purge stale test ext-jwt-signers: %w", err)
+	}
+	log.Printf("setup: purging stale test auth-policies")
+	if err := state.overlay.PurgeAuthPolicies(); err != nil {
+		return fmt.Errorf("purge stale test auth policies: %w", err)
 	}
 	log.Printf("setup: purging stale test service-policies")
 	if err := state.overlay.PurgeServicePolicies(); err != nil {

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -191,13 +191,13 @@ func doSetup(state TestState) error {
 	if err := state.overlay.PurgeIdentitiesByExternalId("@test.com"); err != nil {
 		return fmt.Errorf("purge stale IdP test user identities: %w", err)
 	}
-	log.Printf("setup: purging stale test ext-jwt-signers")
-	if err := state.overlay.PurgeExtJwtSigners(); err != nil {
-		return fmt.Errorf("purge stale test ext-jwt-signers: %w", err)
-	}
 	log.Printf("setup: purging stale test auth-policies")
 	if err := state.overlay.PurgeAuthPolicies(); err != nil {
 		return fmt.Errorf("purge stale test auth policies: %w", err)
+	}
+	log.Printf("setup: purging stale test ext-jwt-signers")
+	if err := state.overlay.PurgeExtJwtSigners(); err != nil {
+		return fmt.Errorf("purge stale test ext-jwt-signers: %w", err)
 	}
 	log.Printf("setup: purging stale test service-policies")
 	if err := state.overlay.PurgeServicePolicies(); err != nil {

--- a/tests/integration/scripts/run-ci.ps1
+++ b/tests/integration/scripts/run-ci.ps1
@@ -137,7 +137,7 @@ try {
             clientId       = "ziti-test"
             extraClientIds = @("ziti-test-2", "ziti-test-3")
             audience       = "ziti-test"
-            scopes         = "openid profile email"
+            scopes         = "openid profile email groups"
             password       = "password"
         }
     }

--- a/tests/integration/scripts/run-ci.sh
+++ b/tests/integration/scripts/run-ci.sh
@@ -139,7 +139,7 @@ jq -n \
       clientId: "ziti-test",
       extraClientIds: ["ziti-test-2", "ziti-test-3"],
       audience: "ziti-test",
-      scopes: "openid profile email",
+      scopes: "openid profile email groups",
       password: "password"
     }
   }' > config.json

--- a/tests/integration/testdata/dex-config.yaml
+++ b/tests/integration/testdata/dex-config.yaml
@@ -60,6 +60,12 @@ staticPasswords:
     hash: *password
     username: test_ext_auth_token_name_selector
     userID: test_ext_auth_token_name_selector
+  - email: test_ext_auth_attr_selector@test.com
+    hash: *password
+    username: test_ext_auth_attr_selector
+    userID: test_ext_auth_attr_selector
+    groups:
+      - ziti-user
   - email: test_ext_auth_cert_both@test.com
     hash: *password
     username: test_ext_auth_cert_both

--- a/tests/integration/testdata/dex-config.yaml
+++ b/tests/integration/testdata/dex-config.yaml
@@ -72,6 +72,20 @@ staticPasswords:
     userID: test_ext_auth_token_attr_selector
     groups:
       - ziti-user
+  - email: test_ext_auth_multi_attr_selector@test.com
+    hash: *password
+    username: test_ext_auth_multi_attr_selector
+    userID: test_ext_auth_multi_attr_selector
+    groups:
+      - ziti-user
+      - ziti-admin
+  - email: test_ext_auth_token_multi_attr_selector@test.com
+    hash: *password
+    username: test_ext_auth_token_multi_attr_selector
+    userID: test_ext_auth_token_multi_attr_selector
+    groups:
+      - ziti-user
+      - ziti-admin
   - email: test_ext_auth_cert_both@test.com
     hash: *password
     username: test_ext_auth_cert_both

--- a/tests/integration/testdata/dex-config.yaml
+++ b/tests/integration/testdata/dex-config.yaml
@@ -52,6 +52,14 @@ staticPasswords:
     hash: *password
     username: test_ext_auth_token_happy
     userID: test_ext_auth_token_happy
+  - email: test_ext_auth_name_selector@test.com
+    hash: *password
+    username: test_ext_auth_name_selector
+    userID: test_ext_auth_name_selector
+  - email: test_ext_auth_token_name_selector@test.com
+    hash: *password
+    username: test_ext_auth_token_name_selector
+    userID: test_ext_auth_token_name_selector
   - email: test_ext_auth_cert_both@test.com
     hash: *password
     username: test_ext_auth_cert_both

--- a/tests/integration/testdata/dex-config.yaml
+++ b/tests/integration/testdata/dex-config.yaml
@@ -86,6 +86,10 @@ staticPasswords:
     groups:
       - ziti-user
       - ziti-admin
+  - email: test_ext_auth_enroll_auth_policy@test.com
+    hash: *password
+    username: test_ext_auth_enroll_auth_policy
+    userID: test_ext_auth_enroll_auth_policy
   - email: test_ext_auth_cert_both@test.com
     hash: *password
     username: test_ext_auth_cert_both

--- a/tests/integration/testdata/dex-config.yaml
+++ b/tests/integration/testdata/dex-config.yaml
@@ -66,6 +66,12 @@ staticPasswords:
     userID: test_ext_auth_attr_selector
     groups:
       - ziti-user
+  - email: test_ext_auth_token_attr_selector@test.com
+    hash: *password
+    username: test_ext_auth_token_attr_selector
+    userID: test_ext_auth_token_attr_selector
+    groups:
+      - ziti-user
   - email: test_ext_auth_cert_both@test.com
     hash: *password
     username: test_ext_auth_cert_both

--- a/tests/integration/testdata/dex-config.yaml
+++ b/tests/integration/testdata/dex-config.yaml
@@ -90,6 +90,10 @@ staticPasswords:
     hash: *password
     username: test_ext_auth_enroll_auth_policy
     userID: test_ext_auth_enroll_auth_policy
+  - email: test_ext_auth_token_enroll_auth_policy@test.com
+    hash: *password
+    username: test_ext_auth_token_enroll_auth_policy
+    userID: test_ext_auth_token_enroll_auth_policy
   - email: test_ext_auth_cert_both@test.com
     hash: *password
     username: test_ext_auth_cert_both

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -4,7 +4,7 @@
       "name": "test_mfa_totp_policy",
       "primary": {
         "cert": { "allowExpiredCerts": false, "allowed": true },
-        "extJwt": { "allowed": false, "allowedSigners": [] },
+        "extJwt": { "allowed": true, "allowedSigners": [] },
         "updb": { "allowed": false, "lockoutDurationMinutes": 0, "maxAttempts": 5, "minPasswordLength": 5, "requireMixedCase": false, "requireNumberChar": false, "requireSpecialChar": false }
       },
       "secondary": { "requireTotp": true },

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -204,5 +204,53 @@
       "authPolicy": "@Default",
       "externalId": "test_ext_auth_multi_default@test.com"
     }
+  ],
+  "configs": [
+    {
+      "name": "test_ext_auth_attr_user_intercept",
+      "configType": "@intercept.v1",
+      "data": {
+        "protocols": ["tcp"],
+        "addresses": ["attr-user.ziti"],
+        "portRanges": [{ "low": 80, "high": 80 }]
+      }
+    },
+    {
+      "name": "test_ext_auth_attr_admin_intercept",
+      "configType": "@intercept.v1",
+      "data": {
+        "protocols": ["tcp"],
+        "addresses": ["attr-admin.ziti"],
+        "portRanges": [{ "low": 80, "high": 80 }]
+      }
+    }
+  ],
+  "services": [
+    {
+      "name": "test_ext_auth_attr_user_svc",
+      "encryptionRequired": true,
+      "configs": ["@test_ext_auth_attr_user_intercept"]
+    },
+    {
+      "name": "test_ext_auth_attr_admin_svc",
+      "encryptionRequired": true,
+      "configs": ["@test_ext_auth_attr_admin_intercept"]
+    }
+  ],
+  "servicePolicies": [
+    {
+      "name": "test_ext_auth_attr_user_dial",
+      "type": "Dial",
+      "semantic": "AnyOf",
+      "identityRoles": ["#ziti-user"],
+      "serviceRoles": ["@test_ext_auth_attr_user_svc"]
+    },
+    {
+      "name": "test_ext_auth_attr_admin_dial",
+      "type": "Dial",
+      "semantic": "AnyOf",
+      "identityRoles": ["#ziti-admin"],
+      "serviceRoles": ["@test_ext_auth_attr_admin_svc"]
+    }
   ]
 }

--- a/tests/integration/testutil/common.go
+++ b/tests/integration/testutil/common.go
@@ -159,7 +159,7 @@ func SetupWorkingExtJwtSigner(t *testing.T, overlay *Overlay, idp *IdP) (string,
 		ClientID: idp.ClientIDWorks,
 		Audience: idp.Audience,
 		Claim:    "email",
-		Scopes:   strings.Fields(idp.Scopes),
+		Scopes:   idp.ScopeList(),
 	})
 	return workingExtJwtSignerName, id
 }

--- a/tests/integration/testutil/idp.go
+++ b/tests/integration/testutil/idp.go
@@ -143,6 +143,10 @@ func (p *IdP) JWKSURI() string {
 	return p.JwksURI
 }
 
+func (p *IdP) ScopeList() []string {
+	return strings.Fields(p.Scopes)
+}
+
 // fetchJWKSURI reads the IdP's OIDC discovery document and returns its jwks_uri.
 // This is the standard endpoint across dex, keycloak, and auth0, so the signer
 // gets the right JWKS URL without per-IdP conventions.

--- a/tests/integration/testutil/ipc.go
+++ b/tests/integration/testutil/ipc.go
@@ -238,6 +238,14 @@ func (c *EventClient) WaitForMfaEvent(t *testing.T, action, fingerprint string) 
 	return ev
 }
 
+// WaitForBulkServiceEvent waits for an Op:"bulkservice" event matching action/fingerprint.
+func (c *EventClient) WaitForBulkServiceEvent(t *testing.T, action, fingerprint string) BulkServiceEvent {
+	raw := c.waitForEvent(t, "bulkservice", action, fingerprint)
+	var ev BulkServiceEvent
+	require.NoError(t, json.Unmarshal(raw, &ev), "parse BulkServiceEvent: %s", raw)
+	return ev
+}
+
 // WaitForStatusEvent waits for the Op:"status" push the daemon sends to every
 // event-pipe client on connect.
 func (c *EventClient) WaitForStatusEvent(t *testing.T) TunnelStatusEvent {

--- a/tests/integration/testutil/ipc_types.go
+++ b/tests/integration/testutil/ipc_types.go
@@ -471,3 +471,49 @@ type MetricsEvent struct {
 	StatusEvent
 	Identities []Identity `json:"Identities"`
 }
+
+type Service struct {
+	Name             string         `json:"Name"`
+	Protocols        []string       `json:"Protocols"`
+	Addresses        []Address      `json:"Addresses"`
+	Ports            []PortRange    `json:"Ports"`
+	OwnsIntercept    bool           `json:"OwnsIntercept"`
+	AssignedIP       string         `json:"AssignedIP"`
+	PostureChecks    []PostureCheck `json:"PostureChecks"`
+	IsAccessible     bool           `json:"IsAccessible"`
+	Timeout          int            `json:"Timeout"`
+	TimeoutRemaining int            `json:"TimeoutRemaining"`
+	Permissions      Permissions    `json:"Permissions"`
+}
+
+type Permissions struct {
+	Bind bool `json:"Bind"`
+	Dial bool `json:"Dial"`
+}
+
+type Address struct {
+	IsHost   bool   `json:"IsHost"`
+	Hostname string `json:"Hostname"`
+	IP       string `json:"IP"`
+	Prefix   int    `json:"Prefix"`
+}
+
+type PortRange struct {
+	High int `json:"High"`
+	Low  int `json:"Low"`
+}
+
+type PostureCheck struct {
+	IsPassing bool   `json:"IsPassing"`
+	QueryType string `json:"QueryType"`
+	Id        string `json:"Id"`
+}
+
+// BulkServiceEvent fires on Op:"bulkservice" when an identity's authorized service
+// set changes; AddedServices/RemovedServices carry the delta.
+type BulkServiceEvent struct {
+	ActionEvent
+	Identifier      string    `json:"Identifier"`
+	AddedServices   []Service `json:"AddedServices"`
+	RemovedServices []Service `json:"RemovedServices"`
+}

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -413,6 +413,7 @@ type ExtJwtSignerSpec struct {
 	EnrollToToken      bool
 	EnrollNameSelector string
 	EnrollAttrSelector string
+	EnrollAuthPolicy   string
 }
 
 // CreateExtJwtSigner registers an ext-jwt-signer on the controller and returns
@@ -444,6 +445,9 @@ func (o *Overlay) CreateExtJwtSigner(t *testing.T, spec ExtJwtSignerSpec) string
 	if spec.EnrollAttrSelector != "" {
 		args = append(args, "--enroll-attr-claims-selector", spec.EnrollAttrSelector)
 	}
+	if spec.EnrollAuthPolicy != "" {
+		args = append(args, "--enroll-auth-policy", spec.EnrollAuthPolicy)
+	}
 	out, err := o.execZiti(args...)
 	require.NoError(t, err, "create ext-jwt-signer %s", spec.Name)
 	id := string(bytes.TrimSpace(out))
@@ -469,8 +473,8 @@ func (o *Overlay) FindExtJwtSignerId(t *testing.T, name string) (string, bool) {
 }
 
 // UpdateExtJwtSigner sends `ziti edge update ext-jwt-signer <name>` with the
-// fields supplied. EnrollToCert, EnrollToToken, EnrollNameSelector, and
-// EnrollAttrSelector are always sent so an empty value resets them on the shared signer.
+// fields supplied. EnrollToCert, EnrollToToken, EnrollNameSelector, EnrollAttrSelector,
+// and EnrollAuthPolicy are always sent so an empty value resets them on the shared signer.
 func (o *Overlay) UpdateExtJwtSigner(t *testing.T, name string, spec ExtJwtSignerSpec) {
 	t.Logf("updating ext-jwt-signer %q (enrollToCert=%t enrollToToken=%t)", name, spec.EnrollToCert, spec.EnrollToToken)
 	args := []string{"edge", "update", "ext-jwt-signer", name}
@@ -501,6 +505,11 @@ func (o *Overlay) UpdateExtJwtSigner(t *testing.T, name string, spec ExtJwtSigne
 	}
 	args = append(args, "--enroll-name-claims-selector", nameSelector)
 	args = append(args, "--enroll-attr-claims-selector", spec.EnrollAttrSelector)
+	authPolicy := spec.EnrollAuthPolicy
+	if authPolicy == "" {
+		authPolicy = "default"
+	}
+	args = append(args, "--enroll-auth-policy", authPolicy)
 	args = append(args, fmt.Sprintf("--enroll-to-cert=%t", spec.EnrollToCert))
 	args = append(args, fmt.Sprintf("--enroll-to-token=%t", spec.EnrollToToken))
 	_, err := o.execZiti(args...)

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -397,9 +397,10 @@ func (o *Overlay) ResetEnrollment(t *testing.T, name string) {
 }
 
 // ExtJwtSignerSpec describes an external JWT signer to register on the controller.
-// EnrollToCert / EnrollToToken require ziti 2.0+. EnrollNameSelector sets
-// --enroll-name-claims-selector: the JWT claim used to name identities auto-
-// provisioned during enrollment (controller defaults to /sub).
+// EnrollToCert / EnrollToToken require ziti 2.0+. EnrollNameSelector and
+// EnrollAttrSelector set --enroll-name-claims-selector and
+// --enroll-attr-claims-selector: the JWT claims used to name and to assign role
+// attributes to identities auto-provisioned during enrollment.
 type ExtJwtSignerSpec struct {
 	Name               string
 	Issuer             string
@@ -411,6 +412,7 @@ type ExtJwtSignerSpec struct {
 	EnrollToCert       bool
 	EnrollToToken      bool
 	EnrollNameSelector string
+	EnrollAttrSelector string
 }
 
 // CreateExtJwtSigner registers an ext-jwt-signer on the controller and returns
@@ -439,6 +441,9 @@ func (o *Overlay) CreateExtJwtSigner(t *testing.T, spec ExtJwtSignerSpec) string
 	if spec.EnrollNameSelector != "" {
 		args = append(args, "--enroll-name-claims-selector", spec.EnrollNameSelector)
 	}
+	if spec.EnrollAttrSelector != "" {
+		args = append(args, "--enroll-attr-claims-selector", spec.EnrollAttrSelector)
+	}
 	out, err := o.execZiti(args...)
 	require.NoError(t, err, "create ext-jwt-signer %s", spec.Name)
 	id := string(bytes.TrimSpace(out))
@@ -464,8 +469,8 @@ func (o *Overlay) FindExtJwtSignerId(t *testing.T, name string) (string, bool) {
 }
 
 // UpdateExtJwtSigner sends `ziti edge update ext-jwt-signer <name>` with the
-// fields supplied. EnrollToCert, EnrollToToken, and EnrollNameSelector are always
-// sent so an empty value resets them on the shared signer.
+// fields supplied. EnrollToCert, EnrollToToken, EnrollNameSelector, and
+// EnrollAttrSelector are always sent so an empty value resets them on the shared signer.
 func (o *Overlay) UpdateExtJwtSigner(t *testing.T, name string, spec ExtJwtSignerSpec) {
 	t.Logf("updating ext-jwt-signer %q (enrollToCert=%t enrollToToken=%t)", name, spec.EnrollToCert, spec.EnrollToToken)
 	args := []string{"edge", "update", "ext-jwt-signer", name}
@@ -495,6 +500,7 @@ func (o *Overlay) UpdateExtJwtSigner(t *testing.T, name string, spec ExtJwtSigne
 		nameSelector = "/sub"
 	}
 	args = append(args, "--enroll-name-claims-selector", nameSelector)
+	args = append(args, "--enroll-attr-claims-selector", spec.EnrollAttrSelector)
 	args = append(args, fmt.Sprintf("--enroll-to-cert=%t", spec.EnrollToCert))
 	args = append(args, fmt.Sprintf("--enroll-to-token=%t", spec.EnrollToToken))
 	_, err := o.execZiti(args...)

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -396,18 +396,21 @@ func (o *Overlay) ResetEnrollment(t *testing.T, name string) {
 	require.NoError(t, err, "re-enroll cert authenticator for %s", name)
 }
 
-// ExtJwtSignerSpec describes an external JWT signer to register on the
-// controller. EnrollToCert / EnrollToToken set the matching ziti 2.0+ flags.
+// ExtJwtSignerSpec describes an external JWT signer to register on the controller.
+// EnrollToCert / EnrollToToken require ziti 2.0+. EnrollNameSelector sets
+// --enroll-name-claims-selector: the JWT claim used to name identities auto-
+// provisioned during enrollment (controller defaults to /sub).
 type ExtJwtSignerSpec struct {
-	Name          string
-	Issuer        string
-	JWKS          string
-	ClientID      string
-	Audience      string
-	Claim         string
-	Scopes        []string
-	EnrollToCert  bool
-	EnrollToToken bool
+	Name               string
+	Issuer             string
+	JWKS               string
+	ClientID           string
+	Audience           string
+	Claim              string
+	Scopes             []string
+	EnrollToCert       bool
+	EnrollToToken      bool
+	EnrollNameSelector string
 }
 
 // CreateExtJwtSigner registers an ext-jwt-signer on the controller and returns
@@ -432,6 +435,9 @@ func (o *Overlay) CreateExtJwtSigner(t *testing.T, spec ExtJwtSignerSpec) string
 	}
 	if spec.EnrollToToken {
 		args = append(args, "--enroll-to-token")
+	}
+	if spec.EnrollNameSelector != "" {
+		args = append(args, "--enroll-name-claims-selector", spec.EnrollNameSelector)
 	}
 	out, err := o.execZiti(args...)
 	require.NoError(t, err, "create ext-jwt-signer %s", spec.Name)
@@ -458,10 +464,8 @@ func (o *Overlay) FindExtJwtSignerId(t *testing.T, name string) (string, bool) {
 }
 
 // UpdateExtJwtSigner sends `ziti edge update ext-jwt-signer <name>` with the
-// fields supplied. Non-empty strings/slices are forwarded as their matching
-// flag; EnrollToCert and EnrollToToken are always sent because false is a
-// meaningful authoritative state and the only way to flip a previously-enabled
-// flag back off.
+// fields supplied. EnrollToCert, EnrollToToken, and EnrollNameSelector are always
+// sent so an empty value resets them on the shared signer.
 func (o *Overlay) UpdateExtJwtSigner(t *testing.T, name string, spec ExtJwtSignerSpec) {
 	t.Logf("updating ext-jwt-signer %q (enrollToCert=%t enrollToToken=%t)", name, spec.EnrollToCert, spec.EnrollToToken)
 	args := []string{"edge", "update", "ext-jwt-signer", name}
@@ -486,6 +490,11 @@ func (o *Overlay) UpdateExtJwtSigner(t *testing.T, name string, spec ExtJwtSigne
 	for _, s := range spec.Scopes {
 		args = append(args, "--scopes", s)
 	}
+	nameSelector := spec.EnrollNameSelector
+	if nameSelector == "" {
+		nameSelector = "/sub"
+	}
+	args = append(args, "--enroll-name-claims-selector", nameSelector)
 	args = append(args, fmt.Sprintf("--enroll-to-cert=%t", spec.EnrollToCert))
 	args = append(args, fmt.Sprintf("--enroll-to-token=%t", spec.EnrollToToken))
 	_, err := o.execZiti(args...)

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -473,8 +473,9 @@ func (o *Overlay) FindExtJwtSignerId(t *testing.T, name string) (string, bool) {
 }
 
 // UpdateExtJwtSigner sends `ziti edge update ext-jwt-signer <name>` with the
-// fields supplied. EnrollToCert, EnrollToToken, EnrollNameSelector, EnrollAttrSelector,
-// and EnrollAuthPolicy are always sent so an empty value resets them on the shared signer.
+// fields supplied. The enroll fields are always sent so the shared signer resets
+// between tests: an empty EnrollAttrSelector clears the selector, while an empty
+// EnrollNameSelector or EnrollAuthPolicy falls back to /sub and default.
 func (o *Overlay) UpdateExtJwtSigner(t *testing.T, name string, spec ExtJwtSignerSpec) {
 	t.Logf("updating ext-jwt-signer %q (enrollToCert=%t enrollToToken=%t)", name, spec.EnrollToCert, spec.EnrollToToken)
 	args := []string{"edge", "update", "ext-jwt-signer", name}


### PR DESCRIPTION
- Adds more ext-auth coverage for enroll-to-cert and enroll-to-token: name-claim and attribute-claim selectors, multi-attribute claims, and enrollment under a TOTP-required auth policy using `--enroll-name-claims-selector`, `--enroll-attr-claims-selector`, and `--enroll-auth-policy` on an ext signer.