### PR TITLE
Fix Windows route API error reporting

### DIFF
--- a/programs/ziti-edge-tunnel/netif_driver/windows/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/windows/tun.c
@@ -511,7 +511,7 @@ static int tun_exclude_rt(netif_handle dev, uv_loop_t *loop, const char *dest) {
     MIB_IPFORWARD_ROW2 *route = calloc(1, sizeof(MIB_IPFORWARD_ROW2));
     route->DestinationPrefix.Prefix.si_family = AF_INET;
     parse_route(&route->DestinationPrefix, dest);
-    int rc = GetIpForwardEntry2(route);
+    DWORD rc = GetIpForwardEntry2(route);
     if (rc == NO_ERROR) {
         ZITI_LOG(DEBUG, "route to %s found", dest);
         DeleteIpForwardEntry2(route);
@@ -527,10 +527,14 @@ static int tun_exclude_rt(netif_handle dev, uv_loop_t *loop, const char *dest) {
     rc = CreateIpForwardEntry2(route);
     if (rc != NO_ERROR) {
         char err[256];
-        FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(),
-                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                      err, sizeof(err), NULL);
-        ZITI_LOG(WARN, "failed to create exclusion route: %d(%s)", rc, err);
+        DWORD len = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, rc,
+                                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                                  err, sizeof(err), NULL);
+        if (len > 0) {
+            ZITI_LOG(WARN, "failed to create exclusion route: %lu(%s)", (unsigned long)rc, err);
+        } else {
+            ZITI_LOG(WARN, "failed to create exclusion route: %lu", (unsigned long)rc);
+        }
     }
     model_map_set(&dev->excluded_routes, dest, route);
     return 0;
@@ -543,13 +547,17 @@ void refresh_routes(uv_timer_t *timer) {
     MIB_IPFORWARD_ROW2 *route;
     MODEL_MAP_FOREACH(dest, route, &tun->excluded_routes) {
         ZITI_LOG(DEBUG, "refreshing route to %s", dest);
-        int rc = SetIpForwardEntry2(route);
+        DWORD rc = SetIpForwardEntry2(route);
         if (rc != NO_ERROR) {
-        char err[256];
-        FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(),
-                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                      err, sizeof(err), NULL);
-            ZITI_LOG(WARN, "failed to create exclusion route[%s]: %d(%s)", dest, rc, err);
+            char err[256];
+            DWORD len = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, rc,
+                                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                                      err, sizeof(err), NULL);
+            if (len > 0) {
+                ZITI_LOG(WARN, "failed to create exclusion route[%s]: %lu(%s)", dest, (unsigned long)rc, err);
+            } else {
+                ZITI_LOG(WARN, "failed to create exclusion route[%s]: %lu", dest, (unsigned long)rc);
+            }
         }
     }
 }


### PR DESCRIPTION
This change updates Windows route API error handling to report the error codes returned directly by the Windows IP Helper APIs rather than using `GetLastError()`. The route APIs return `NO_ERROR` on success and an error code directly on failure. Refer to [Microsoft documentation for `CreateIpForwardEntry2`](https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-createipforwardentry2#return-value) for documented return behavior.

The existing behavior can result in misleading messages such as:

```text
WARN ziti-edge-tunnel:tun.c:550 refresh_routes() failed to create exclusion route[1.2.3.4]: 1168(The operation completed successfully.)
```
Here, the route API returned error `1168`, while `GetLastError()` yielded a value corresponding to `The operation completed successfully`.

The change also verifies that `FormatMessage()` returns `len > 0` before using the formatted error message, avoiding use of an empty or unavailable message.
