### PR TITLE
Propagate enroll failure error text to the AddIdentity IPC response

### DIFF
--- a/programs/ziti-edge-tunnel/process_cmd.c
+++ b/programs/ziti-edge-tunnel/process_cmd.c
@@ -65,6 +65,7 @@ static void tunnel_enroll_cb(const ziti_config *cfg, int status, const char *err
         }
         ZITI_LOG(ERROR, "enrollment failed: %s(%d)", err, status);
 
+        result.error = (char *) err;
         if (status == ZITI_KEY_GENERATION_FAILED) {
             result.error = "ZITI_KEY_GENERATION_FAILED";
         }

--- a/tests/integration/add_identity_test.go
+++ b/tests/integration/add_identity_test.go
@@ -61,7 +61,7 @@ func withInvalidJwtFails(t *testing.T) {
 		badJwt := "this.is.not-a-real-jwt"
 		identityData := testutil.NewJwtIdentityData("test_add_id_invalid_jwt", badJwt)
 		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertFail(500, "")
+		addResp.AssertFail(500, "enrollment failed")
 	})
 }
 
@@ -70,7 +70,7 @@ func withEmptyJwtFails(t *testing.T) {
 		emptyJwt := ""
 		identityData := testutil.NewJwtIdentityData("test_add_id_empty_jwt", emptyJwt)
 		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertFail(500, "")
+		addResp.AssertFail(500, "enrollment failed")
 	})
 }
 
@@ -84,7 +84,7 @@ func withDeletedIdentityFails(t *testing.T) {
 
 		identityData := testutil.NewJwtIdentityData(idName, jwt)
 		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertFail(500, "")
+		addResp.AssertFail(500, "JWT not accepted by controller")
 	})
 }
 
@@ -156,7 +156,7 @@ func withNonZitiEndpointFails(t *testing.T) {
 		identityData := testutil.NewUrlIdentityData("test_url_enroll_non_ziti", nonZitiURL, testutil.EnrollModeNone)
 
 		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertFail(500, "")
+		addResp.AssertFail(500, "received non-JSON response")
 	})
 }
 
@@ -166,6 +166,6 @@ func withMalformedUrlFails(t *testing.T) {
 		identityData := testutil.NewUrlIdentityData("test_url_enroll_malformed_url", badURL, testutil.EnrollModeNone)
 
 		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertFail(500, "")
+		addResp.AssertFail(500, "enrollment failed")
 	})
 }


### PR DESCRIPTION
- AddIdentity enroll failures returned Success=false with code 500 and a null Error, so the reason only existed in the ZET log. The response now carries the SDK's error text.
- Fix add-identity negative tests to assert the fixed error text instead of an empty string.