### PR TITLE
Check for powershell.exe on PATH before running NRPT commands

### DIFF
--- a/programs/ziti-edge-tunnel/windows-scripts.c
+++ b/programs/ziti-edge-tunnel/windows-scripts.c
@@ -45,6 +45,25 @@ static bool is_buffer_available(size_t buf_len, size_t max_size, char* script) {
     return true;
 }
 
+// DNS (NRPT) rule management shells out to powershell.exe. If it isn't on the PATH
+// (e.g. a stripped-down Windows image, or a PATH misconfiguration), every NRPT command
+// below would otherwise fail with a generic spawn/system error that gives the user no
+// actionable indication of what's actually wrong. Check once, cache the result, and log
+// a clear diagnostic instead.
+static bool is_powershell_available() {
+    static int available = -1;
+    if (available == -1) {
+        char path_buf[MAX_PATH];
+        DWORD len = SearchPathA(NULL, "powershell.exe", NULL, MAX_PATH, path_buf, NULL);
+        available = (len > 0 && len < MAX_PATH) ? 1 : 0;
+        if (!available) {
+            ZITI_LOG(ERROR, "'powershell.exe' was not found on the system PATH. DNS (NRPT) rules cannot be managed without it "
+                            "- please ensure PowerShell is installed and its location is included in the PATH environment variable.");
+        }
+    }
+    return available == 1;
+}
+
 static bool exec_process(uv_loop_t *ziti_loop, const char* program, char* args[]) {
     uv_process_t* process = calloc(1, sizeof(uv_process_t));
     uv_process_options_t options = {0};
@@ -181,6 +200,9 @@ void chunked_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames, co
 void add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip, const char* zet_id) {
     ZITI_LOG(VERBOSE, "Add nrpt rules");
 
+    if (!is_powershell_available()) {
+        return;
+    }
     if (hostnames == NULL || model_map_size(hostnames) == 0) {
         ZITI_LOG(DEBUG, "No domains specified to add_nrpt_rules, exiting early");
         return;
@@ -272,6 +294,9 @@ void chunked_remove_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *hostnames,
 void remove_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* zet_id) {
     ZITI_LOG(VERBOSE, "Remove nrpt rules");
 
+    if (!is_powershell_available()) {
+        return;
+    }
     if (hostnames == NULL || model_map_size(hostnames) == 0) {
         ZITI_LOG(DEBUG, "No domains specified to remove_nrpt_rules, exiting early");
         return;
@@ -329,6 +354,9 @@ void remove_orphaned_nrpt_rules(const char **running_ids, size_t count) {
     // The regex below matches both: an optional "<disc>." followed by the executable name
     // at end-of-string. This also ensures a pre-multi-tun build's "StartsWith('Added by
     // ziti-edge-tunnel')" nuke won't catch discriminated rules.
+    if (!is_powershell_available()) {
+        return;
+    }
     char cmd[MAX_POWERSHELL_COMMAND_LEN] = { 0 };
     size_t copied = snprintf(cmd, MAX_POWERSHELL_COMMAND_LEN,
                              "powershell -Command \"$r=@(");
@@ -349,6 +377,9 @@ void remove_orphaned_nrpt_rules(const char **running_ids, size_t count) {
 }
 
 void remove_all_nrpt_rules(const char* zet_id, bool exact) {
+    if (!is_powershell_available()) {
+        return;
+    }
     char remove_cmd[MAX_POWERSHELL_COMMAND_LEN];
 
     char* nrpt_filter = get_nrpt_comment(zet_id, exact);
@@ -444,6 +475,9 @@ void chunked_remove_and_add_nrpt_rules(uv_loop_t *ziti_loop, hostname_list_t *ho
 void remove_and_add_nrpt_rules(uv_loop_t *nrpt_loop, model_map *hostnames, const char* dns_ip, const char* zet_id) {
     ZITI_LOG(VERBOSE, "Remove and add nrpt rules");
 
+    if (!is_powershell_available()) {
+        return;
+    }
     if (hostnames == NULL || model_map_size(hostnames) == 0) {
         ZITI_LOG(DEBUG, "No domains specified to remove_and_add_nrpt_rules, exiting early");
         return;
@@ -488,6 +522,9 @@ void remove_single_nrpt_rule(char* nrpt_rule) {
 }
 
 bool is_nrpt_policies_effective(const char* tns_ip, char* zet_id) {
+    if (!is_powershell_available()) {
+        return false;
+    }
     char add_cmd[MAX_POWERSHELL_COMMAND_LEN];
     size_t buf_len = sprintf(add_cmd, "powershell -Command \"Add-DnsClientNrptRule -Namespace '.ziti.test' -NameServers '%s' -Comment 'Added by %s' -DisplayName '%s:.ziti.test'\"",tns_ip, zet_id, zet_id);
     ZITI_LOG(TRACE, "add test nrpt rule. total script size: %zd", buf_len);


### PR DESCRIPTION
## Change Description

Every NRPT-related function (`add_nrpt_rules`, `remove_nrpt_rules`, `remove_and_add_nrpt_rules`, `remove_orphaned_nrpt_rules`, `remove_all_nrpt_rules`, `is_nrpt_policies_effective`) shells out to `powershell.exe`, either via `uv_spawn` (through `exec_process`) or `system()`/`popen`. If PowerShell isn't on the PATH, each of these previously failed independently with a generic spawn/system error, giving the user no clear signal about what was actually wrong.

This adds a small helper, `is_powershell_available()`, that checks once (via `SearchPathA`, caching the result in a static) whether `powershell.exe` resolves on the PATH, and logs one clear diagnostic message if not. Each of the six public NRPT entry points now bails out early via this check instead of letting the underlying command fail.

## Rationale

Fixes #800. Referenced report: https://openziti.discourse.group/t/windows-edge-client-dns-not-working/2087/5 — a user's Windows DNS didn't work because PowerShell wasn't on the PATH, and the failure wasn't diagnosable from the resulting logs.

## Testing/Review Recommendations

I don't have the full Windows build toolchain (vcpkg + libuv + ziti-sdk-c) set up locally, so I wasn't able to run the project's own CI build here. I did verify by careful manual review:
- `SearchPathA` signature and usage match the standard Win32 API (`lpPath=NULL` to search the standard locations + PATH env var, `lpFileName="powershell.exe"`, output buffer sized `MAX_PATH`).
- `DWORD`/`GetLastError` are already used elsewhere in this file without an explicit `windows.h` include, confirming it's already available transitively — no new include was needed.
- The guard clause was added to all six functions declared in `windows-scripts.h` that ultimately invoke a `powershell` command, matching this file's existing early-return style (e.g. the "No domains specified... exiting early" pattern already used in three of these functions).
- `remove_single_nrpt_rule` (an internal-only helper, not in the header) is only reached via `is_nrpt_policies_effective` after that function's own guard has already passed, so it didn't need a separate check.

Happy to adjust if a different approach (e.g. a single startup-time check instead of per-call-site) is preferred.
