### PR TITLE
Restore Windows backup config before loading it and never overwrite existing files

### DIFF
--- a/programs/ziti-edge-tunnel/instance.c
+++ b/programs/ziti-edge-tunnel/instance.c
@@ -943,7 +943,7 @@ void set_pcap_ifname(const char* pcap_ifname) {
         free((char*)tnl_status.PcapInterface);
         tnl_status.PcapInterface = NULL;
     }
-    if (pcap_ifname) {
+    if (pcap_ifname && pcap_ifname[0] != '\0') {
         tnl_status.PcapInterface = strdup(pcap_ifname);
         set_l2_enabled(true);
     }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1794,9 +1794,9 @@ static void run(int argc, char *argv[]) {
         }
     }
     ziti_tunnel_set_log_level(ziti_log_level(NULL, NULL));
-    // don't override the saved LogLevel, and don't seed a fresh config with the ephemeral -v level
-    if (get_log_level_label() == NULL && configured_log_level == NULL) {
-        set_log_level(ziti_log_level_label());
+    // seed a fresh config with the default level, never the ephemeral -v/ZITI_LOG level
+    if (get_log_level_label() == NULL) {
+        set_log_level("info");
     }
     ziti_tunnel_set_logger(ziti_logger);
 

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -3517,8 +3517,8 @@ void scm_service_stop() {
 
 static void move_config_from_previous_windows_backup(uv_loop_t *loop) {
     char *backup_folders[] = {
-        "Windows.~BT\\Windows\\System32\\config\\systemprofile\\AppData\\Roaming\\NetFoundry",
         "Windows.old\\Windows\\System32\\config\\systemprofile\\AppData\\Roaming\\NetFoundry",
+        "$Windows.~BT\\Windows\\System32\\config\\systemprofile\\AppData\\Roaming\\NetFoundry",
         NULL
     };
 

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1660,6 +1660,10 @@ static void run(int argc, char *argv[]) {
         snprintf(config_file, PATH_MAX - 1, "%s%c%s", config_dir, PATH_SEP, "config.json");
         normalize_identifier(config_file);
 
+#if _WIN32
+        // must run before the config load or the recovered config is never read
+        move_config_from_previous_windows_backup(global_loop_ref);
+#endif
         load_tunnel_status_from_file(config_file);
         if (config_dir) {
             set_config_dir(config_dir);
@@ -1773,7 +1777,6 @@ static void run(int argc, char *argv[]) {
         ZITI_LOG(INFO, "	- openssl config   : configured using %s found by %s", openssl_conf_resolved, openssl_conf_found_by);
     }
     ZITI_LOG(INFO,"============================================================================");
-    move_config_from_previous_windows_backup(global_loop_ref);
 
     ZITI_LOG(DEBUG, "granting se_debug privilege to current process to allow access to privileged processes during posture checks");
     //ensure this process has the necessary access token to get the full path of privileged processes
@@ -3516,6 +3519,11 @@ static void move_config_from_previous_windows_backup(uv_loop_t *loop) {
         NULL
     };
 
+    if (config_dir == NULL) {
+        ZITI_LOG(WARN, "config dir is not set, skipping windows backup recovery");
+        return;
+    }
+
     char* system_drive = getenv("SystemDrive");
 
     for (int i =0; backup_folders[i]; i++) {
@@ -3546,13 +3554,20 @@ static void move_config_from_previous_windows_backup(uv_loop_t *loop) {
                 char new_file[PATH_MAX];
                 snprintf(new_file, PATH_MAX, "%s\\%s", config_dir, file.name);
                 uv_fs_t fs_cpy;
-                rc = uv_fs_copyfile(loop, &fs_cpy, old_file, new_file, 0, NULL);
+                // EXCL: an existing live file is always newer than what the upgrade left behind
+                rc = uv_fs_copyfile(loop, &fs_cpy, old_file, new_file, UV_FS_COPYFILE_EXCL, NULL);
                 if (rc == 0) {
-                    ZITI_LOG(INFO, "Restored old identity from the backup path - %s to new path - %s", old_file , new_file);
-                    ZITI_LOG(INFO, "Removing old identity from the backup path - %s", old_file);
-                    remove(old_file);
+                    ZITI_LOG(INFO, "Restored old identity from the backup path - %s to new path - %s", old_file, new_file);
+                } else if (rc == UV_EEXIST) {
+                    ZITI_LOG(INFO, "keeping existing file %s, discarding backup %s", new_file, old_file);
                 } else {
                     ZITI_LOG(ERROR, "failed to copy backup identity file[%s]: %d/%s", old_file, rc, uv_strerror(rc));
+                }
+                if (rc == 0 || rc == UV_EEXIST) {
+                    // consume the backup either way so it cannot re-copy on a later start
+                    if (remove(old_file) != 0) {
+                        ZITI_LOG(ERROR, "failed to remove backup file[%s]: %d/%s", old_file, errno, strerror(errno));
+                    }
                 }
                 uv_fs_req_cleanup(&fs_cpy);
             }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -3519,11 +3519,6 @@ static void move_config_from_previous_windows_backup(uv_loop_t *loop) {
         NULL
     };
 
-    if (config_dir == NULL) {
-        ZITI_LOG(WARN, "config dir is not set, skipping windows backup recovery");
-        return;
-    }
-
     char* system_drive = getenv("SystemDrive");
 
     for (int i =0; backup_folders[i]; i++) {

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -3552,20 +3552,18 @@ static void move_config_from_previous_windows_backup(uv_loop_t *loop) {
                 char new_file[PATH_MAX];
                 snprintf(new_file, PATH_MAX, "%s\\%s", config_dir, file.name);
                 uv_fs_t fs_cpy;
-                // EXCL: an existing live file is always newer than what the upgrade left behind
+                // EXCL: the upgrade empties the live dir, so an existing file was written after the upgrade and wins
                 rc = uv_fs_copyfile(loop, &fs_cpy, old_file, new_file, UV_FS_COPYFILE_EXCL, NULL);
                 if (rc == 0) {
                     ZITI_LOG(INFO, "Restored old identity from the backup path - %s to new path - %s", old_file, new_file);
-                } else if (rc == UV_EEXIST) {
-                    ZITI_LOG(INFO, "keeping existing file %s, discarding backup %s", new_file, old_file);
-                } else {
-                    ZITI_LOG(ERROR, "failed to copy backup identity file[%s]: %d/%s", old_file, rc, uv_strerror(rc));
-                }
-                if (rc == 0 || rc == UV_EEXIST) {
-                    // consume the backup either way so it cannot re-copy on a later start
                     if (remove(old_file) != 0) {
                         ZITI_LOG(WARN, "failed to remove backup file[%s]: %d/%s", old_file, errno, strerror(errno));
                     }
+                } else if (rc == UV_EEXIST) {
+                    // never delete a backup that was not restored, Windows prunes Windows.old on its own
+                    ZITI_LOG(WARN, "keeping existing file %s, backup file left at %s", new_file, old_file);
+                } else {
+                    ZITI_LOG(ERROR, "failed to copy backup identity file[%s]: %d/%s", old_file, rc, uv_strerror(rc));
                 }
                 uv_fs_req_cleanup(&fs_cpy);
             }

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -3564,7 +3564,7 @@ static void move_config_from_previous_windows_backup(uv_loop_t *loop) {
                 if (rc == 0 || rc == UV_EEXIST) {
                     // consume the backup either way so it cannot re-copy on a later start
                     if (remove(old_file) != 0) {
-                        ZITI_LOG(ERROR, "failed to remove backup file[%s]: %d/%s", old_file, errno, strerror(errno));
+                        ZITI_LOG(WARN, "failed to remove backup file[%s]: %d/%s", old_file, errno, strerror(errno));
                     }
                 }
                 uv_fs_req_cleanup(&fs_cpy);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1794,7 +1794,10 @@ static void run(int argc, char *argv[]) {
         }
     }
     ziti_tunnel_set_log_level(ziti_log_level(NULL, NULL));
-    set_log_level(ziti_log_level_label());
+    // don't override the saved LogLevel with -v
+    if (get_log_level_label() == NULL) {
+        set_log_level(ziti_log_level_label());
+    }
     ziti_tunnel_set_logger(ziti_logger);
 
     // prioritize command line flags, but respect config file values.

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -1794,8 +1794,8 @@ static void run(int argc, char *argv[]) {
         }
     }
     ziti_tunnel_set_log_level(ziti_log_level(NULL, NULL));
-    // don't override the saved LogLevel with -v
-    if (get_log_level_label() == NULL) {
+    // don't override the saved LogLevel, and don't seed a fresh config with the ephemeral -v level
+    if (get_log_level_label() == NULL && configured_log_level == NULL) {
         set_log_level(ziti_log_level_label());
     }
     ziti_tunnel_set_logger(ziti_logger);

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -199,6 +199,12 @@
       "enrollment": { "ott": true }
     },
     {
+      "name": "test_restore_only_copies_missing_files",
+      "isAdmin": false,
+      "authPolicy": "@Default",
+      "enrollment": { "ott": true }
+    },
+    {
       "name": "test_ext_auth_none_happy",
       "isAdmin": false,
       "authPolicy": "@Default",

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -187,7 +187,7 @@
       "enrollment": { "ott": true }
     },
     {
-      "name": "test_backup_recovery",
+      "name": "test_config_survives_windows_upgrade",
       "isAdmin": false,
       "authPolicy": "@Default",
       "enrollment": { "ott": true }

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -187,6 +187,12 @@
       "enrollment": { "ott": true }
     },
     {
+      "name": "test_backup_recovery",
+      "isAdmin": false,
+      "authPolicy": "@Default",
+      "enrollment": { "ott": true }
+    },
+    {
       "name": "test_ext_auth_none_happy",
       "isAdmin": false,
       "authPolicy": "@Default",

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -193,6 +193,12 @@
       "enrollment": { "ott": true }
     },
     {
+      "name": "test_existing_config_wins_over_backup",
+      "isAdmin": false,
+      "authPolicy": "@Default",
+      "enrollment": { "ott": true }
+    },
+    {
       "name": "test_ext_auth_none_happy",
       "isAdmin": false,
       "authPolicy": "@Default",

--- a/tests/integration/testutil/zet.go
+++ b/tests/integration/testutil/zet.go
@@ -52,6 +52,8 @@ type ZET struct {
 	// TlsuvDebug, if > 0, sets the TLSUV_DEBUG env var (0=off..6=trace) for
 	// debugging TLS handshake / cert chain issues.
 	TlsuvDebug int
+	// Env entries (KEY=VALUE) appended to the parent environment for the ZET process.
+	Env []string
 	// Major and Minor are this binary's version, set by ProbeVersion.
 	Major int
 	Minor int
@@ -101,8 +103,12 @@ func (z *ZET) Start() error {
 	}
 
 	z.cmd = exec.Command(z.BinPath, args...)
-	if z.TlsuvDebug > 0 {
-		z.cmd.Env = append(os.Environ(), "TLSUV_DEBUG="+strconv.Itoa(z.TlsuvDebug))
+	if len(z.Env) > 0 || z.TlsuvDebug > 0 {
+		env := append(os.Environ(), z.Env...)
+		if z.TlsuvDebug > 0 {
+			env = append(env, "TLSUV_DEBUG="+strconv.Itoa(z.TlsuvDebug))
+		}
+		z.cmd.Env = env
 	}
 	stdout := newSyncBuffer()
 	stderr := newSyncBuffer()

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -65,6 +65,7 @@ func newUpgradeContext(t *testing.T, dirName, idName string) *upgradeContext {
 func TestWindowsUpgrade(t *testing.T) {
 	t.Run("configSurvivesWindowsUpgrade", configSurvivesWindowsUpgrade)
 	t.Run("existingConfigWinsOverBackup", existingConfigWinsOverBackup)
+	t.Run("restoreOnlyCopiesMissingFiles", restoreOnlyCopiesMissingFiles)
 }
 
 func configSurvivesWindowsUpgrade(t *testing.T) {
@@ -147,6 +148,42 @@ func existingConfigWinsOverBackup(t *testing.T) {
 		_, statErr := os.Stat(filepath.Join(c.backupDir, "config.json"))
 		require.NoError(t, statErr)
 		_, statErr = os.Stat(filepath.Join(c.backupDir, c.idName+".json"))
+		require.NoError(t, statErr)
+	})
+}
+
+func restoreOnlyCopiesMissingFiles(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
+		c := newUpgradeContext(t, "upgrade-partial-restore", "test_restore_only_copies_missing_files")
+		preUpgradeConfig := c.runZetBeforeUpgrade(t)
+
+		identityFile := preUpgradeConfig.Identities[0].Identifier
+		enrolledIdentity, err := os.ReadFile(identityFile)
+		require.NoError(t, err)
+
+		// An earlier boot restored config.json but failed to delete it from the backup, and the identity copy failed.
+		require.NoError(t, os.MkdirAll(c.backupDir, 0o755))
+		require.NoError(t, os.Rename(identityFile, filepath.Join(c.backupDir, c.idName+".json")))
+		configJSON, err := os.ReadFile(filepath.Join(c.configDir, "config.json"))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(c.backupDir, "config.json"), configJSON, 0o644))
+
+		require.NoError(t, c.zet.Start())
+		afterRecovery := c.zet.WaitForStatusEvent(t)
+		require.Equal(t, c.tunIp, afterRecovery.Status.TunIpv4)
+
+		restored := findIdentityInStatus(t, afterRecovery, identityFile)
+		assertValidJwtIdState(t, restored)
+		c.zet.WaitForControllerEvent(t, "connected", c.idName)
+
+		restoredIdentity, err := os.ReadFile(identityFile)
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(enrolledIdentity, restoredIdentity), "restored identity file differs from the enrolled one")
+
+		// The missing identity was restored and deleted from the backup, the existing config should still be in the backup folder.
+		_, statErr := os.Stat(filepath.Join(c.backupDir, c.idName+".json"))
+		require.True(t, os.IsNotExist(statErr))
+		_, statErr = os.Stat(filepath.Join(c.backupDir, "config.json"))
 		require.NoError(t, statErr)
 	})
 }

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package integration_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -83,8 +82,7 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 		require.NotEmpty(t, beforeRecovery.ServiceVersion.Version)
 
 		identityFile := beforeRecovery.Identities[0].Identifier
-		enrolledIdentity, err := os.ReadFile(identityFile)
-		require.NoError(t, err)
+		enrolledIdentity := testutil.ReadIdentityFile(t, identityFile)
 
 		// The "upgrade": the whole dir moves to Windows.old.
 		require.NoError(t, os.MkdirAll(filepath.Dir(c.backupDir), 0o755))
@@ -123,8 +121,7 @@ func existingConfigWinsOverBackup(t *testing.T) {
 		beforeRecovery := c.runZetBeforeUpgrade(t)
 
 		identityFile := beforeRecovery.Identities[0].Identifier
-		enrolledIdentity, err := os.ReadFile(identityFile)
-		require.NoError(t, err)
+		enrolledIdentity := testutil.ReadIdentityFile(t, identityFile)
 
 		// A backup left behind like a failed delete on an earlier boot: its config
 		// differs from the existing one and its files are newer on disk.
@@ -159,8 +156,7 @@ func restoreOnlyCopiesMissingFiles(t *testing.T) {
 		beforeRecovery := c.runZetBeforeUpgrade(t)
 
 		identityFile := beforeRecovery.Identities[0].Identifier
-		enrolledIdentity, err := os.ReadFile(identityFile)
-		require.NoError(t, err)
+		enrolledIdentity := testutil.ReadIdentityFile(t, identityFile)
 
 		// An earlier boot restored config.json but failed to delete it from the backup, and the identity copy failed.
 		require.NoError(t, os.MkdirAll(c.backupDir, 0o755))
@@ -187,10 +183,9 @@ func restoreOnlyCopiesMissingFiles(t *testing.T) {
 	})
 }
 
-func assertIdentityUnchanged(t *testing.T, identityFile string, enrolledIdentity []byte) {
-	identityAfterRecovery, err := os.ReadFile(identityFile)
-	require.NoError(t, err)
-	require.True(t, bytes.Equal(enrolledIdentity, identityAfterRecovery), "existing identity was overwritten by the backup")
+func assertIdentityUnchanged(t *testing.T, identityFile string, enrolledIdentity testutil.IdentityFileContent) {
+	identityAfterRecovery := testutil.ReadIdentityFile(t, identityFile)
+	require.True(t, enrolledIdentity.ID == identityAfterRecovery.ID, "existing identity was overwritten by the backup")
 }
 
 // runZetBeforeUpgrade starts ZET, enrolls the context's identity, updates the

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -133,7 +133,7 @@ func existingConfigWinsOverBackup(t *testing.T) {
 		backupIdentity := []byte(`{"marker":"dummy identity"}`)
 		require.NoError(t, os.WriteFile(filepath.Join(c.backupDir, c.idName+".json"), backupIdentity, 0o600))
 
-		// The existing files must win over the newer backup, and the backup is removed.
+		// The existing files must win over the newer backup, and the backup is left in place.
 		require.NoError(t, c.zet.Start())
 		afterRecovery := c.zet.WaitForStatusEvent(t)
 		require.Equal(t, c.tunIp, afterRecovery.Status.TunIpv4)
@@ -143,7 +143,11 @@ func existingConfigWinsOverBackup(t *testing.T) {
 		require.True(t, bytes.Equal(existingIdentity, identityAfterRecovery), "existing identity was overwritten by the backup")
 		c.zet.WaitForControllerEvent(t, "connected", c.idName)
 
-		c.assertBackupRemoved(t)
+		// Ensure backup files were not deleted
+		_, statErr := os.Stat(filepath.Join(c.backupDir, "config.json"))
+		require.NoError(t, statErr)
+		_, statErr = os.Stat(filepath.Join(c.backupDir, c.idName+".json"))
+		require.NoError(t, statErr)
 	})
 }
 

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package integration_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -106,9 +107,7 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 		assertValidJwtIdState(t, restored)
 		c.zet.WaitForControllerEvent(t, "connected", c.idName)
 
-		restoredIdentity, err := os.ReadFile(identityFile)
-		require.NoError(t, err)
-		require.Equal(t, enrolledIdentity, restoredIdentity)
+		assertIdentityUnchanged(t, identityFile, enrolledIdentity)
 
 		// Ensure backup files were deleted
 		_, statErr := os.Stat(filepath.Join(c.backupDir, "config.json"))
@@ -124,7 +123,7 @@ func existingConfigWinsOverBackup(t *testing.T) {
 		beforeRecovery := c.runZetBeforeUpgrade(t)
 
 		identityFile := beforeRecovery.Identities[0].Identifier
-		existingIdentity, err := os.ReadFile(identityFile)
+		enrolledIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
 
 		// A backup left behind like a failed delete on an earlier boot: its config
@@ -143,9 +142,7 @@ func existingConfigWinsOverBackup(t *testing.T) {
 		afterRecovery := c.zet.WaitForStatusEvent(t)
 		require.Equal(t, c.tunIp, afterRecovery.Status.TunIpv4)
 
-		identityAfterRecovery, err := os.ReadFile(identityFile)
-		require.NoError(t, err)
-		require.Equal(t, existingIdentity, identityAfterRecovery)
+		assertIdentityUnchanged(t, identityFile, enrolledIdentity)
 		c.zet.WaitForControllerEvent(t, "connected", c.idName)
 
 		// Ensure backup files were not deleted
@@ -180,9 +177,7 @@ func restoreOnlyCopiesMissingFiles(t *testing.T) {
 		assertValidJwtIdState(t, restored)
 		c.zet.WaitForControllerEvent(t, "connected", c.idName)
 
-		restoredIdentity, err := os.ReadFile(identityFile)
-		require.NoError(t, err)
-		require.Equal(t, enrolledIdentity, restoredIdentity)
+		assertIdentityUnchanged(t, identityFile, enrolledIdentity)
 
 		// The missing identity was restored and deleted from the backup, the existing config should still be in the backup folder.
 		_, statErr := os.Stat(filepath.Join(c.backupDir, c.idName+".json"))
@@ -190,6 +185,12 @@ func restoreOnlyCopiesMissingFiles(t *testing.T) {
 		_, statErr = os.Stat(filepath.Join(c.backupDir, "config.json"))
 		require.NoError(t, statErr)
 	})
+}
+
+func assertIdentityUnchanged(t *testing.T, identityFile string, enrolledIdentity []byte) {
+	identityAfterRecovery, err := os.ReadFile(identityFile)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(enrolledIdentity, identityAfterRecovery), "existing identity was overwritten by the backup")
 }
 
 // runZetBeforeUpgrade starts ZET, enrolls the context's identity, updates the

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -1,0 +1,119 @@
+//go:build windows
+
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openziti/ziti-tunnel-sdk-c/tests/integration/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowsUpgrade(t *testing.T) {
+	t.Run("configSurvivesWindowsUpgrade", configSurvivesWindowsUpgrade)
+}
+
+func configSurvivesWindowsUpgrade(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
+		fakeDrive := filepath.Join(t.TempDir(), "fakedrive")
+		idName := "test_backup_recovery"
+		tunIp := "100.200.0.1"
+
+		zet := &testutil.ZET{
+			BinPath:       state.zetClient.BinPath,
+			Discriminator: "zetUpgrade",
+			RootDir:       filepath.Join(t.TempDir(), "zet"),
+			Verbosity:     state.zetClient.Verbosity,
+			Env:           []string{"SystemDrive=" + fakeDrive},
+		}
+		configDir := filepath.Join(zet.RootDir, "identities")
+		require.NoError(t, zet.Start())
+		t.Cleanup(zet.Stop)
+
+		// First run writes a config: enrolled identity + range and log level changed
+		testutil.FetchAndEnrollJwt(t, state.overlay, zet, idName)
+		zet.WaitForControllerEvent(t, "connected", idName)
+		interfaceData := testutil.InterfaceConfigData{
+			L3: testutil.TunIPv4Data{TunIPv4: tunIp, TunPrefixLength: 24, AddDns: true},
+		}
+
+		updateConfigResponse := zet.UpdateInterfaceConfig(t, interfaceData)
+		updateConfigResponse.AssertSuccess()
+
+		logLevelResp := zet.SetLogLevel(t, "debug")
+		logLevelResp.AssertSuccess()
+
+		// A single read can catch a stale or torn file.
+		// Poll until the settled config is on disk, then it is safe to kill.
+		configFile := filepath.Join(configDir, "config.json")
+		baseline := waitForSavedConfig(t, configFile, tunIp, "debug")
+		zet.Stop()
+
+		identityFile := baseline.Identities[0].Identifier
+		enrolledIdentity, err := os.ReadFile(identityFile)
+		require.NoError(t, err)
+
+		// The upgrade: the whole dir moves to Windows.old.
+		backupDir := filepath.Join(fakeDrive, `Windows.old\Windows\System32\config\systemprofile\AppData\Roaming\NetFoundry`)
+		require.NoError(t, os.MkdirAll(filepath.Dir(backupDir), 0o755))
+		require.NoError(t, os.Rename(configDir, backupDir))
+
+		// Second run must restore the backup before the config load.
+		require.NoError(t, zet.Start())
+		status := zet.WaitForStatusEvent(t)
+		require.Equal(t, baseline.TunIpv4, status.Status.TunIpv4)
+		require.Equal(t, baseline.TunIpv4Mask, status.Status.TunIpv4Mask)
+		require.Equal(t, baseline.LogLevel, status.Status.LogLevel)
+		restored := findIdentityInStatus(t, status, identityFile)
+		assertValidJwtIdState(t, restored)
+		zet.WaitForControllerEvent(t, "connected", idName)
+
+		restoredIdentity, err := os.ReadFile(identityFile)
+		require.NoError(t, err)
+		require.Equal(t, enrolledIdentity, restoredIdentity, "restored identity file differs from the enrolled one")
+		_, statErr := os.Stat(filepath.Join(backupDir, "config.json"))
+		require.True(t, os.IsNotExist(statErr), "backup config.json was not consumed")
+		_, statErr = os.Stat(filepath.Join(backupDir, idName+".json"))
+		require.True(t, os.IsNotExist(statErr), "backup identity file was not consumed")
+	})
+}
+
+func waitForSavedConfig(t *testing.T, configFile string, tunIp string, logLevel string) testutil.TunnelStatus {
+	deadline := time.Now().Add(10 * time.Second)
+	var tunnelStatus testutil.TunnelStatus
+	for {
+		configJSON, readErr := os.ReadFile(configFile)
+		if readErr == nil && json.Unmarshal(configJSON, &tunnelStatus) == nil {
+			settled := tunnelStatus.TunIpv4 == tunIp &&
+				strings.EqualFold(tunnelStatus.LogLevel, logLevel) && len(tunnelStatus.Identities) == 1
+			if settled {
+				return tunnelStatus
+			}
+		}
+		if time.Now().After(deadline) {
+			require.FailNow(t, "config.json never contained the configured range, log level and identity", "file=%s status=%+v", configFile, tunnelStatus)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -19,10 +19,8 @@ limitations under the License.
 package integration_test
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -38,7 +36,6 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
 		fakeDrive := filepath.Join(t.TempDir(), "fakedrive")
 		idName := "test_backup_recovery"
-		tunIp := "100.200.0.1"
 
 		zet := &testutil.ZET{
 			BinPath:       state.zetClient.BinPath,
@@ -55,7 +52,7 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 		testutil.FetchAndEnrollJwt(t, state.overlay, zet, idName)
 		zet.WaitForControllerEvent(t, "connected", idName)
 		interfaceData := testutil.InterfaceConfigData{
-			L3: testutil.TunIPv4Data{TunIPv4: tunIp, TunPrefixLength: 24, AddDns: true},
+			L3: testutil.TunIPv4Data{TunIPv4: "100.200.0.1", TunPrefixLength: 24, AddDns: true},
 		}
 
 		updateConfigResponse := zet.UpdateInterfaceConfig(t, interfaceData)
@@ -64,13 +61,14 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 		logLevelResp := zet.SetLogLevel(t, "debug")
 		logLevelResp.AssertSuccess()
 
-		// A single read can catch a stale or torn file.
-		// Poll until the settled config is on disk, then it is safe to kill.
-		configFile := filepath.Join(configDir, "config.json")
-		baseline := waitForSavedConfig(t, configFile, tunIp, "debug")
+		// Ensure config changes are saved before Stop()
+		zet.ReconnectEvents(t)
+		beforeUpgrade := zet.WaitForStatusEvent(t)
+		require.Equal(t, "100.200.0.1", beforeUpgrade.Status.TunIpv4)
+		require.Len(t, beforeUpgrade.Status.Identities, 1)
 		zet.Stop()
 
-		identityFile := baseline.Identities[0].Identifier
+		identityFile := beforeUpgrade.Status.Identities[0].Identifier
 		enrolledIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
 
@@ -81,11 +79,11 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 
 		// Second run must restore the backup before the config load.
 		require.NoError(t, zet.Start())
-		status := zet.WaitForStatusEvent(t)
-		require.Equal(t, baseline.TunIpv4, status.Status.TunIpv4)
-		require.Equal(t, baseline.TunIpv4Mask, status.Status.TunIpv4Mask)
-		require.Equal(t, baseline.LogLevel, status.Status.LogLevel)
-		restored := findIdentityInStatus(t, status, identityFile)
+		afterUpgrade := zet.WaitForStatusEvent(t)
+		require.Equal(t, beforeUpgrade.Status.TunIpv4, afterUpgrade.Status.TunIpv4)
+		require.Equal(t, beforeUpgrade.Status.TunIpv4Mask, afterUpgrade.Status.TunIpv4Mask)
+		require.Equal(t, beforeUpgrade.Status.LogLevel, afterUpgrade.Status.LogLevel)
+		restored := findIdentityInStatus(t, afterUpgrade, identityFile)
 		assertValidJwtIdState(t, restored)
 		zet.WaitForControllerEvent(t, "connected", idName)
 
@@ -97,23 +95,4 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 		_, statErr = os.Stat(filepath.Join(backupDir, idName+".json"))
 		require.True(t, os.IsNotExist(statErr), "backup identity file was not consumed")
 	})
-}
-
-func waitForSavedConfig(t *testing.T, configFile string, tunIp string, logLevel string) testutil.TunnelStatus {
-	deadline := time.Now().Add(10 * time.Second)
-	var tunnelStatus testutil.TunnelStatus
-	for {
-		configJSON, readErr := os.ReadFile(configFile)
-		if readErr == nil && json.Unmarshal(configJSON, &tunnelStatus) == nil {
-			settled := tunnelStatus.TunIpv4 == tunIp &&
-				strings.EqualFold(tunnelStatus.LogLevel, logLevel) && len(tunnelStatus.Identities) == 1
-			if settled {
-				return tunnelStatus
-			}
-		}
-		if time.Now().After(deadline) {
-			require.FailNow(t, "config.json never contained the configured range, log level and identity", "file=%s status=%+v", configFile, tunnelStatus)
-		}
-		time.Sleep(250 * time.Millisecond)
-	}
 }

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package integration_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func TestWindowsUpgrade(t *testing.T) {
 
 func configSurvivesWindowsUpgrade(t *testing.T) {
 	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
-		c := newUpgradeContext(t, "upgrade", "test_backup_recovery")
+		c := newUpgradeContext(t, "upgrade", "test_config_survives_windows_upgrade")
 		beforeRecovery := c.runZetBeforeUpgrade(t)
 
 		require.Equal(t, c.tunIp, beforeRecovery.TunIpv4)
@@ -109,24 +108,29 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 
 		restoredIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
-		require.True(t, bytes.Equal(enrolledIdentity, restoredIdentity), "restored identity file differs from the enrolled one")
-		c.assertBackupRemoved(t)
+		require.Equal(t, enrolledIdentity, restoredIdentity)
+
+		// Ensure backup files were deleted
+		_, statErr := os.Stat(filepath.Join(c.backupDir, "config.json"))
+		require.True(t, os.IsNotExist(statErr), "backup config was not removed")
+		_, statErr = os.Stat(filepath.Join(c.backupDir, c.idName+".json"))
+		require.True(t, os.IsNotExist(statErr), "backup identity was not removed")
 	})
 }
 
 func existingConfigWinsOverBackup(t *testing.T) {
 	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
 		c := newUpgradeContext(t, "upgrade-existing-wins", "test_existing_config_wins_over_backup")
-		existingConfig := c.runZetBeforeUpgrade(t)
+		beforeRecovery := c.runZetBeforeUpgrade(t)
 
-		identityFile := existingConfig.Identities[0].Identifier
+		identityFile := beforeRecovery.Identities[0].Identifier
 		existingIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
 
 		// A backup left behind like a failed delete on an earlier boot: its config
 		// differs from the existing one and its files are newer on disk.
 		require.NoError(t, os.MkdirAll(c.backupDir, 0o755))
-		backupConfig := existingConfig
+		backupConfig := beforeRecovery
 		backupConfig.TunIpv4 = "100.203.0.1"
 		backupConfigJSON, err := json.Marshal(backupConfig)
 		require.NoError(t, err)
@@ -141,7 +145,7 @@ func existingConfigWinsOverBackup(t *testing.T) {
 
 		identityAfterRecovery, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
-		require.True(t, bytes.Equal(existingIdentity, identityAfterRecovery), "existing identity was overwritten by the backup")
+		require.Equal(t, existingIdentity, identityAfterRecovery)
 		c.zet.WaitForControllerEvent(t, "connected", c.idName)
 
 		// Ensure backup files were not deleted
@@ -155,9 +159,9 @@ func existingConfigWinsOverBackup(t *testing.T) {
 func restoreOnlyCopiesMissingFiles(t *testing.T) {
 	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
 		c := newUpgradeContext(t, "upgrade-partial-restore", "test_restore_only_copies_missing_files")
-		preUpgradeConfig := c.runZetBeforeUpgrade(t)
+		beforeRecovery := c.runZetBeforeUpgrade(t)
 
-		identityFile := preUpgradeConfig.Identities[0].Identifier
+		identityFile := beforeRecovery.Identities[0].Identifier
 		enrolledIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
 
@@ -178,7 +182,7 @@ func restoreOnlyCopiesMissingFiles(t *testing.T) {
 
 		restoredIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
-		require.True(t, bytes.Equal(enrolledIdentity, restoredIdentity), "restored identity file differs from the enrolled one")
+		require.Equal(t, enrolledIdentity, restoredIdentity)
 
 		// The missing identity was restored and deleted from the backup, the existing config should still be in the backup folder.
 		_, statErr := os.Stat(filepath.Join(c.backupDir, c.idName+".json"))
@@ -228,9 +232,3 @@ func (c *upgradeContext) runZetBeforeUpgrade(t *testing.T) testutil.TunnelStatus
 	return savedConfig
 }
 
-func (c *upgradeContext) assertBackupRemoved(t *testing.T) {
-	_, statErr := os.Stat(filepath.Join(c.backupDir, "config.json"))
-	require.True(t, os.IsNotExist(statErr), "backup config was not removed")
-	_, statErr = os.Stat(filepath.Join(c.backupDir, c.idName+".json"))
-	require.True(t, os.IsNotExist(statErr), "backup identity was not removed")
-}

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -35,15 +35,16 @@ func TestWindowsUpgrade(t *testing.T) {
 
 func configSurvivesWindowsUpgrade(t *testing.T) {
 	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
-		fakeDrive := filepath.Join(t.TempDir(), "fakedrive")
+		upgradeDir := filepath.Join(state.zetClient.RootDir, "upgrade")
+		require.NoError(t, os.RemoveAll(upgradeDir))
+		fakeDrive := filepath.Join(upgradeDir, "fakedrive")
 		idName := "test_backup_recovery"
 		tunIp := "100.200.0.1"
-		logLevel := "debug"
 
 		zet := &testutil.ZET{
 			BinPath:       state.zetClient.BinPath,
 			Discriminator: "zetUpgrade",
-			RootDir:       filepath.Join(t.TempDir(), "zet"),
+			RootDir:       filepath.Join(upgradeDir, "zet"),
 			Verbosity:     state.zetClient.Verbosity,
 			Env:           []string{"SystemDrive=" + fakeDrive},
 		}
@@ -58,20 +59,22 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 			L3: testutil.TunIPv4Data{TunIPv4: tunIp, TunPrefixLength: 24, AddDns: true},
 		}
 
+		logLevelResp := zet.SetLogLevel(t, "trace")
+		logLevelResp.AssertSuccess()
+
 		updateConfigResponse := zet.UpdateInterfaceConfig(t, interfaceData)
 		updateConfigResponse.AssertSuccess()
-
-		logLevelResp := zet.SetLogLevel(t, logLevel)
-		logLevelResp.AssertSuccess()
 
 		// A command response can arrive before its config save finishes writing, so wait for the settled file
 		var beforeRecovery testutil.TunnelStatus
 		configFile := filepath.Join(configDir, "config.json")
-		deadline := time.Now().Add(5 * time.Second)
+		deadline := time.Now().Add(2 * time.Second)
 		for {
+			var tunnelStatus testutil.TunnelStatus
 			configJSON, err := os.ReadFile(configFile)
-			parsed := err == nil && json.Unmarshal(configJSON, &beforeRecovery) == nil
-			if parsed && beforeRecovery.LogLevel == logLevel {
+			parsed := err == nil && json.Unmarshal(configJSON, &tunnelStatus) == nil
+			if parsed && tunnelStatus.TunIpv4 == tunIp {
+				beforeRecovery = tunnelStatus
 				break
 			}
 			require.False(t, time.Now().After(deadline), "config.json never settled")
@@ -81,6 +84,7 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 
 		require.Equal(t, tunIp, beforeRecovery.TunIpv4)
 		require.Equal(t, 24, beforeRecovery.TunIpv4Mask)
+		require.Equal(t, "trace", beforeRecovery.LogLevel)
 		require.True(t, beforeRecovery.AddDns)
 		require.Equal(t, 25, beforeRecovery.ApiPageSize)
 		require.False(t, beforeRecovery.L2Enabled)

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package integration_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,6 +37,8 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
 		fakeDrive := filepath.Join(t.TempDir(), "fakedrive")
 		idName := "test_backup_recovery"
+		tunIp := "100.200.0.1"
+		logLevel := "debug"
 
 		zet := &testutil.ZET{
 			BinPath:       state.zetClient.BinPath,
@@ -48,42 +51,66 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 		require.NoError(t, zet.Start())
 		t.Cleanup(zet.Stop)
 
-		// First run writes a config: enrolled identity + range and log level changed
+		// First ZET start writes a config: enrolled identity + range and log level changed
 		testutil.FetchAndEnrollJwt(t, state.overlay, zet, idName)
 		zet.WaitForControllerEvent(t, "connected", idName)
 		interfaceData := testutil.InterfaceConfigData{
-			L3: testutil.TunIPv4Data{TunIPv4: "100.200.0.1", TunPrefixLength: 24, AddDns: true},
+			L3: testutil.TunIPv4Data{TunIPv4: tunIp, TunPrefixLength: 24, AddDns: true},
 		}
 
 		updateConfigResponse := zet.UpdateInterfaceConfig(t, interfaceData)
 		updateConfigResponse.AssertSuccess()
 
-		logLevelResp := zet.SetLogLevel(t, "debug")
+		logLevelResp := zet.SetLogLevel(t, logLevel)
 		logLevelResp.AssertSuccess()
 
-		// Ensure config changes are saved before Stop()
-		zet.ReconnectEvents(t)
-		beforeUpgrade := zet.WaitForStatusEvent(t)
-		require.Equal(t, "100.200.0.1", beforeUpgrade.Status.TunIpv4)
-		require.Len(t, beforeUpgrade.Status.Identities, 1)
+		// A command response can arrive before its config save finishes writing, so wait for the settled file
+		var beforeRecovery testutil.TunnelStatus
+		configFile := filepath.Join(configDir, "config.json")
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			configJSON, err := os.ReadFile(configFile)
+			parsed := err == nil && json.Unmarshal(configJSON, &beforeRecovery) == nil
+			if parsed && beforeRecovery.LogLevel == logLevel {
+				break
+			}
+			require.False(t, time.Now().After(deadline), "config.json never settled")
+			time.Sleep(100 * time.Millisecond)
+		}
 		zet.Stop()
 
-		identityFile := beforeUpgrade.Status.Identities[0].Identifier
+		require.Equal(t, tunIp, beforeRecovery.TunIpv4)
+		require.Equal(t, 24, beforeRecovery.TunIpv4Mask)
+		require.True(t, beforeRecovery.AddDns)
+		require.Equal(t, 25, beforeRecovery.ApiPageSize)
+		require.False(t, beforeRecovery.L2Enabled)
+		require.Empty(t, beforeRecovery.PcapInterface)
+		require.NotEmpty(t, beforeRecovery.ServiceVersion.Version)
+		require.Len(t, beforeRecovery.Identities, 1)
+
+		identityFile := beforeRecovery.Identities[0].Identifier
 		enrolledIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
 
-		// The upgrade: the whole dir moves to Windows.old.
+		// The "upgrade": the whole dir moves to Windows.old.
 		backupDir := filepath.Join(fakeDrive, `Windows.old\Windows\System32\config\systemprofile\AppData\Roaming\NetFoundry`)
 		require.NoError(t, os.MkdirAll(filepath.Dir(backupDir), 0o755))
 		require.NoError(t, os.Rename(configDir, backupDir))
 
-		// Second run must restore the backup before the config load.
+		// Second ZET start must restore the backup before the config load.
 		require.NoError(t, zet.Start())
-		afterUpgrade := zet.WaitForStatusEvent(t)
-		require.Equal(t, beforeUpgrade.Status.TunIpv4, afterUpgrade.Status.TunIpv4)
-		require.Equal(t, beforeUpgrade.Status.TunIpv4Mask, afterUpgrade.Status.TunIpv4Mask)
-		require.Equal(t, beforeUpgrade.Status.LogLevel, afterUpgrade.Status.LogLevel)
-		restored := findIdentityInStatus(t, afterUpgrade, identityFile)
+		afterRecovery := zet.WaitForStatusEvent(t)
+		require.Equal(t, beforeRecovery.TunIpv4, afterRecovery.Status.TunIpv4)
+		require.Equal(t, afterRecovery.Status.TunIpv4, afterRecovery.Status.IpInfo.Ip)
+		require.Equal(t, beforeRecovery.TunIpv4Mask, afterRecovery.Status.TunIpv4Mask)
+		require.Equal(t, beforeRecovery.LogLevel, afterRecovery.Status.LogLevel)
+		require.Equal(t, beforeRecovery.AddDns, afterRecovery.Status.AddDns)
+		require.Equal(t, beforeRecovery.ApiPageSize, afterRecovery.Status.ApiPageSize)
+		require.Equal(t, beforeRecovery.L2Enabled, afterRecovery.Status.L2Enabled)
+		require.Equal(t, beforeRecovery.PcapInterface, afterRecovery.Status.PcapInterface)
+		require.Equal(t, beforeRecovery.ServiceVersion, afterRecovery.Status.ServiceVersion)
+
+		restored := findIdentityInStatus(t, afterRecovery, identityFile)
 		assertValidJwtIdState(t, restored)
 		zet.WaitForControllerEvent(t, "connected", idName)
 
@@ -91,8 +118,8 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, enrolledIdentity, restoredIdentity, "restored identity file differs from the enrolled one")
 		_, statErr := os.Stat(filepath.Join(backupDir, "config.json"))
-		require.True(t, os.IsNotExist(statErr), "backup config.json was not consumed")
+		require.True(t, os.IsNotExist(statErr), "backup config was not removed")
 		_, statErr = os.Stat(filepath.Join(backupDir, idName+".json"))
-		require.True(t, os.IsNotExist(statErr), "backup identity file was not consumed")
+		require.True(t, os.IsNotExist(statErr), "backup identity was not removed")
 	})
 }

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package integration_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -29,58 +30,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const windowsOldNetFoundry = `Windows.old\Windows\System32\config\systemprofile\AppData\Roaming\NetFoundry`
+
+type upgradeContext struct {
+	zet       *testutil.ZET
+	configDir string
+	backupDir string
+}
+
+// newUpgradeContext creates a ZET instance that uses a folder inside dirName
+// as its Windows system drive. dirName survives the run for inspection and is
+// deleted at the start of the next one.
+func newUpgradeContext(t *testing.T, dirName string) *upgradeContext {
+	upgradeDir := filepath.Join(state.zetClient.RootDir, dirName)
+	require.NoError(t, os.RemoveAll(upgradeDir))
+	fakeDrive := filepath.Join(upgradeDir, "fakedrive")
+
+	zet := &testutil.ZET{
+		BinPath:       state.zetClient.BinPath,
+		Discriminator: "zetUpgrade",
+		RootDir:       filepath.Join(upgradeDir, "zet"),
+		Verbosity:     state.zetClient.Verbosity,
+		Env:           []string{"SystemDrive=" + fakeDrive},
+	}
+	return &upgradeContext{
+		zet:       zet,
+		configDir: filepath.Join(zet.RootDir, "identities"),
+		backupDir: filepath.Join(fakeDrive, windowsOldNetFoundry),
+	}
+}
+
 func TestWindowsUpgrade(t *testing.T) {
 	t.Run("configSurvivesWindowsUpgrade", configSurvivesWindowsUpgrade)
+	t.Run("existingConfigWinsOverBackup", existingConfigWinsOverBackup)
 }
 
 func configSurvivesWindowsUpgrade(t *testing.T) {
 	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
-		upgradeDir := filepath.Join(state.zetClient.RootDir, "upgrade")
-		require.NoError(t, os.RemoveAll(upgradeDir))
-		fakeDrive := filepath.Join(upgradeDir, "fakedrive")
 		idName := "test_backup_recovery"
 		tunIp := "100.200.0.1"
-
-		zet := &testutil.ZET{
-			BinPath:       state.zetClient.BinPath,
-			Discriminator: "zetUpgrade",
-			RootDir:       filepath.Join(upgradeDir, "zet"),
-			Verbosity:     state.zetClient.Verbosity,
-			Env:           []string{"SystemDrive=" + fakeDrive},
-		}
-		configDir := filepath.Join(zet.RootDir, "identities")
-		require.NoError(t, zet.Start())
-		t.Cleanup(zet.Stop)
-
-		// First ZET start writes a config: enrolled identity + range and log level changed
-		testutil.FetchAndEnrollJwt(t, state.overlay, zet, idName)
-		zet.WaitForControllerEvent(t, "connected", idName)
-		interfaceData := testutil.InterfaceConfigData{
-			L3: testutil.TunIPv4Data{TunIPv4: tunIp, TunPrefixLength: 24, AddDns: true},
-		}
-
-		logLevelResp := zet.SetLogLevel(t, "trace")
-		logLevelResp.AssertSuccess()
-
-		updateConfigResponse := zet.UpdateInterfaceConfig(t, interfaceData)
-		updateConfigResponse.AssertSuccess()
-
-		// A command response can arrive before its config save finishes writing, so wait for the settled file
-		var beforeRecovery testutil.TunnelStatus
-		configFile := filepath.Join(configDir, "config.json")
-		deadline := time.Now().Add(2 * time.Second)
-		for {
-			var tunnelStatus testutil.TunnelStatus
-			configJSON, err := os.ReadFile(configFile)
-			parsed := err == nil && json.Unmarshal(configJSON, &tunnelStatus) == nil
-			if parsed && tunnelStatus.TunIpv4 == tunIp {
-				beforeRecovery = tunnelStatus
-				break
-			}
-			require.False(t, time.Now().After(deadline), "config.json never settled")
-			time.Sleep(100 * time.Millisecond)
-		}
-		zet.Stop()
+		c := newUpgradeContext(t, "upgrade")
+		beforeRecovery := c.runZetBeforeUpgrade(t, idName, tunIp, "trace")
 
 		require.Equal(t, tunIp, beforeRecovery.TunIpv4)
 		require.Equal(t, 24, beforeRecovery.TunIpv4Mask)
@@ -90,20 +80,18 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 		require.False(t, beforeRecovery.L2Enabled)
 		require.Empty(t, beforeRecovery.PcapInterface)
 		require.NotEmpty(t, beforeRecovery.ServiceVersion.Version)
-		require.Len(t, beforeRecovery.Identities, 1)
 
 		identityFile := beforeRecovery.Identities[0].Identifier
 		enrolledIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
 
 		// The "upgrade": the whole dir moves to Windows.old.
-		backupDir := filepath.Join(fakeDrive, `Windows.old\Windows\System32\config\systemprofile\AppData\Roaming\NetFoundry`)
-		require.NoError(t, os.MkdirAll(filepath.Dir(backupDir), 0o755))
-		require.NoError(t, os.Rename(configDir, backupDir))
+		require.NoError(t, os.MkdirAll(filepath.Dir(c.backupDir), 0o755))
+		require.NoError(t, os.Rename(c.configDir, c.backupDir))
 
 		// Second ZET start must restore the backup before the config load.
-		require.NoError(t, zet.Start())
-		afterRecovery := zet.WaitForStatusEvent(t)
+		require.NoError(t, c.zet.Start())
+		afterRecovery := c.zet.WaitForStatusEvent(t)
 		require.Equal(t, beforeRecovery.TunIpv4, afterRecovery.Status.TunIpv4)
 		require.Equal(t, afterRecovery.Status.TunIpv4, afterRecovery.Status.IpInfo.Ip)
 		require.Equal(t, beforeRecovery.TunIpv4Mask, afterRecovery.Status.TunIpv4Mask)
@@ -116,14 +104,94 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 
 		restored := findIdentityInStatus(t, afterRecovery, identityFile)
 		assertValidJwtIdState(t, restored)
-		zet.WaitForControllerEvent(t, "connected", idName)
+		c.zet.WaitForControllerEvent(t, "connected", idName)
 
 		restoredIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
-		require.Equal(t, enrolledIdentity, restoredIdentity, "restored identity file differs from the enrolled one")
-		_, statErr := os.Stat(filepath.Join(backupDir, "config.json"))
-		require.True(t, os.IsNotExist(statErr), "backup config was not removed")
-		_, statErr = os.Stat(filepath.Join(backupDir, idName+".json"))
-		require.True(t, os.IsNotExist(statErr), "backup identity was not removed")
+		require.True(t, bytes.Equal(enrolledIdentity, restoredIdentity), "restored identity file differs from the enrolled one")
+		c.assertBackupRemoved(t, idName)
 	})
+}
+
+func existingConfigWinsOverBackup(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
+		idName := "test_existing_config_wins_over_backup"
+		tunIp := "100.202.0.1"
+		c := newUpgradeContext(t, "upgrade-existing-wins")
+		existingConfig := c.runZetBeforeUpgrade(t, idName, tunIp, "trace")
+
+		identityFile := existingConfig.Identities[0].Identifier
+		existingIdentity, err := os.ReadFile(identityFile)
+		require.NoError(t, err)
+
+		// A backup left behind (a failed delete on an earlier boot): its config
+		// differs from the existing one and its files are newer on disk.
+		require.NoError(t, os.MkdirAll(c.backupDir, 0o755))
+		backupConfig := existingConfig
+		backupConfig.TunIpv4 = "100.203.0.1"
+		backupConfigJSON, err := json.Marshal(backupConfig)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(c.backupDir, "config.json"), backupConfigJSON, 0o644))
+		backupIdentity := []byte(`{"marker":"dummy identity"}`)
+		require.NoError(t, os.WriteFile(filepath.Join(c.backupDir, idName+".json"), backupIdentity, 0o600))
+
+		// The existing files must win over the newer backup, and the backup is removed.
+		require.NoError(t, c.zet.Start())
+		afterRecovery := c.zet.WaitForStatusEvent(t)
+		require.Equal(t, tunIp, afterRecovery.Status.TunIpv4)
+
+		identityAfterRecovery, err := os.ReadFile(identityFile)
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(existingIdentity, identityAfterRecovery), "existing identity was overwritten by the backup")
+		c.zet.WaitForControllerEvent(t, "connected", idName)
+
+		c.assertBackupRemoved(t, idName)
+	})
+}
+
+// runZetBeforeUpgrade starts ZET, enrolls idName, updates tunIp and logLevel,
+// waits for the config to write to disk, then stops ZET. It returns the saved
+// config as a TunnelStatus struct.
+func (c *upgradeContext) runZetBeforeUpgrade(t *testing.T, idName, tunIp, logLevel string) testutil.TunnelStatus {
+	require.NoError(t, c.zet.Start())
+	t.Cleanup(c.zet.Stop)
+
+	testutil.FetchAndEnrollJwt(t, state.overlay, c.zet, idName)
+	c.zet.WaitForControllerEvent(t, "connected", idName)
+
+	logLevelResp := c.zet.SetLogLevel(t, logLevel)
+	logLevelResp.AssertSuccess()
+
+	interfaceData := testutil.InterfaceConfigData{
+		L3: testutil.TunIPv4Data{TunIPv4: tunIp, TunPrefixLength: 24, AddDns: true},
+	}
+	updateConfigResponse := c.zet.UpdateInterfaceConfig(t, interfaceData)
+	updateConfigResponse.AssertSuccess()
+
+	// A command response can arrive before its config save finishes writing, so wait for the settled file
+	var savedConfig testutil.TunnelStatus
+	configFile := filepath.Join(c.configDir, "config.json")
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var tunnelStatus testutil.TunnelStatus
+		configJSON, err := os.ReadFile(configFile)
+		parsed := err == nil && json.Unmarshal(configJSON, &tunnelStatus) == nil
+		if parsed && tunnelStatus.TunIpv4 == tunIp {
+			savedConfig = tunnelStatus
+			break
+		}
+		require.False(t, time.Now().After(deadline), "config.json never settled")
+		time.Sleep(100 * time.Millisecond)
+	}
+	c.zet.Stop()
+
+	require.Len(t, savedConfig.Identities, 1)
+	return savedConfig
+}
+
+func (c *upgradeContext) assertBackupRemoved(t *testing.T, idName string) {
+	_, statErr := os.Stat(filepath.Join(c.backupDir, "config.json"))
+	require.True(t, os.IsNotExist(statErr), "backup config was not removed")
+	_, statErr = os.Stat(filepath.Join(c.backupDir, idName+".json"))
+	require.True(t, os.IsNotExist(statErr), "backup identity was not removed")
 }

--- a/tests/integration/windows_upgrade_test.go
+++ b/tests/integration/windows_upgrade_test.go
@@ -30,18 +30,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const windowsOldNetFoundry = `Windows.old\Windows\System32\config\systemprofile\AppData\Roaming\NetFoundry`
-
 type upgradeContext struct {
 	zet       *testutil.ZET
+	idName    string
 	configDir string
 	backupDir string
+	tunIp     string
 }
 
 // newUpgradeContext creates a ZET instance that uses a folder inside dirName
 // as its Windows system drive. dirName survives the run for inspection and is
 // deleted at the start of the next one.
-func newUpgradeContext(t *testing.T, dirName string) *upgradeContext {
+func newUpgradeContext(t *testing.T, dirName, idName string) *upgradeContext {
 	upgradeDir := filepath.Join(state.zetClient.RootDir, dirName)
 	require.NoError(t, os.RemoveAll(upgradeDir))
 	fakeDrive := filepath.Join(upgradeDir, "fakedrive")
@@ -55,8 +55,10 @@ func newUpgradeContext(t *testing.T, dirName string) *upgradeContext {
 	}
 	return &upgradeContext{
 		zet:       zet,
+		idName:    idName,
 		configDir: filepath.Join(zet.RootDir, "identities"),
-		backupDir: filepath.Join(fakeDrive, windowsOldNetFoundry),
+		backupDir: filepath.Join(fakeDrive, `Windows.old\Windows\System32\config\systemprofile\AppData\Roaming\NetFoundry`),
+		tunIp:     "100.200.0.1",
 	}
 }
 
@@ -67,12 +69,10 @@ func TestWindowsUpgrade(t *testing.T) {
 
 func configSurvivesWindowsUpgrade(t *testing.T) {
 	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
-		idName := "test_backup_recovery"
-		tunIp := "100.200.0.1"
-		c := newUpgradeContext(t, "upgrade")
-		beforeRecovery := c.runZetBeforeUpgrade(t, idName, tunIp, "trace")
+		c := newUpgradeContext(t, "upgrade", "test_backup_recovery")
+		beforeRecovery := c.runZetBeforeUpgrade(t)
 
-		require.Equal(t, tunIp, beforeRecovery.TunIpv4)
+		require.Equal(t, c.tunIp, beforeRecovery.TunIpv4)
 		require.Equal(t, 24, beforeRecovery.TunIpv4Mask)
 		require.Equal(t, "trace", beforeRecovery.LogLevel)
 		require.True(t, beforeRecovery.AddDns)
@@ -104,27 +104,25 @@ func configSurvivesWindowsUpgrade(t *testing.T) {
 
 		restored := findIdentityInStatus(t, afterRecovery, identityFile)
 		assertValidJwtIdState(t, restored)
-		c.zet.WaitForControllerEvent(t, "connected", idName)
+		c.zet.WaitForControllerEvent(t, "connected", c.idName)
 
 		restoredIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
 		require.True(t, bytes.Equal(enrolledIdentity, restoredIdentity), "restored identity file differs from the enrolled one")
-		c.assertBackupRemoved(t, idName)
+		c.assertBackupRemoved(t)
 	})
 }
 
 func existingConfigWinsOverBackup(t *testing.T) {
 	testutil.RunWithTimeoutOf(t, time.Second*30, func(t *testing.T) {
-		idName := "test_existing_config_wins_over_backup"
-		tunIp := "100.202.0.1"
-		c := newUpgradeContext(t, "upgrade-existing-wins")
-		existingConfig := c.runZetBeforeUpgrade(t, idName, tunIp, "trace")
+		c := newUpgradeContext(t, "upgrade-existing-wins", "test_existing_config_wins_over_backup")
+		existingConfig := c.runZetBeforeUpgrade(t)
 
 		identityFile := existingConfig.Identities[0].Identifier
 		existingIdentity, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
 
-		// A backup left behind (a failed delete on an earlier boot): its config
+		// A backup left behind like a failed delete on an earlier boot: its config
 		// differs from the existing one and its files are newer on disk.
 		require.NoError(t, os.MkdirAll(c.backupDir, 0o755))
 		backupConfig := existingConfig
@@ -133,37 +131,37 @@ func existingConfigWinsOverBackup(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(filepath.Join(c.backupDir, "config.json"), backupConfigJSON, 0o644))
 		backupIdentity := []byte(`{"marker":"dummy identity"}`)
-		require.NoError(t, os.WriteFile(filepath.Join(c.backupDir, idName+".json"), backupIdentity, 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(c.backupDir, c.idName+".json"), backupIdentity, 0o600))
 
 		// The existing files must win over the newer backup, and the backup is removed.
 		require.NoError(t, c.zet.Start())
 		afterRecovery := c.zet.WaitForStatusEvent(t)
-		require.Equal(t, tunIp, afterRecovery.Status.TunIpv4)
+		require.Equal(t, c.tunIp, afterRecovery.Status.TunIpv4)
 
 		identityAfterRecovery, err := os.ReadFile(identityFile)
 		require.NoError(t, err)
 		require.True(t, bytes.Equal(existingIdentity, identityAfterRecovery), "existing identity was overwritten by the backup")
-		c.zet.WaitForControllerEvent(t, "connected", idName)
+		c.zet.WaitForControllerEvent(t, "connected", c.idName)
 
-		c.assertBackupRemoved(t, idName)
+		c.assertBackupRemoved(t)
 	})
 }
 
-// runZetBeforeUpgrade starts ZET, enrolls idName, updates tunIp and logLevel,
-// waits for the config to write to disk, then stops ZET. It returns the saved
-// config as a TunnelStatus struct.
-func (c *upgradeContext) runZetBeforeUpgrade(t *testing.T, idName, tunIp, logLevel string) testutil.TunnelStatus {
+// runZetBeforeUpgrade starts ZET, enrolls the context's identity, updates the
+// tun IP and log level, waits for the config to write to disk, then stops ZET.
+// It returns the saved config as a TunnelStatus struct.
+func (c *upgradeContext) runZetBeforeUpgrade(t *testing.T) testutil.TunnelStatus {
 	require.NoError(t, c.zet.Start())
 	t.Cleanup(c.zet.Stop)
 
-	testutil.FetchAndEnrollJwt(t, state.overlay, c.zet, idName)
-	c.zet.WaitForControllerEvent(t, "connected", idName)
+	testutil.FetchAndEnrollJwt(t, state.overlay, c.zet, c.idName)
+	c.zet.WaitForControllerEvent(t, "connected", c.idName)
 
-	logLevelResp := c.zet.SetLogLevel(t, logLevel)
+	logLevelResp := c.zet.SetLogLevel(t, "trace")
 	logLevelResp.AssertSuccess()
 
 	interfaceData := testutil.InterfaceConfigData{
-		L3: testutil.TunIPv4Data{TunIPv4: tunIp, TunPrefixLength: 24, AddDns: true},
+		L3: testutil.TunIPv4Data{TunIPv4: c.tunIp, TunPrefixLength: 24, AddDns: true},
 	}
 	updateConfigResponse := c.zet.UpdateInterfaceConfig(t, interfaceData)
 	updateConfigResponse.AssertSuccess()
@@ -176,7 +174,7 @@ func (c *upgradeContext) runZetBeforeUpgrade(t *testing.T, idName, tunIp, logLev
 		var tunnelStatus testutil.TunnelStatus
 		configJSON, err := os.ReadFile(configFile)
 		parsed := err == nil && json.Unmarshal(configJSON, &tunnelStatus) == nil
-		if parsed && tunnelStatus.TunIpv4 == tunIp {
+		if parsed && tunnelStatus.TunIpv4 == c.tunIp {
 			savedConfig = tunnelStatus
 			break
 		}
@@ -189,9 +187,9 @@ func (c *upgradeContext) runZetBeforeUpgrade(t *testing.T, idName, tunIp, logLev
 	return savedConfig
 }
 
-func (c *upgradeContext) assertBackupRemoved(t *testing.T, idName string) {
+func (c *upgradeContext) assertBackupRemoved(t *testing.T) {
 	_, statErr := os.Stat(filepath.Join(c.backupDir, "config.json"))
 	require.True(t, os.IsNotExist(statErr), "backup config was not removed")
-	_, statErr = os.Stat(filepath.Join(c.backupDir, idName+".json"))
+	_, statErr = os.Stat(filepath.Join(c.backupDir, c.idName+".json"))
 	require.True(t, os.IsNotExist(statErr), "backup identity was not removed")
 }


### PR DESCRIPTION
- Run Windows.old restore before config load so recovered settings are read and not overwritten by defaults on the next save (closes #1392)
- Never overwrite an existing file with a backup copy, and only delete a backup file after a successful restore, otherwise it stays in Windows.old with a warning naming both paths
- Fix $Windows.~BT folder name and scan Windows.old first
- Stop -v from overwriting or seeding the LogLevel saved in config.json (closes #1393)
- Treat an empty pcap interface as unset so it cannot force L2 on
- Add Windows upgrade integration tests 