### PR TITLE
Add third-party CA enrollment integration tests

### DIFF
--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -192,6 +192,10 @@ func doSetup(state TestState) error {
 	if err := state.overlay.PurgeIdentitiesByExternalId("@test.com"); err != nil {
 		return fmt.Errorf("purge stale IdP test user identities: %w", err)
 	}
+	log.Printf("setup: purging stale test certificate authorities")
+	if err := state.overlay.PurgeCAs(); err != nil {
+		return fmt.Errorf("purge stale test certificate authorities: %w", err)
+	}
 	log.Printf("setup: purging stale test auth-policies")
 	if err := state.overlay.PurgeAuthPolicies(); err != nil {
 		return fmt.Errorf("purge stale test auth policies: %w", err)

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -250,6 +250,10 @@ func doSetup(state TestState) error {
 	if err := state.zetClient.RemoveJSONIdentities(); err != nil {
 		return fmt.Errorf("wipe shared identity dir: %w", err)
 	}
+	log.Printf("setup: wiping stale on-disk test pki")
+	if err := state.overlay.PurgeLocalPki(); err != nil {
+		return fmt.Errorf("wipe stale on-disk test pki: %w", err)
+	}
 
 	// Multi-tunnel works on every OS when ZET >= 1.17.0
 	// Tests against an older ZET start only zetA and skip t2t tests.

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -13,6 +13,12 @@
   ],
   "identities": [
     {
+      "name": "test_tpca_ottca_user1",
+      "isAdmin": false,
+      "authPolicy": "@Default",
+      "enrollment": { "ott": true }
+    },
+    {
       "name": "test_restart_jwt",
       "isAdmin": false,
       "authPolicy": "@Default",

--- a/tests/integration/testdata/fixture.json
+++ b/tests/integration/testdata/fixture.json
@@ -15,8 +15,7 @@
     {
       "name": "test_tpca_ottca_user1",
       "isAdmin": false,
-      "authPolicy": "@Default",
-      "enrollment": { "ott": true }
+      "authPolicy": "@Default"
     },
     {
       "name": "test_restart_jwt",

--- a/tests/integration/testutil/common.go
+++ b/tests/integration/testutil/common.go
@@ -59,6 +59,23 @@ func FetchAndEnrollJwt(t *testing.T, overlay *Overlay, zet *ZET, name string) Id
 	return identityEvent
 }
 
+// EnrollCaJwt enrolls a third-party-CA-issued cert/key pair on zet with the
+// given autoca or ottca enrollment JWT, waits for the identity:added and
+// controller:connected events, asserts the on-disk identity file, and returns
+// the added event.
+func EnrollCaJwt(t *testing.T, zet *ZET, name, jwt, cert, key string) IdentityEvent {
+	identityData := NewCaIdentityData(name, jwt, cert, key)
+	addResp := zet.AddIdentity(t, identityData)
+	addResp.AssertSuccess()
+
+	added := zet.WaitForIdentityEvent(t, "added", name)
+	require.NotEmpty(t, added.Id.Identifier, "identity:added Identifier empty")
+	require.True(t, added.Id.Active, "identity:added Active=%t", added.Id.Active)
+	zet.WaitForControllerEvent(t, "connected", name)
+	AssertValidJwtEnrolledIdentityFile(t, added.Id.Identifier)
+	return added
+}
+
 // ParseTOTPSecret extracts the base32 TOTP secret from an otpauth provisioning URL.
 func ParseTOTPSecret(t *testing.T, provisioningURL string) string {
 	parsed, err := url.Parse(provisioningURL)

--- a/tests/integration/testutil/identity_file.go
+++ b/tests/integration/testutil/identity_file.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -52,6 +53,13 @@ func ReadIdentityFile(t *testing.T, path string) IdentityFileContent {
 	dec.DisallowUnknownFields()
 	require.NoError(t, dec.Decode(&content), "identity file at %s has unknown fields or invalid shape: %s", path, raw)
 	return content
+}
+
+// AssertNoIdentityFile asserts a failed enrollment left no identity file in
+// zet's identity dir.
+func AssertNoIdentityFile(t *testing.T, zet *ZET, name string) {
+	idPath := filepath.Join(zet.RootDir, "identities", name+".json")
+	require.NoFileExists(t, idPath)
 }
 
 func AssertValidJwtEnrolledIdentityFile(t *testing.T, path string) {

--- a/tests/integration/testutil/ipc_types.go
+++ b/tests/integration/testutil/ipc_types.go
@@ -133,6 +133,15 @@ func NewUrlIdentityData(name, url string, mode EnrollMode, provider ...string) A
 	return data
 }
 
+func NewCaIdentityData(name, caJwt, cert, key string) AddIdentityData {
+	return AddIdentityData{
+		IdentityFilename: name,
+		JwtContent:       &caJwt,
+		Certificate:      &cert,
+		Key:              &key,
+	}
+}
+
 func NewIdentityOnOffData(identifier string, onOff bool) IdentityOnOffData {
 	return IdentityOnOffData{
 		Identifier: identifier,

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -571,17 +571,18 @@ type CAResult struct {
 	Name string
 }
 
-// caPkiPath is the on-disk PKI directory for a CA created by CreateLocalPkiCA.
-func (o *Overlay) caPkiPath(name string) string {
-	return filepath.Join(o.Home, "third-party-pki", name)
+// pkiRoot is the on-disk root under which all test CAs are created; the ziti
+// pki CLI lays out each CA at <root>/<ca-name>.
+func (o *Overlay) pkiRoot() string {
+	return filepath.Join(o.Home, "third-party-pki")
 }
 
 // CreateLocalPkiCA creates a root CA on disk without registering it on the
 // controller.
 func (o *Overlay) CreateLocalPkiCA(t *testing.T, name string) {
 	// ziti pki refuses to overwrite PKI left by a previous run
-	require.NoError(t, os.RemoveAll(o.caPkiPath(name)), "clear stale pki for %s", name)
-	_, err := o.execZiti("pki", "create", "ca", "--pki-root", filepath.Join(o.Home, "third-party-pki"), "--ca-file", name, "--ca-name", name)
+	require.NoError(t, os.RemoveAll(filepath.Join(o.pkiRoot(), name)), "clear stale pki for %s", name)
+	_, err := o.execZiti("pki", "create", "ca", "--pki-root", o.pkiRoot(), "--ca-file", name, "--ca-name", name)
 	require.NoError(t, err, "pki create ca %s", name)
 }
 
@@ -592,13 +593,13 @@ func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) CAResult {
 	t.Logf("creating third-party CA %q", name)
 	o.CreateLocalPkiCA(t, name)
 
-	caCert := filepath.Join(o.caPkiPath(name), "certs", name+".cert")
+	caCert := filepath.Join(o.pkiRoot(), name, "certs", name+".cert")
 	out, err := o.execZiti("edge", "create", "ca", name, caCert, "--auth", "--ottca", "--autoca")
 	require.NoError(t, err, "create ca %s", name)
 	id := string(bytes.TrimSpace(out))
 
 	// --cacert/--cakey makes the CLI fetch the verificationToken and mint the CN=token cert itself
-	_, err = o.execZiti("edge", "verify", "ca", name, "--cacert", caCert, "--cakey", filepath.Join(o.caPkiPath(name), "keys", name+".key"))
+	_, err = o.execZiti("edge", "verify", "ca", name, "--cacert", caCert, "--cakey", filepath.Join(o.pkiRoot(), name, "keys", name+".key"))
 	require.NoError(t, err, "verify ca %s", name)
 	t.Logf("third-party CA %q registered and verified with id=%s", name, id)
 	return CAResult{ID: id, Name: name}
@@ -627,11 +628,11 @@ func (o *Overlay) CreateOttCaEnrollment(t *testing.T, identityName, caName strin
 // CA and returns the cert and key PEM contents (the AddIdentity command carries
 // content, not file paths).
 func (o *Overlay) CreateClientCert(t *testing.T, caName, commonName string) (certPEM, keyPEM string) {
-	_, err := o.execZiti("pki", "create", "client", "--pki-root", filepath.Join(o.Home, "third-party-pki"), "--ca-name", caName, "--client-name", commonName, "--client-file", commonName)
+	_, err := o.execZiti("pki", "create", "client", "--pki-root", o.pkiRoot(), "--ca-name", caName, "--client-name", commonName, "--client-file", commonName)
 	require.NoError(t, err, "pki create client %s for ca %s", commonName, caName)
-	cert, err := os.ReadFile(filepath.Join(o.caPkiPath(caName), "certs", commonName+".cert"))
+	cert, err := os.ReadFile(filepath.Join(o.pkiRoot(), caName, "certs", commonName+".cert"))
 	require.NoError(t, err, "read client cert for %s", commonName)
-	key, err := os.ReadFile(filepath.Join(o.caPkiPath(caName), "keys", commonName+".key"))
+	key, err := os.ReadFile(filepath.Join(o.pkiRoot(), caName, "keys", commonName+".key"))
 	require.NoError(t, err, "read client key for %s", commonName)
 	return string(cert), string(key)
 }

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -627,9 +627,8 @@ func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) string {
 	token := resp.Data[0].VerificationToken
 	require.NotEmpty(t, token, "ca %s has no verificationToken", name)
 
-	_, err = o.execZiti("pki create client --pki-root %s --ca-name %s --client-name %s --client-file verification", o.pkiRoot(), name, token)
-	require.NoError(t, err, "mint verification cert for ca %s", name)
-	verifyCert := filepath.Join(o.pkiRoot(), name, "certs", "verification.cert")
+	o.CreateClientCert(t, name, token)
+	verifyCert := filepath.Join(o.pkiRoot(), name, "certs", token+".cert")
 	_, err = o.execZiti("edge verify ca %s --cert %s", name, verifyCert)
 	require.NoError(t, err, "verify ca %s", name)
 	t.Logf("third-party CA %q registered and verified with id=%s", name, id)

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -604,6 +604,25 @@ func (o *Overlay) Create3rdPartyCA(t *testing.T, name string) CAResult {
 	return CAResult{ID: id, Name: name}
 }
 
+// CreateOttCaEnrollment adds an ottca enrollment binding the identity to the
+// CA and returns the enrollment JWT.
+func (o *Overlay) CreateOttCaEnrollment(t *testing.T, identityName, caName string) string {
+	out, err := o.execZiti("edge", "create", "enrollment", "ottca", identityName, caName)
+	require.NoError(t, err, "create ottca enrollment for %s", identityName)
+	enrollmentID := string(bytes.TrimSpace(out))
+	listOut, err := o.execZiti("edge", "list", "enrollments", fmt.Sprintf("id=%q", enrollmentID), "-j")
+	require.NoError(t, err, "list enrollment %s", enrollmentID)
+	var resp struct {
+		Data []struct {
+			JWT string `json:"jwt"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(listOut, &resp), "parse enrollment %s", enrollmentID)
+	require.Len(t, resp.Data, 1, "expected exactly one enrollment %s", enrollmentID)
+	require.NotEmpty(t, resp.Data[0].JWT, "enrollment %s has no jwt", enrollmentID)
+	return resp.Data[0].JWT
+}
+
 // CreateClientCert signs a client cert with the given common name by the named
 // CA and returns the cert and key PEM contents (the AddIdentity command carries
 // content, not file paths).

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -603,13 +603,16 @@ func (o *Overlay) CreateLocalPkiCA(t *testing.T, name string) {
 // CreateThirdPartyCA creates a root CA, registers it on the controller for
 // auth+ottca+autoca enrollment, verifies it, and returns its assigned ID.
 // Identities created by autoca enrollment are named with the controller
-// default format, [caName]-[commonName].
-func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) string {
+// default format, [caName]-[commonName]. createCaFlags are appended to the
+// `edge create ca` command.
+func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string, createCaFlags ...string) string {
 	t.Logf("creating third-party CA %q", name)
 	o.CreateLocalPkiCA(t, name)
 
 	caCert := filepath.Join(o.pkiRoot(), name, "certs", name+".cert")
-	out, err := o.execZiti("edge create ca %s %s --auth --ottca --autoca", name, caCert)
+	cmd := "edge create ca %s %s --auth --ottca --autoca" + strings.Repeat(" %s", len(createCaFlags))
+	args := append([]string{name, caCert}, createCaFlags...)
+	out, err := o.execZiti(cmd, args...)
 	require.NoError(t, err, "create ca %s", name)
 	id := string(bytes.TrimSpace(out))
 

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -576,15 +576,21 @@ func (o *Overlay) caPkiPath(name string) string {
 	return filepath.Join(o.Home, "third-party-pki", name)
 }
 
+// CreateLocalPkiCA mints a root CA on disk without registering it on the
+// controller.
+func (o *Overlay) CreateLocalPkiCA(t *testing.T, name string) {
+	// ziti pki refuses to overwrite PKI left by a previous run
+	require.NoError(t, os.RemoveAll(o.caPkiPath(name)), "clear stale pki for %s", name)
+	_, err := o.execZiti("pki", "create", "ca", "--pki-root", filepath.Join(o.Home, "third-party-pki"), "--ca-file", name, "--ca-name", name)
+	require.NoError(t, err, "pki create ca %s", name)
+}
+
 // Create3rdPartyCA mints a root CA, registers it on the controller for
 // auth+ottca+autoca enrollment, and verifies it. Auto-provisioned identities
 // are named with the controller default format, [caName]-[commonName].
 func (o *Overlay) Create3rdPartyCA(t *testing.T, name string) CAResult {
 	t.Logf("creating 3rd-party CA %q", name)
-	// ziti pki refuses to overwrite PKI left by a previous run
-	require.NoError(t, os.RemoveAll(o.caPkiPath(name)), "clear stale pki for %s", name)
-	_, err := o.execZiti("pki", "create", "ca", "--pki-root", filepath.Join(o.Home, "third-party-pki"), "--ca-file", name, "--ca-name", name)
-	require.NoError(t, err, "pki create ca %s", name)
+	o.CreateLocalPkiCA(t, name)
 
 	caCert := filepath.Join(o.caPkiPath(name), "certs", name+".cert")
 	out, err := o.execZiti("edge", "create", "ca", name, caCert, "--auth", "--ottca", "--autoca")

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -613,9 +613,24 @@ func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) string {
 	require.NoError(t, err, "create ca %s", name)
 	id := string(bytes.TrimSpace(out))
 
-	// --cacert/--cakey makes the CLI fetch the verificationToken and mint the CN=token cert itself
-	caKey := filepath.Join(o.pkiRoot(), name, "keys", name+".key")
-	_, err = o.execZiti("edge verify ca %s --cacert %s --cakey %s", name, caCert, caKey)
+	// verify by minting a client cert whose CN is the CA's verificationToken
+	filter := fmt.Sprintf("name=%q", name)
+	listOut, err := o.execZiti("edge list cas %s -j", filter)
+	require.NoError(t, err, "list ca %s", name)
+	var resp struct {
+		Data []struct {
+			VerificationToken string `json:"verificationToken"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(listOut, &resp), "parse ca %s", name)
+	require.Len(t, resp.Data, 1, "expected exactly one ca named %s", name)
+	token := resp.Data[0].VerificationToken
+	require.NotEmpty(t, token, "ca %s has no verificationToken", name)
+
+	_, err = o.execZiti("pki create client --pki-root %s --ca-name %s --client-name %s --client-file verification", o.pkiRoot(), name, token)
+	require.NoError(t, err, "mint verification cert for ca %s", name)
+	verifyCert := filepath.Join(o.pkiRoot(), name, "certs", "verification.cert")
+	_, err = o.execZiti("edge verify ca %s --cert %s", name, verifyCert)
 	require.NoError(t, err, "verify ca %s", name)
 	t.Logf("third-party CA %q registered and verified with id=%s", name, id)
 	return id

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -565,18 +565,18 @@ func (o *Overlay) CreateIdentityWithExternalId(t *testing.T, name, externalID, a
 	t.Logf("controller identity %q created", name)
 }
 
-// CAResult identifies a registered 3rd-party CA.
+// CAResult identifies a registered third-party CA.
 type CAResult struct {
 	ID   string
 	Name string
 }
 
-// caPkiPath is the on-disk PKI directory for a CA created by Create3rdPartyCA.
+// caPkiPath is the on-disk PKI directory for a CA created by CreateLocalPkiCA.
 func (o *Overlay) caPkiPath(name string) string {
 	return filepath.Join(o.Home, "third-party-pki", name)
 }
 
-// CreateLocalPkiCA mints a root CA on disk without registering it on the
+// CreateLocalPkiCA creates a root CA on disk without registering it on the
 // controller.
 func (o *Overlay) CreateLocalPkiCA(t *testing.T, name string) {
 	// ziti pki refuses to overwrite PKI left by a previous run
@@ -585,11 +585,11 @@ func (o *Overlay) CreateLocalPkiCA(t *testing.T, name string) {
 	require.NoError(t, err, "pki create ca %s", name)
 }
 
-// Create3rdPartyCA mints a root CA, registers it on the controller for
-// auth+ottca+autoca enrollment, and verifies it. Auto-provisioned identities
-// are named with the controller default format, [caName]-[commonName].
-func (o *Overlay) Create3rdPartyCA(t *testing.T, name string) CAResult {
-	t.Logf("creating 3rd-party CA %q", name)
+// CreateThirdPartyCA creates a root CA, registers it on the controller for
+// auth+ottca+autoca enrollment, and verifies it. Identities created by autoca
+// enrollment are named with the controller default format, [caName]-[commonName].
+func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) CAResult {
+	t.Logf("creating third-party CA %q", name)
 	o.CreateLocalPkiCA(t, name)
 
 	caCert := filepath.Join(o.caPkiPath(name), "certs", name+".cert")
@@ -600,7 +600,7 @@ func (o *Overlay) Create3rdPartyCA(t *testing.T, name string) CAResult {
 	// --cacert/--cakey makes the CLI fetch the verificationToken and mint the CN=token cert itself
 	_, err = o.execZiti("edge", "verify", "ca", name, "--cacert", caCert, "--cakey", filepath.Join(o.caPkiPath(name), "keys", name+".key"))
 	require.NoError(t, err, "verify ca %s", name)
-	t.Logf("3rd-party CA %q registered and verified with id=%s", name, id)
+	t.Logf("third-party CA %q registered and verified with id=%s", name, id)
 	return CAResult{ID: id, Name: name}
 }
 

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -342,7 +342,7 @@ func (o *Overlay) Logs() string {
 // CreateIdentityJWT provisions a new (non-admin) identity and returns its enrollment JWT content.
 func (o *Overlay) CreateIdentityJWT(name string) (string, error) {
 	jwtPath := filepath.Join(o.Home, name+".jwt")
-	if _, err := o.execZiti("edge", "create", "identity", name, "-o", jwtPath); err != nil {
+	if _, err := o.execZiti("edge create identity %s -o %s", name, jwtPath); err != nil {
 		return "", fmt.Errorf("create identity %s: %w", name, err)
 	}
 	content, err := os.ReadFile(jwtPath)
@@ -356,7 +356,7 @@ func (o *Overlay) CreateIdentityJWT(name string) (string, error) {
 // at path via `ziti ops import`. The importer skips entities that already exist,
 // so callers should purge stale fixtures first.
 func (o *Overlay) ImportFixture(path string) error {
-	if _, err := o.execZiti("ops", "import", path, "-u", o.ControllerUser, "-p", o.ControllerPassword, "--yes"); err != nil {
+	if _, err := o.execZiti("ops import %s -u %s -p %s --yes", path, o.ControllerUser, o.ControllerPassword); err != nil {
 		return fmt.Errorf("import fixture %s: %w", path, err)
 	}
 	return nil
@@ -366,7 +366,8 @@ func (o *Overlay) ImportFixture(path string) error {
 // with the given name. The identity must have been created with an OTT enrollment
 // (e.g. via ImportFixture) and not yet enrolled.
 func (o *Overlay) GetJwtFromController(t *testing.T, name string) string {
-	out, err := o.execZiti("edge", "list", "identities", fmt.Sprintf("name=%q", name), "-j")
+	filter := fmt.Sprintf("name=%q", name)
+	out, err := o.execZiti("edge list identities %s -j", filter)
 	require.NoError(t, err, "list identities name=%s", name)
 	var resp struct {
 		Data []struct {
@@ -385,7 +386,7 @@ func (o *Overlay) GetJwtFromController(t *testing.T, name string) string {
 }
 
 func (o *Overlay) DeleteIdentity(name string) error {
-	if _, err := o.execZiti("edge", "delete", "identity", name); err != nil {
+	if _, err := o.execZiti("edge delete identity %s", name); err != nil {
 		return fmt.Errorf("delete identity %s: %w", name, err)
 	}
 	return nil
@@ -393,7 +394,8 @@ func (o *Overlay) DeleteIdentity(name string) error {
 
 // Mirrors the controller's "Reset Enrollment" action so the identity can enroll again.
 func (o *Overlay) ResetEnrollment(t *testing.T, name string) {
-	out, err := o.execZiti("edge", "list", "identities", fmt.Sprintf("name=%q", name), "-j")
+	filter := fmt.Sprintf("name=%q", name)
+	out, err := o.execZiti("edge list identities %s -j", filter)
 	require.NoError(t, err, "list identity %s", name)
 	var resp struct {
 		Data []struct {
@@ -407,7 +409,7 @@ func (o *Overlay) ResetEnrollment(t *testing.T, name string) {
 	require.NoError(t, json.Unmarshal(out, &resp), "parse identity %s", name)
 	authID := resp.Data[0].Authenticators.Cert.ID
 
-	_, err = o.execZiti("edge", "update", "authenticator", "cert", authID, "--re-enroll")
+	_, err = o.execZiti("edge update authenticator cert %s --re-enroll", authID)
 	require.NoError(t, err, "re-enroll cert authenticator for %s", name)
 }
 
@@ -435,35 +437,35 @@ type ExtJwtSignerSpec struct {
 // its assigned ID.
 func (o *Overlay) CreateExtJwtSigner(t *testing.T, spec ExtJwtSignerSpec) string {
 	t.Logf("creating ext-jwt-signer %q (issuer=%s audience=%s clientID=%s enrollToCert=%t enrollToToken=%t)", spec.Name, spec.Issuer, spec.Audience, spec.ClientID, spec.EnrollToCert, spec.EnrollToToken)
-	args := []string{
-		"edge", "create", "ext-jwt-signer", spec.Name, spec.Issuer,
-		"--jwks-endpoint", spec.JWKS,
-		"--audience", spec.Audience,
-		"--client-id", spec.ClientID,
-		"--external-auth-url", spec.Issuer,
-	}
+	cmd := "edge create ext-jwt-signer %s %s --jwks-endpoint %s --audience %s --client-id %s --external-auth-url %s"
+	args := []string{spec.Name, spec.Issuer, spec.JWKS, spec.Audience, spec.ClientID, spec.Issuer}
 	if spec.Claim != "" {
-		args = append(args, "--claims-property", spec.Claim)
+		cmd += " --claims-property %s"
+		args = append(args, spec.Claim)
 	}
 	for _, s := range spec.Scopes {
-		args = append(args, "--scopes", s)
+		cmd += " --scopes %s"
+		args = append(args, s)
 	}
 	if spec.EnrollToCert {
-		args = append(args, "--enroll-to-cert")
+		cmd += " --enroll-to-cert"
 	}
 	if spec.EnrollToToken {
-		args = append(args, "--enroll-to-token")
+		cmd += " --enroll-to-token"
 	}
 	if spec.EnrollNameSelector != "" {
-		args = append(args, "--enroll-name-claims-selector", spec.EnrollNameSelector)
+		cmd += " --enroll-name-claims-selector %s"
+		args = append(args, spec.EnrollNameSelector)
 	}
 	if spec.EnrollAttrSelector != "" {
-		args = append(args, "--enroll-attr-claims-selector", spec.EnrollAttrSelector)
+		cmd += " --enroll-attr-claims-selector %s"
+		args = append(args, spec.EnrollAttrSelector)
 	}
 	if spec.EnrollAuthPolicy != "" {
-		args = append(args, "--enroll-auth-policy", spec.EnrollAuthPolicy)
+		cmd += " --enroll-auth-policy %s"
+		args = append(args, spec.EnrollAuthPolicy)
 	}
-	out, err := o.execZiti(args...)
+	out, err := o.execZiti(cmd, args...)
 	require.NoError(t, err, "create ext-jwt-signer %s", spec.Name)
 	id := string(bytes.TrimSpace(out))
 	t.Logf("ext-jwt-signer %q created with id=%s", spec.Name, id)
@@ -473,7 +475,8 @@ func (o *Overlay) CreateExtJwtSigner(t *testing.T, spec ExtJwtSignerSpec) string
 // FindExtJwtSignerId returns the id of the ext-jwt-signer with the given name
 // and whether it exists.
 func (o *Overlay) FindExtJwtSignerId(t *testing.T, name string) (string, bool) {
-	out, err := o.execZiti("edge", "list", "ext-jwt-signers", fmt.Sprintf("name=%q", name), "-j")
+	filter := fmt.Sprintf("name=%q", name)
+	out, err := o.execZiti("edge list ext-jwt-signers %s -j", filter)
 	require.NoError(t, err, "list ext-jwt-signers name=%s", name)
 	var resp struct {
 		Data []struct {
@@ -493,42 +496,48 @@ func (o *Overlay) FindExtJwtSignerId(t *testing.T, name string) (string, bool) {
 // EnrollNameSelector or EnrollAuthPolicy falls back to /sub and default.
 func (o *Overlay) UpdateExtJwtSigner(t *testing.T, name string, spec ExtJwtSignerSpec) {
 	t.Logf("updating ext-jwt-signer %q (enrollToCert=%t enrollToToken=%t)", name, spec.EnrollToCert, spec.EnrollToToken)
-	args := []string{"edge", "update", "ext-jwt-signer", name}
+	cmd := "edge update ext-jwt-signer %s"
+	args := []string{name}
 	if spec.Name != "" {
-		args = append(args, "--name", spec.Name)
+		cmd += " --name %s"
+		args = append(args, spec.Name)
 	}
 	if spec.Issuer != "" {
-		args = append(args, "--issuer", spec.Issuer, "--external-auth-url", spec.Issuer)
+		cmd += " --issuer %s --external-auth-url %s"
+		args = append(args, spec.Issuer, spec.Issuer)
 	}
 	if spec.JWKS != "" {
-		args = append(args, "--jwks-endpoint", spec.JWKS)
+		cmd += " --jwks-endpoint %s"
+		args = append(args, spec.JWKS)
 	}
 	if spec.Audience != "" {
-		args = append(args, "--audience", spec.Audience)
+		cmd += " --audience %s"
+		args = append(args, spec.Audience)
 	}
 	if spec.ClientID != "" {
-		args = append(args, "--client-id", spec.ClientID)
+		cmd += " --client-id %s"
+		args = append(args, spec.ClientID)
 	}
 	if spec.Claim != "" {
-		args = append(args, "--claims-property", spec.Claim)
+		cmd += " --claims-property %s"
+		args = append(args, spec.Claim)
 	}
 	for _, s := range spec.Scopes {
-		args = append(args, "--scopes", s)
+		cmd += " --scopes %s"
+		args = append(args, s)
 	}
 	nameSelector := spec.EnrollNameSelector
 	if nameSelector == "" {
 		nameSelector = "/sub"
 	}
-	args = append(args, "--enroll-name-claims-selector", nameSelector)
-	args = append(args, "--enroll-attr-claims-selector", spec.EnrollAttrSelector)
 	authPolicy := spec.EnrollAuthPolicy
 	if authPolicy == "" {
 		authPolicy = "default"
 	}
-	args = append(args, "--enroll-auth-policy", authPolicy)
-	args = append(args, fmt.Sprintf("--enroll-to-cert=%t", spec.EnrollToCert))
-	args = append(args, fmt.Sprintf("--enroll-to-token=%t", spec.EnrollToToken))
-	_, err := o.execZiti(args...)
+	cmd += " --enroll-name-claims-selector %s --enroll-attr-claims-selector %s --enroll-auth-policy %s"
+	args = append(args, nameSelector, spec.EnrollAttrSelector, authPolicy)
+	cmd += fmt.Sprintf(" --enroll-to-cert=%t --enroll-to-token=%t", spec.EnrollToCert, spec.EnrollToToken)
+	_, err := o.execZiti(cmd, args...)
 	require.NoError(t, err, "update ext-jwt-signer %s", name)
 	t.Logf("ext-jwt-signer %q updated", name)
 }
@@ -537,11 +546,13 @@ func (o *Overlay) UpdateExtJwtSigner(t *testing.T, name string, spec ExtJwtSigne
 // is the ext-jwt-signer set with the given IDs. Pass one or more signer IDs.
 func (o *Overlay) CreateAuthPolicyForExtJwt(t *testing.T, name string, signerIDs ...string) {
 	t.Logf("creating auth policy %q with %d ext-jwt-signer(s)", name, len(signerIDs))
-	args := []string{"edge", "create", "auth-policy", name, "--primary-ext-jwt-allowed"}
+	cmd := "edge create auth-policy %s --primary-ext-jwt-allowed"
+	args := []string{name}
 	for _, id := range signerIDs {
-		args = append(args, "--primary-ext-jwt-allowed-signers", id)
+		cmd += " --primary-ext-jwt-allowed-signers %s"
+		args = append(args, id)
 	}
-	_, err := o.execZiti(args...)
+	_, err := o.execZiti(cmd, args...)
 	require.NoError(t, err, "create auth policy %s", name)
 	t.Logf("auth policy %q created", name)
 }
@@ -556,11 +567,13 @@ func (o *Overlay) CreateIdentityWithExternalId(t *testing.T, name, externalID, a
 		policyDesc = "default"
 	}
 	t.Logf("creating controller identity %q with externalId=%q bound to auth policy %q", name, externalID, policyDesc)
-	args := []string{"edge", "create", "identity", name, "--external-id", externalID}
+	cmd := "edge create identity %s --external-id %s"
+	args := []string{name, externalID}
 	if authPolicy != "" {
-		args = append(args, "-P", authPolicy)
+		cmd += " -P %s"
+		args = append(args, authPolicy)
 	}
-	_, err := o.execZiti(args...)
+	_, err := o.execZiti(cmd, args...)
 	require.NoError(t, err, "create identity %s with externalId %s", name, externalID)
 	t.Logf("controller identity %q created", name)
 }
@@ -576,7 +589,7 @@ func (o *Overlay) pkiRoot() string {
 func (o *Overlay) CreateLocalPkiCA(t *testing.T, name string) {
 	// ziti pki refuses to overwrite PKI left by a previous run
 	require.NoError(t, os.RemoveAll(filepath.Join(o.pkiRoot(), name)), "clear stale pki for %s", name)
-	_, err := o.execZiti("pki", "create", "ca", "--pki-root", o.pkiRoot(), "--ca-file", name, "--ca-name", name)
+	_, err := o.execZiti("pki create ca --pki-root %s --ca-file %s --ca-name %s", o.pkiRoot(), name, name)
 	require.NoError(t, err, "pki create ca %s", name)
 }
 
@@ -589,12 +602,13 @@ func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) string {
 	o.CreateLocalPkiCA(t, name)
 
 	caCert := filepath.Join(o.pkiRoot(), name, "certs", name+".cert")
-	out, err := o.execZiti("edge", "create", "ca", name, caCert, "--auth", "--ottca", "--autoca")
+	out, err := o.execZiti("edge create ca %s %s --auth --ottca --autoca", name, caCert)
 	require.NoError(t, err, "create ca %s", name)
 	id := string(bytes.TrimSpace(out))
 
 	// --cacert/--cakey makes the CLI fetch the verificationToken and mint the CN=token cert itself
-	_, err = o.execZiti("edge", "verify", "ca", name, "--cacert", caCert, "--cakey", filepath.Join(o.pkiRoot(), name, "keys", name+".key"))
+	caKey := filepath.Join(o.pkiRoot(), name, "keys", name+".key")
+	_, err = o.execZiti("edge verify ca %s --cacert %s --cakey %s", name, caCert, caKey)
 	require.NoError(t, err, "verify ca %s", name)
 	t.Logf("third-party CA %q registered and verified with id=%s", name, id)
 	return id
@@ -603,10 +617,11 @@ func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) string {
 // CreateOttCaEnrollment adds an ottca enrollment binding the identity to the
 // CA and returns the enrollment JWT.
 func (o *Overlay) CreateOttCaEnrollment(t *testing.T, identityName, caName string) string {
-	out, err := o.execZiti("edge", "create", "enrollment", "ottca", identityName, caName)
+	out, err := o.execZiti("edge create enrollment ottca %s %s", identityName, caName)
 	require.NoError(t, err, "create ottca enrollment for %s", identityName)
 	enrollmentID := string(bytes.TrimSpace(out))
-	listOut, err := o.execZiti("edge", "list", "enrollments", fmt.Sprintf("id=%q", enrollmentID), "-j")
+	filter := fmt.Sprintf("id=%q", enrollmentID)
+	listOut, err := o.execZiti("edge list enrollments %s -j", filter)
 	require.NoError(t, err, "list enrollment %s", enrollmentID)
 	var resp struct {
 		Data []struct {
@@ -623,7 +638,7 @@ func (o *Overlay) CreateOttCaEnrollment(t *testing.T, identityName, caName strin
 // CA and returns the cert and key PEM contents (the AddIdentity command carries
 // content, not file paths).
 func (o *Overlay) CreateClientCert(t *testing.T, caName, commonName string) (certPEM, keyPEM string) {
-	_, err := o.execZiti("pki", "create", "client", "--pki-root", o.pkiRoot(), "--ca-name", caName, "--client-name", commonName, "--client-file", commonName)
+	_, err := o.execZiti("pki create client --pki-root %s --ca-name %s --client-name %s --client-file %s", o.pkiRoot(), caName, commonName, commonName)
 	require.NoError(t, err, "pki create client %s for ca %s", commonName, caName)
 	cert, err := os.ReadFile(filepath.Join(o.pkiRoot(), caName, "certs", commonName+".cert"))
 	require.NoError(t, err, "read client cert for %s", commonName)
@@ -672,7 +687,7 @@ func (o *Overlay) GetCaJwt(t *testing.T, caID string) string {
 
 // DeleteExtJwtSigner removes an ext-jwt-signer by name.
 func (o *Overlay) DeleteExtJwtSigner(name string) error {
-	if _, err := o.execZiti("edge", "delete", "ext-jwt-signer", name); err != nil {
+	if _, err := o.execZiti("edge delete ext-jwt-signer %s", name); err != nil {
 		return fmt.Errorf("delete ext-jwt-signer %s: %w", name, err)
 	}
 	return nil
@@ -680,7 +695,7 @@ func (o *Overlay) DeleteExtJwtSigner(name string) error {
 
 // DeleteAuthPolicy removes an auth policy by name.
 func (o *Overlay) DeleteAuthPolicy(name string) error {
-	if _, err := o.execZiti("edge", "delete", "auth-policy", name); err != nil {
+	if _, err := o.execZiti("edge delete auth-policy %s", name); err != nil {
 		return fmt.Errorf("delete auth policy %s: %w", name, err)
 	}
 	return nil
@@ -696,7 +711,7 @@ func (o *Overlay) CreateHostConfigV1(name, protocol, forwardAddr string, forward
 	if err != nil {
 		return err
 	}
-	if _, err := o.execZiti("edge", "create", "config", name, "host.v1", string(body)); err != nil {
+	if _, err := o.execZiti("edge create config %s host.v1 %s", name, string(body)); err != nil {
 		return fmt.Errorf("create host config %s: %w", name, err)
 	}
 	return nil
@@ -722,7 +737,7 @@ func (o *Overlay) CreateInterceptConfigV1(name string, protocols, addresses []st
 	if err != nil {
 		return err
 	}
-	if _, err := o.execZiti("edge", "create", "config", name, "intercept.v1", string(body)); err != nil {
+	if _, err := o.execZiti("edge create config %s intercept.v1 %s", name, string(body)); err != nil {
 		return fmt.Errorf("create intercept config %s: %w", name, err)
 	}
 	return nil
@@ -730,8 +745,8 @@ func (o *Overlay) CreateInterceptConfigV1(name string, protocols, addresses []st
 
 // CreateService creates a service that references the given configs.
 func (o *Overlay) CreateService(name string, configs []string) error {
-	args := []string{"edge", "create", "service", name, "--configs", strings.Join(configs, ",")}
-	if _, err := o.execZiti(args...); err != nil {
+	configsCSV := strings.Join(configs, ",")
+	if _, err := o.execZiti("edge create service %s --configs %s", name, configsCSV); err != nil {
 		return fmt.Errorf("create service %s: %w", name, err)
 	}
 	return nil
@@ -739,11 +754,8 @@ func (o *Overlay) CreateService(name string, configs []string) error {
 
 // CreateBindServicePolicy creates a Bind service policy granting identityName access to serviceName.
 func (o *Overlay) CreateBindServicePolicy(name, identityName, serviceName string) error {
-	if _, err := o.execZiti("edge", "create", "service-policy", name, "Bind",
-		"--identity-roles", "@"+identityName,
-		"--service-roles", "@"+serviceName,
-		"--semantic", "AnyOf",
-	); err != nil {
+	if _, err := o.execZiti("edge create service-policy %s Bind --identity-roles %s --service-roles %s --semantic AnyOf",
+		name, "@"+identityName, "@"+serviceName); err != nil {
 		return fmt.Errorf("create bind policy %s: %w", name, err)
 	}
 	return nil
@@ -751,11 +763,8 @@ func (o *Overlay) CreateBindServicePolicy(name, identityName, serviceName string
 
 // CreateDialServicePolicy creates a Dial service policy granting identityName access to serviceName.
 func (o *Overlay) CreateDialServicePolicy(name, identityName, serviceName string) error {
-	if _, err := o.execZiti("edge", "create", "service-policy", name, "Dial",
-		"--identity-roles", "@"+identityName,
-		"--service-roles", "@"+serviceName,
-		"--semantic", "AnyOf",
-	); err != nil {
+	if _, err := o.execZiti("edge create service-policy %s Dial --identity-roles %s --service-roles %s --semantic AnyOf",
+		name, "@"+identityName, "@"+serviceName); err != nil {
 		return fmt.Errorf("create dial policy %s: %w", name, err)
 	}
 	return nil
@@ -763,7 +772,7 @@ func (o *Overlay) CreateDialServicePolicy(name, identityName, serviceName string
 
 // DeleteServicePolicy deletes a service policy by name.
 func (o *Overlay) DeleteServicePolicy(name string) error {
-	if _, err := o.execZiti("edge", "delete", "service-policy", name); err != nil {
+	if _, err := o.execZiti("edge delete service-policy %s", name); err != nil {
 		return fmt.Errorf("delete service policy %s: %w", name, err)
 	}
 	return nil
@@ -771,7 +780,7 @@ func (o *Overlay) DeleteServicePolicy(name string) error {
 
 // DeleteService deletes a service by name.
 func (o *Overlay) DeleteService(name string) error {
-	if _, err := o.execZiti("edge", "delete", "service", name); err != nil {
+	if _, err := o.execZiti("edge delete service %s", name); err != nil {
 		return fmt.Errorf("delete service %s: %w", name, err)
 	}
 	return nil
@@ -779,7 +788,7 @@ func (o *Overlay) DeleteService(name string) error {
 
 // DeleteConfig deletes a config by name.
 func (o *Overlay) DeleteConfig(name string) error {
-	if _, err := o.execZiti("edge", "delete", "config", name); err != nil {
+	if _, err := o.execZiti("edge delete config %s", name); err != nil {
 		return fmt.Errorf("delete config %s: %w", name, err)
 	}
 	return nil
@@ -805,8 +814,8 @@ func (o *Overlay) waitUntilReady() error {
 	attempts := 0
 	for {
 		attempts++
-		if _, err := o.execZiti("edge", "login", o.ControllerHostPort(),
-			"-u", o.ControllerUser, "-p", o.ControllerPassword, "--yes"); err == nil {
+		if _, err := o.execZiti("edge login %s -u %s -p %s --yes",
+			o.ControllerHostPort(), o.ControllerUser, o.ControllerPassword); err == nil {
 			log.Printf("overlay: admin login OK after %d attempt(s)", attempts)
 			return nil
 		} else {
@@ -838,20 +847,40 @@ func (o *Overlay) waitForControllerPort() error {
 	}
 }
 
-func (o *Overlay) execZiti(args ...string) ([]byte, error) {
-	cmd := exec.Command(o.ZitiBin, args...)
-	cmd.Env = append(os.Environ(),
-		"ZITI_CONFIG_DIR="+filepath.Join(o.Home, "cli-config"),
-	)
-	var stdout, stderr syncBuffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if o.ShowZitiCliCommands {
-		fmt.Println("COMMAND: " + cmd.String())
+// execZiti runs the ziti CLI with the command written as one readable line.
+// The line is tokenized on spaces before values are substituted: each literal
+// "%s" token becomes exactly one argument, so a value keeps its spaces and
+// quotes intact.
+func (o *Overlay) execZiti(cmd string, args ...string) ([]byte, error) {
+	tokens := strings.Fields(cmd)
+	argv := make([]string, 0, len(tokens))
+	i := 0
+	for _, tok := range tokens {
+		if tok != "%s" {
+			argv = append(argv, tok)
+			continue
+		}
+		if i >= len(args) {
+			return nil, fmt.Errorf("execZiti: %d args for more placeholders in %q", len(args), cmd)
+		}
+		argv = append(argv, args[i])
+		i++
 	}
-	if err := cmd.Run(); err != nil {
+	if i != len(args) {
+		return nil, fmt.Errorf("execZiti: %d args for %d placeholders in %q", len(args), i, cmd)
+	}
+
+	ziti := exec.Command(o.ZitiBin, argv...)
+	ziti.Env = append(os.Environ(), "ZITI_CONFIG_DIR="+filepath.Join(o.Home, "cli-config"))
+	var stdout, stderr syncBuffer
+	ziti.Stdout = &stdout
+	ziti.Stderr = &stderr
+	if o.ShowZitiCliCommands {
+		fmt.Println("COMMAND: " + ziti.String())
+	}
+	if err := ziti.Run(); err != nil {
 		return nil, fmt.Errorf("%s %v: %w\nstdout: %s\nstderr: %s",
-			o.ZitiBin, args, err, stdout.String(), stderr.String())
+			o.ZitiBin, argv, err, stdout.String(), stderr.String())
 	}
 	if o.ShowZitiCliCommands {
 		fmt.Println("COMMAND RESULT: \n" + stdout.String())
@@ -869,7 +898,7 @@ func (o *Overlay) PurgeIdentities() error {
 // named from the token's sub claim (not test_*)
 func (o *Overlay) PurgeIdentitiesByExternalId(fragment string) error {
 	filter := fmt.Sprintf(`externalId contains "%s" limit none`, fragment)
-	if _, err := o.execZiti("edge", "delete", "identities", "where", filter); err != nil {
+	if _, err := o.execZiti("edge delete identities where %s", filter); err != nil {
 		return fmt.Errorf("delete identities where %s: %w", filter, err)
 	}
 	return nil
@@ -910,7 +939,7 @@ func (o *Overlay) PurgeConfigs() error {
 // Test* names from t.Name().
 func (o *Overlay) deleteWhere(entity string) error {
 	filter := `name contains "test_" or name contains "Test" limit none`
-	if _, err := o.execZiti("edge", "delete", entity, "where", filter); err != nil {
+	if _, err := o.execZiti("edge delete %s where %s", entity, filter); err != nil {
 		return fmt.Errorf("delete %s where %s: %w", entity, filter, err)
 	}
 	return nil
@@ -928,7 +957,7 @@ func (o *Overlay) WaitForClusterLeader() error {
 	attempts := 0
 	for {
 		attempts++
-		out, err := o.execZiti("ops", "cluster", "list", "-j")
+		out, err := o.execZiti("ops cluster list -j")
 		if err == nil {
 			var resp struct {
 				Data []struct {
@@ -959,7 +988,7 @@ func (o *Overlay) WaitForDataModelConsensus() {
 			time.Sleep(100 * time.Millisecond)
 		}
 
-		out, err := o.execZiti("fabric", "inspect", "data-model-index")
+		out, err := o.execZiti("fabric inspect data-model-index")
 		if err != nil {
 			log.Printf("overlay: inspect data-model-index failed, retrying: %v", err)
 			continue

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -660,9 +660,12 @@ func (o *Overlay) CreateOttCaEnrollment(t *testing.T, identityName, caName strin
 
 // CreateClientCert signs a client cert with the given common name by the named
 // CA and returns the cert and key PEM contents (the AddIdentity command carries
-// content, not file paths).
-func (o *Overlay) CreateClientCert(t *testing.T, caName, commonName string) (certPEM, keyPEM string) {
-	_, err := o.execZiti("pki create client --pki-root %s --ca-name %s --client-name %s --client-file %s", o.pkiRoot(), caName, commonName, commonName)
+// content, not file paths). createClientFlags are appended to the
+// `pki create client` command.
+func (o *Overlay) CreateClientCert(t *testing.T, caName, commonName string, createClientFlags ...string) (certPEM, keyPEM string) {
+	cmd := "pki create client --pki-root %s --ca-name %s --client-name %s --client-file %s" + strings.Repeat(" %s", len(createClientFlags))
+	args := append([]string{o.pkiRoot(), caName, commonName, commonName}, createClientFlags...)
+	_, err := o.execZiti(cmd, args...)
 	require.NoError(t, err, "pki create client %s for ca %s", commonName, caName)
 	cert, err := os.ReadFile(filepath.Join(o.pkiRoot(), caName, "certs", commonName+".cert"))
 	require.NoError(t, err, "read client cert for %s", commonName)

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -18,6 +18,7 @@ package testutil
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -564,6 +565,90 @@ func (o *Overlay) CreateIdentityWithExternalId(t *testing.T, name, externalID, a
 	t.Logf("controller identity %q created", name)
 }
 
+// CAResult identifies a registered 3rd-party CA.
+type CAResult struct {
+	ID   string
+	Name string
+}
+
+// caPkiPath is the on-disk PKI directory for a CA created by Create3rdPartyCA.
+func (o *Overlay) caPkiPath(name string) string {
+	return filepath.Join(o.Home, "third-party-pki", name)
+}
+
+// Create3rdPartyCA mints a root CA, registers it on the controller for
+// auth+ottca+autoca enrollment, and verifies it. Auto-provisioned identities
+// are named with the controller default format, [caName]-[commonName].
+func (o *Overlay) Create3rdPartyCA(t *testing.T, name string) CAResult {
+	t.Logf("creating 3rd-party CA %q", name)
+	// ziti pki refuses to overwrite PKI left by a previous run
+	require.NoError(t, os.RemoveAll(o.caPkiPath(name)), "clear stale pki for %s", name)
+	_, err := o.execZiti("pki", "create", "ca", "--pki-root", filepath.Join(o.Home, "third-party-pki"), "--ca-file", name, "--ca-name", name)
+	require.NoError(t, err, "pki create ca %s", name)
+
+	caCert := filepath.Join(o.caPkiPath(name), "certs", name+".cert")
+	out, err := o.execZiti("edge", "create", "ca", name, caCert, "--auth", "--ottca", "--autoca")
+	require.NoError(t, err, "create ca %s", name)
+	id := string(bytes.TrimSpace(out))
+
+	// --cacert/--cakey makes the CLI fetch the verificationToken and mint the CN=token cert itself
+	_, err = o.execZiti("edge", "verify", "ca", name, "--cacert", caCert, "--cakey", filepath.Join(o.caPkiPath(name), "keys", name+".key"))
+	require.NoError(t, err, "verify ca %s", name)
+	t.Logf("3rd-party CA %q registered and verified with id=%s", name, id)
+	return CAResult{ID: id, Name: name}
+}
+
+// CreateClientCert signs a client cert with the given common name by the named
+// CA and returns the cert and key PEM contents (the AddIdentity command carries
+// content, not file paths).
+func (o *Overlay) CreateClientCert(t *testing.T, caName, commonName string) (certPEM, keyPEM string) {
+	_, err := o.execZiti("pki", "create", "client", "--pki-root", filepath.Join(o.Home, "third-party-pki"), "--ca-name", caName, "--client-name", commonName, "--client-file", commonName)
+	require.NoError(t, err, "pki create client %s for ca %s", commonName, caName)
+	cert, err := os.ReadFile(filepath.Join(o.caPkiPath(caName), "certs", commonName+".cert"))
+	require.NoError(t, err, "read client cert for %s", commonName)
+	key, err := os.ReadFile(filepath.Join(o.caPkiPath(caName), "keys", commonName+".key"))
+	require.NoError(t, err, "read client key for %s", commonName)
+	return string(cert), string(key)
+}
+
+// GetCaJwt fetches the CA enrollment JWT from the management API, authenticated
+// with the session the CLI cached at login. No ziti CLI verb exposes it.
+func (o *Overlay) GetCaJwt(t *testing.T, caID string) string {
+	cliConfig, err := os.ReadFile(filepath.Join(o.Home, "cli-config", "ziti-cli.json"))
+	require.NoError(t, err, "read cached cli session")
+	var cfg struct {
+		EdgeIdentities map[string]struct {
+			Token      string `json:"token"`
+			ApiSession struct {
+				OidcAccessToken string `json:"oidcAccessToken"`
+			} `json:"apiSession"`
+		} `json:"edgeIdentities"`
+		Default string `json:"default"`
+	}
+	require.NoError(t, json.Unmarshal(cliConfig, &cfg), "parse cached cli session")
+	session := cfg.EdgeIdentities[cfg.Default]
+
+	req, err := http.NewRequest(http.MethodGet, o.ControllerHostPort()+"/edge/management/v1/cas/"+caID+"/jwt", nil)
+	require.NoError(t, err, "build CA jwt request")
+	if session.ApiSession.OidcAccessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+session.ApiSession.OidcAccessToken)
+	} else {
+		req.Header.Set("zt-session", session.Token)
+	}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		// the quickstart CA is not OS-trusted
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err, "GET %s", req.URL)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "read CA jwt response")
+	require.Equal(t, http.StatusOK, resp.StatusCode, "GET %s: %s", req.URL, body)
+	return strings.TrimSpace(string(body))
+}
+
 // DeleteExtJwtSigner removes an ext-jwt-signer by name.
 func (o *Overlay) DeleteExtJwtSigner(name string) error {
 	if _, err := o.execZiti("edge", "delete", "ext-jwt-signer", name); err != nil {
@@ -767,6 +852,11 @@ func (o *Overlay) PurgeIdentitiesByExternalId(fragment string) error {
 		return fmt.Errorf("delete identities where %s: %w", filter, err)
 	}
 	return nil
+}
+
+// PurgeCAs deletes every certificate authority carrying a test name.
+func (o *Overlay) PurgeCAs() error {
+	return o.deleteWhere("cas")
 }
 
 // PurgeAuthPolicies deletes every auth policy carrying a test name.

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -565,12 +565,6 @@ func (o *Overlay) CreateIdentityWithExternalId(t *testing.T, name, externalID, a
 	t.Logf("controller identity %q created", name)
 }
 
-// CAResult identifies a registered third-party CA.
-type CAResult struct {
-	ID   string
-	Name string
-}
-
 // pkiRoot is the on-disk root under which all test CAs are created; the ziti
 // pki CLI lays out each CA at <root>/<ca-name>.
 func (o *Overlay) pkiRoot() string {
@@ -587,9 +581,10 @@ func (o *Overlay) CreateLocalPkiCA(t *testing.T, name string) {
 }
 
 // CreateThirdPartyCA creates a root CA, registers it on the controller for
-// auth+ottca+autoca enrollment, and verifies it. Identities created by autoca
-// enrollment are named with the controller default format, [caName]-[commonName].
-func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) CAResult {
+// auth+ottca+autoca enrollment, verifies it, and returns its assigned ID.
+// Identities created by autoca enrollment are named with the controller
+// default format, [caName]-[commonName].
+func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) string {
 	t.Logf("creating third-party CA %q", name)
 	o.CreateLocalPkiCA(t, name)
 
@@ -602,7 +597,7 @@ func (o *Overlay) CreateThirdPartyCA(t *testing.T, name string) CAResult {
 	_, err = o.execZiti("edge", "verify", "ca", name, "--cacert", caCert, "--cakey", filepath.Join(o.pkiRoot(), name, "keys", name+".key"))
 	require.NoError(t, err, "verify ca %s", name)
 	t.Logf("third-party CA %q registered and verified with id=%s", name, id)
-	return CAResult{ID: id, Name: name}
+	return id
 }
 
 // CreateOttCaEnrollment adds an ottca enrollment binding the identity to the

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -584,11 +584,18 @@ func (o *Overlay) pkiRoot() string {
 	return filepath.Join(o.Home, "third-party-pki")
 }
 
+// PurgeLocalPki removes the on-disk test PKI. Runs once in doSetup because
+// ziti pki refuses to overwrite PKI left by a previous run.
+func (o *Overlay) PurgeLocalPki() error {
+	if err := os.RemoveAll(o.pkiRoot()); err != nil {
+		return fmt.Errorf("remove test pki root %s: %w", o.pkiRoot(), err)
+	}
+	return nil
+}
+
 // CreateLocalPkiCA creates a root CA on disk without registering it on the
 // controller.
 func (o *Overlay) CreateLocalPkiCA(t *testing.T, name string) {
-	// ziti pki refuses to overwrite PKI left by a previous run
-	require.NoError(t, os.RemoveAll(filepath.Join(o.pkiRoot(), name)), "clear stale pki for %s", name)
 	_, err := o.execZiti("pki create ca --pki-root %s --ca-file %s --ca-name %s", o.pkiRoot(), name, name)
 	require.NoError(t, err, "pki create ca %s", name)
 }

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -45,15 +45,8 @@ func autocaEnrollCreatesIdentity(t *testing.T) {
 
 		// the controller names the auto-provisioned identity [caName]-[commonName]
 		idName := caName + "-" + commonName
-		identityData := testutil.NewCaIdentityData(idName, caJwt, cert, key)
-		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertSuccess()
+		added := testutil.EnrollCaJwt(t, state.zetClient, idName, caJwt, cert, key)
 
-		added := state.zetClient.WaitForIdentityEvent(t, "added", idName)
-		require.True(t, added.Id.Active)
-		state.zetClient.WaitForControllerEvent(t, "connected", idName)
-
-		testutil.AssertValidJwtEnrolledIdentityFile(t, added.Id.Identifier)
 		idFile := testutil.ReadIdentityFile(t, added.Id.Identifier)
 		require.Equal(t, cert, idFile.ID.Cert)
 		require.Equal(t, key, idFile.ID.Key)
@@ -68,15 +61,7 @@ func ottcaEnrollsPreCreatedIdentity(t *testing.T) {
 		ottcaJwt := state.overlay.CreateOttCaEnrollment(t, idName, caName)
 		cert, key := state.overlay.CreateClientCert(t, caName, idName)
 
-		identityData := testutil.NewCaIdentityData(idName, ottcaJwt, cert, key)
-		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertSuccess()
-
-		added := state.zetClient.WaitForIdentityEvent(t, "added", idName)
-		require.True(t, added.Id.Active)
-		state.zetClient.WaitForControllerEvent(t, "connected", idName)
-
-		testutil.AssertValidJwtEnrolledIdentityFile(t, added.Id.Identifier)
+		testutil.EnrollCaJwt(t, state.zetClient, idName, ottcaJwt, cert, key)
 	})
 }
 
@@ -89,12 +74,9 @@ func rejectsAddingSameIdentityTwice(t *testing.T) {
 		caJwt := state.overlay.GetCaJwt(t, caID)
 
 		idName := caName + "-" + commonName
-		identityData := testutil.NewCaIdentityData(idName, caJwt, cert, key)
-		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertSuccess()
-		state.zetClient.WaitForIdentityEvent(t, "added", idName)
-		state.zetClient.WaitForControllerEvent(t, "connected", idName)
+		testutil.EnrollCaJwt(t, state.zetClient, idName, caJwt, cert, key)
 
+		identityData := testutil.NewCaIdentityData(idName, caJwt, cert, key)
 		dupResp := state.zetClient.AddIdentity(t, identityData)
 		dupResp.AssertFail(500, "identity exists with the same name")
 	})
@@ -109,11 +91,7 @@ func rejectsReenrollingSameCert(t *testing.T) {
 		caJwt := state.overlay.GetCaJwt(t, caID)
 
 		idName := caName + "-" + commonName
-		identityData := testutil.NewCaIdentityData(idName, caJwt, cert, key)
-		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertSuccess()
-		state.zetClient.WaitForIdentityEvent(t, "added", idName)
-		state.zetClient.WaitForControllerEvent(t, "connected", idName)
+		testutil.EnrollCaJwt(t, state.zetClient, idName, caJwt, cert, key)
 
 		renamedData := testutil.NewCaIdentityData(idName+"_renamed", caJwt, cert, key)
 		dupResp := state.zetClient.AddIdentity(t, renamedData)

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -67,6 +67,8 @@ func ottcaEnrollsPreCreatedIdentity(t *testing.T) {
 		added := state.zetClient.WaitForIdentityEvent(t, "added", idName)
 		require.True(t, added.Id.Active)
 		state.zetClient.WaitForControllerEvent(t, "connected", idName)
+
+		testutil.AssertValidJwtEnrolledIdentityFile(t, added.Id.Identifier)
 	})
 }
 

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -18,7 +18,6 @@ package integration_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/openziti/ziti-tunnel-sdk-c/tests/integration/testutil"
 	"github.com/stretchr/testify/require"
@@ -26,11 +25,12 @@ import (
 
 func TestThirdPartyCa(t *testing.T) {
 	t.Run("enrollWithCaSignedCert", enrollWithCaSignedCert)
+	t.Run("enrollOttcaWithPreCreatedIdentity", enrollOttcaWithPreCreatedIdentity)
 	t.Run("rejectsCertFromUnregisteredCa", rejectsCertFromUnregisteredCa)
 }
 
 func enrollWithCaSignedCert(t *testing.T) {
-	testutil.RunWithTimeoutOf(t, 15*time.Second, func(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
 		ca := state.overlay.Create3rdPartyCA(t, "test_tpca")
 		commonName := "test_tpca_user1"
 		cert, key := state.overlay.CreateClientCert(t, ca.Name, commonName)
@@ -53,8 +53,25 @@ func enrollWithCaSignedCert(t *testing.T) {
 	})
 }
 
+func enrollOttcaWithPreCreatedIdentity(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		ca := state.overlay.Create3rdPartyCA(t, "test_tpca_ottca")
+		idName := "test_tpca_ottca_user1"
+		ottcaJwt := state.overlay.CreateOttCaEnrollment(t, idName, ca.Name)
+		cert, key := state.overlay.CreateClientCert(t, ca.Name, idName)
+
+		identityData := testutil.NewCaIdentityData(idName, ottcaJwt, cert, key)
+		addResp := state.zetClient.AddIdentity(t, identityData)
+		addResp.AssertSuccess()
+
+		added := state.zetClient.WaitForIdentityEvent(t, "added", idName)
+		require.True(t, added.Id.Active)
+		state.zetClient.WaitForControllerEvent(t, "connected", idName)
+	})
+}
+
 func rejectsCertFromUnregisteredCa(t *testing.T) {
-	testutil.RunWithTimeoutOf(t, 15*time.Second, func(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
 		ca := state.overlay.Create3rdPartyCA(t, "test_tpca_neg")
 		caJwt := state.overlay.GetCaJwt(t, ca.ID)
 		state.overlay.CreateLocalPkiCA(t, "test_tpca_unregistered")

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -27,6 +27,7 @@ func TestThirdPartyCa(t *testing.T) {
 	t.Run("autocaEnrollCreatesIdentity", autocaEnrollCreatesIdentity)
 	t.Run("ottcaEnrollsPreCreatedIdentity", ottcaEnrollsPreCreatedIdentity)
 	t.Run("rejectsCertFromUnregisteredCa", rejectsCertFromUnregisteredCa)
+	t.Run("rejectsAddingSameIdentityTwice", rejectsAddingSameIdentityTwice)
 }
 
 func autocaEnrollCreatesIdentity(t *testing.T) {
@@ -71,6 +72,26 @@ func ottcaEnrollsPreCreatedIdentity(t *testing.T) {
 		state.zetClient.WaitForControllerEvent(t, "connected", idName)
 
 		testutil.AssertValidJwtEnrolledIdentityFile(t, added.Id.Identifier)
+	})
+}
+
+func rejectsAddingSameIdentityTwice(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		caName := "test_tpca_dup"
+		caID := state.overlay.CreateThirdPartyCA(t, caName)
+		commonName := "test_tpca_dup_user1"
+		cert, key := state.overlay.CreateClientCert(t, caName, commonName)
+		caJwt := state.overlay.GetCaJwt(t, caID)
+
+		idName := caName + "-" + commonName
+		identityData := testutil.NewCaIdentityData(idName, caJwt, cert, key)
+		addResp := state.zetClient.AddIdentity(t, identityData)
+		addResp.AssertSuccess()
+		state.zetClient.WaitForIdentityEvent(t, "added", idName)
+		state.zetClient.WaitForControllerEvent(t, "connected", idName)
+
+		dupResp := state.zetClient.AddIdentity(t, identityData)
+		dupResp.AssertFail(500, "identity exists with the same name")
 	})
 }
 

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/ziti-tunnel-sdk-c/tests/integration/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThirdPartyCa(t *testing.T) {
+	t.Run("enrollWithCaSignedCert", enrollWithCaSignedCert)
+}
+
+func enrollWithCaSignedCert(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, 15*time.Second, func(t *testing.T) {
+		ca := state.overlay.Create3rdPartyCA(t, "test_tpca")
+		commonName := "test_tpca_user1"
+		cert, key := state.overlay.CreateClientCert(t, ca.Name, commonName)
+		caJwt := state.overlay.GetCaJwt(t, ca.ID)
+
+		// the controller names the auto-provisioned identity [caName]-[commonName]
+		idName := ca.Name + "-" + commonName
+		identityData := testutil.NewCaIdentityData(idName, caJwt, cert, key)
+		addResp := state.zetClient.AddIdentity(t, identityData)
+		addResp.AssertSuccess()
+
+		added := state.zetClient.WaitForIdentityEvent(t, "added", idName)
+		require.True(t, added.Id.Active)
+		state.zetClient.WaitForControllerEvent(t, "connected", idName)
+
+		testutil.AssertValidJwtEnrolledIdentityFile(t, added.Id.Identifier)
+		idFile := testutil.ReadIdentityFile(t, added.Id.Identifier)
+		require.Equal(t, cert, idFile.ID.Cert)
+		require.Equal(t, key, idFile.ID.Key)
+	})
+}

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -18,10 +18,14 @@ package integration_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/openziti/ziti-tunnel-sdk-c/tests/integration/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+// each subtest creates, registers, and verifies its own CA, which can fail the default timeout on slower systems
+const thirdPartyCaTestTimeout = 10 * time.Second
 
 func TestThirdPartyCa(t *testing.T) {
 	t.Run("autocaEnrollCreatesIdentity", autocaEnrollCreatesIdentity)
@@ -32,7 +36,7 @@ func TestThirdPartyCa(t *testing.T) {
 }
 
 func autocaEnrollCreatesIdentity(t *testing.T) {
-	testutil.RunWithTimeout(t, func(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, thirdPartyCaTestTimeout, func(t *testing.T) {
 		caName := "test_tpca"
 		caID := state.overlay.CreateThirdPartyCA(t, caName)
 		commonName := "test_tpca_user1"
@@ -57,7 +61,7 @@ func autocaEnrollCreatesIdentity(t *testing.T) {
 }
 
 func ottcaEnrollsPreCreatedIdentity(t *testing.T) {
-	testutil.RunWithTimeout(t, func(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, thirdPartyCaTestTimeout, func(t *testing.T) {
 		caName := "test_tpca_ottca"
 		state.overlay.CreateThirdPartyCA(t, caName)
 		idName := "test_tpca_ottca_user1"
@@ -77,7 +81,7 @@ func ottcaEnrollsPreCreatedIdentity(t *testing.T) {
 }
 
 func rejectsAddingSameIdentityTwice(t *testing.T) {
-	testutil.RunWithTimeout(t, func(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, thirdPartyCaTestTimeout, func(t *testing.T) {
 		caName := "test_tpca_dup"
 		caID := state.overlay.CreateThirdPartyCA(t, caName)
 		commonName := "test_tpca_dup_user1"
@@ -97,7 +101,7 @@ func rejectsAddingSameIdentityTwice(t *testing.T) {
 }
 
 func rejectsReenrollingSameCert(t *testing.T) {
-	testutil.RunWithTimeout(t, func(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, thirdPartyCaTestTimeout, func(t *testing.T) {
 		caName := "test_tpca_reuse"
 		caID := state.overlay.CreateThirdPartyCA(t, caName)
 		commonName := "test_tpca_reuse_user1"
@@ -118,7 +122,7 @@ func rejectsReenrollingSameCert(t *testing.T) {
 }
 
 func rejectsCertFromUnregisteredCa(t *testing.T) {
-	testutil.RunWithTimeout(t, func(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, thirdPartyCaTestTimeout, func(t *testing.T) {
 		caID := state.overlay.CreateThirdPartyCA(t, "test_tpca_neg")
 		caJwt := state.overlay.GetCaJwt(t, caID)
 		state.overlay.CreateLocalPkiCA(t, "test_tpca_unregistered")

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -28,6 +28,7 @@ func TestThirdPartyCa(t *testing.T) {
 	t.Run("ottcaEnrollsPreCreatedIdentity", ottcaEnrollsPreCreatedIdentity)
 	t.Run("rejectsCertFromUnregisteredCa", rejectsCertFromUnregisteredCa)
 	t.Run("rejectsAddingSameIdentityTwice", rejectsAddingSameIdentityTwice)
+	t.Run("rejectsReenrollingSameCert", rejectsReenrollingSameCert)
 }
 
 func autocaEnrollCreatesIdentity(t *testing.T) {
@@ -92,6 +93,27 @@ func rejectsAddingSameIdentityTwice(t *testing.T) {
 
 		dupResp := state.zetClient.AddIdentity(t, identityData)
 		dupResp.AssertFail(500, "identity exists with the same name")
+	})
+}
+
+func rejectsReenrollingSameCert(t *testing.T) {
+	testutil.RunWithTimeout(t, func(t *testing.T) {
+		caName := "test_tpca_reuse"
+		caID := state.overlay.CreateThirdPartyCA(t, caName)
+		commonName := "test_tpca_reuse_user1"
+		cert, key := state.overlay.CreateClientCert(t, caName, commonName)
+		caJwt := state.overlay.GetCaJwt(t, caID)
+
+		idName := caName + "-" + commonName
+		identityData := testutil.NewCaIdentityData(idName, caJwt, cert, key)
+		addResp := state.zetClient.AddIdentity(t, identityData)
+		addResp.AssertSuccess()
+		state.zetClient.WaitForIdentityEvent(t, "added", idName)
+		state.zetClient.WaitForControllerEvent(t, "connected", idName)
+
+		renamedData := testutil.NewCaIdentityData(idName+"_renamed", caJwt, cert, key)
+		dupResp := state.zetClient.AddIdentity(t, renamedData)
+		dupResp.AssertFail(500, "certificate already in use")
 	})
 }
 

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -33,6 +33,7 @@ func TestThirdPartyCa(t *testing.T) {
 	t.Run("rejectsCertFromUnregisteredCa", rejectsCertFromUnregisteredCa)
 	t.Run("rejectsAddingSameIdentityTwice", rejectsAddingSameIdentityTwice)
 	t.Run("rejectsReenrollingSameCert", rejectsReenrollingSameCert)
+	t.Run("rejectsCertMissingExternalId", rejectsCertMissingExternalId)
 }
 
 func autocaEnrollCreatesIdentity(t *testing.T) {
@@ -96,6 +97,21 @@ func rejectsReenrollingSameCert(t *testing.T) {
 		renamedData := testutil.NewCaIdentityData(idName+"_renamed", caJwt, cert, key)
 		dupResp := state.zetClient.AddIdentity(t, renamedData)
 		dupResp.AssertFail(500, "certificate already in use")
+	})
+}
+
+func rejectsCertMissingExternalId(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, thirdPartyCaTestTimeout, func(t *testing.T) {
+		caName := "test_tpca_extid"
+		// the claim location is a SAN URI, which CreateClientCert certs never carry
+		caID := state.overlay.CreateThirdPartyCA(t, caName, "--location", "SAN_URI", "--matcher", "ALL", "--parser", "NONE")
+		commonName := "test_tpca_extid_user1"
+		cert, key := state.overlay.CreateClientCert(t, caName, commonName)
+		caJwt := state.overlay.GetCaJwt(t, caID)
+
+		identityData := testutil.NewCaIdentityData(commonName, caJwt, cert, key)
+		addResp := state.zetClient.AddIdentity(t, identityData)
+		addResp.AssertFail(500, "expected to contain an externalId")
 	})
 }
 

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -34,6 +34,7 @@ func TestThirdPartyCa(t *testing.T) {
 	t.Run("rejectsAddingSameIdentityTwice", rejectsAddingSameIdentityTwice)
 	t.Run("rejectsReenrollingSameCert", rejectsReenrollingSameCert)
 	t.Run("rejectsCertMissingExternalId", rejectsCertMissingExternalId)
+	t.Run("rejectsExpiredCert", rejectsExpiredCert)
 }
 
 func autocaEnrollCreatesIdentity(t *testing.T) {
@@ -97,6 +98,7 @@ func rejectsReenrollingSameCert(t *testing.T) {
 		renamedData := testutil.NewCaIdentityData(idName+"_renamed", caJwt, cert, key)
 		dupResp := state.zetClient.AddIdentity(t, renamedData)
 		dupResp.AssertFail(500, "certificate already in use")
+		testutil.AssertNoIdentityFile(t, state.zetClient, idName+"_renamed")
 	})
 }
 
@@ -112,6 +114,22 @@ func rejectsCertMissingExternalId(t *testing.T) {
 		identityData := testutil.NewCaIdentityData(commonName, caJwt, cert, key)
 		addResp := state.zetClient.AddIdentity(t, identityData)
 		addResp.AssertFail(500, "expected to contain an externalId")
+		testutil.AssertNoIdentityFile(t, state.zetClient, commonName)
+	})
+}
+
+func rejectsExpiredCert(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, thirdPartyCaTestTimeout, func(t *testing.T) {
+		caName := "test_tpca_expired"
+		caID := state.overlay.CreateThirdPartyCA(t, caName)
+		commonName := "test_tpca_expired_user1"
+		cert, key := state.overlay.CreateClientCert(t, caName, commonName, "--expire-limit=-1")
+		caJwt := state.overlay.GetCaJwt(t, caID)
+
+		identityData := testutil.NewCaIdentityData(commonName, caJwt, cert, key)
+		addResp := state.zetClient.AddIdentity(t, identityData)
+		addResp.AssertFail(500, "key/cert are invalid")
+		testutil.AssertNoIdentityFile(t, state.zetClient, commonName)
 	})
 }
 
@@ -125,5 +143,6 @@ func rejectsCertFromUnregisteredCa(t *testing.T) {
 		identityData := testutil.NewCaIdentityData("test_tpca_unregistered_user1", caJwt, cert, key)
 		addResp := state.zetClient.AddIdentity(t, identityData)
 		addResp.AssertFail(500, "key/cert are invalid")
+		testutil.AssertNoIdentityFile(t, state.zetClient, "test_tpca_unregistered_user1")
 	})
 }

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestThirdPartyCa(t *testing.T) {
 	t.Run("enrollWithCaSignedCert", enrollWithCaSignedCert)
+	t.Run("rejectsCertFromUnregisteredCa", rejectsCertFromUnregisteredCa)
 }
 
 func enrollWithCaSignedCert(t *testing.T) {
@@ -49,5 +50,18 @@ func enrollWithCaSignedCert(t *testing.T) {
 		idFile := testutil.ReadIdentityFile(t, added.Id.Identifier)
 		require.Equal(t, cert, idFile.ID.Cert)
 		require.Equal(t, key, idFile.ID.Key)
+	})
+}
+
+func rejectsCertFromUnregisteredCa(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, 15*time.Second, func(t *testing.T) {
+		ca := state.overlay.Create3rdPartyCA(t, "test_tpca_neg")
+		caJwt := state.overlay.GetCaJwt(t, ca.ID)
+		state.overlay.CreateLocalPkiCA(t, "test_tpca_unregistered")
+		cert, key := state.overlay.CreateClientCert(t, "test_tpca_unregistered", "test_tpca_unregistered_user1")
+
+		identityData := testutil.NewCaIdentityData("test_tpca_unregistered_user1", caJwt, cert, key)
+		addResp := state.zetClient.AddIdentity(t, identityData)
+		addResp.AssertFail(500, "")
 	})
 }

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -31,13 +31,14 @@ func TestThirdPartyCa(t *testing.T) {
 
 func autocaEnrollCreatesIdentity(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		ca := state.overlay.CreateThirdPartyCA(t, "test_tpca")
+		caName := "test_tpca"
+		caID := state.overlay.CreateThirdPartyCA(t, caName)
 		commonName := "test_tpca_user1"
-		cert, key := state.overlay.CreateClientCert(t, ca.Name, commonName)
-		caJwt := state.overlay.GetCaJwt(t, ca.ID)
+		cert, key := state.overlay.CreateClientCert(t, caName, commonName)
+		caJwt := state.overlay.GetCaJwt(t, caID)
 
 		// the controller names the auto-provisioned identity [caName]-[commonName]
-		idName := ca.Name + "-" + commonName
+		idName := caName + "-" + commonName
 		identityData := testutil.NewCaIdentityData(idName, caJwt, cert, key)
 		addResp := state.zetClient.AddIdentity(t, identityData)
 		addResp.AssertSuccess()
@@ -55,10 +56,11 @@ func autocaEnrollCreatesIdentity(t *testing.T) {
 
 func ottcaEnrollsPreCreatedIdentity(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		ca := state.overlay.CreateThirdPartyCA(t, "test_tpca_ottca")
+		caName := "test_tpca_ottca"
+		state.overlay.CreateThirdPartyCA(t, caName)
 		idName := "test_tpca_ottca_user1"
-		ottcaJwt := state.overlay.CreateOttCaEnrollment(t, idName, ca.Name)
-		cert, key := state.overlay.CreateClientCert(t, ca.Name, idName)
+		ottcaJwt := state.overlay.CreateOttCaEnrollment(t, idName, caName)
+		cert, key := state.overlay.CreateClientCert(t, caName, idName)
 
 		identityData := testutil.NewCaIdentityData(idName, ottcaJwt, cert, key)
 		addResp := state.zetClient.AddIdentity(t, identityData)
@@ -74,8 +76,8 @@ func ottcaEnrollsPreCreatedIdentity(t *testing.T) {
 
 func rejectsCertFromUnregisteredCa(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		ca := state.overlay.CreateThirdPartyCA(t, "test_tpca_neg")
-		caJwt := state.overlay.GetCaJwt(t, ca.ID)
+		caID := state.overlay.CreateThirdPartyCA(t, "test_tpca_neg")
+		caJwt := state.overlay.GetCaJwt(t, caID)
 		state.overlay.CreateLocalPkiCA(t, "test_tpca_unregistered")
 		cert, key := state.overlay.CreateClientCert(t, "test_tpca_unregistered", "test_tpca_unregistered_user1")
 

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -79,6 +79,6 @@ func rejectsCertFromUnregisteredCa(t *testing.T) {
 
 		identityData := testutil.NewCaIdentityData("test_tpca_unregistered_user1", caJwt, cert, key)
 		addResp := state.zetClient.AddIdentity(t, identityData)
-		addResp.AssertFail(500, "")
+		addResp.AssertFail(500, "key/cert are invalid")
 	})
 }

--- a/tests/integration/third_party_ca_test.go
+++ b/tests/integration/third_party_ca_test.go
@@ -24,14 +24,14 @@ import (
 )
 
 func TestThirdPartyCa(t *testing.T) {
-	t.Run("enrollWithCaSignedCert", enrollWithCaSignedCert)
-	t.Run("enrollOttcaWithPreCreatedIdentity", enrollOttcaWithPreCreatedIdentity)
+	t.Run("autocaEnrollCreatesIdentity", autocaEnrollCreatesIdentity)
+	t.Run("ottcaEnrollsPreCreatedIdentity", ottcaEnrollsPreCreatedIdentity)
 	t.Run("rejectsCertFromUnregisteredCa", rejectsCertFromUnregisteredCa)
 }
 
-func enrollWithCaSignedCert(t *testing.T) {
+func autocaEnrollCreatesIdentity(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		ca := state.overlay.Create3rdPartyCA(t, "test_tpca")
+		ca := state.overlay.CreateThirdPartyCA(t, "test_tpca")
 		commonName := "test_tpca_user1"
 		cert, key := state.overlay.CreateClientCert(t, ca.Name, commonName)
 		caJwt := state.overlay.GetCaJwt(t, ca.ID)
@@ -53,9 +53,9 @@ func enrollWithCaSignedCert(t *testing.T) {
 	})
 }
 
-func enrollOttcaWithPreCreatedIdentity(t *testing.T) {
+func ottcaEnrollsPreCreatedIdentity(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		ca := state.overlay.Create3rdPartyCA(t, "test_tpca_ottca")
+		ca := state.overlay.CreateThirdPartyCA(t, "test_tpca_ottca")
 		idName := "test_tpca_ottca_user1"
 		ottcaJwt := state.overlay.CreateOttCaEnrollment(t, idName, ca.Name)
 		cert, key := state.overlay.CreateClientCert(t, ca.Name, idName)
@@ -72,7 +72,7 @@ func enrollOttcaWithPreCreatedIdentity(t *testing.T) {
 
 func rejectsCertFromUnregisteredCa(t *testing.T) {
 	testutil.RunWithTimeout(t, func(t *testing.T) {
-		ca := state.overlay.Create3rdPartyCA(t, "test_tpca_neg")
+		ca := state.overlay.CreateThirdPartyCA(t, "test_tpca_neg")
 		caJwt := state.overlay.GetCaJwt(t, ca.ID)
 		state.overlay.CreateLocalPkiCA(t, "test_tpca_unregistered")
 		cert, key := state.overlay.CreateClientCert(t, "test_tpca_unregistered", "test_tpca_unregistered_user1")


### PR DESCRIPTION
Adds integration tests for enrolling with client certificates signed by a registered 3rd-party CA: 
- Auto CA enrollment (no pre-created identity)
- OTT CA enrollment (a one-time token presented with a client certificate signed by the CA)
- Rejection of a certificate signed by an unregistered CA.