### PR TITLE
Fix legacy MFA re-auth flakes on cluster overlays

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -257,6 +257,7 @@ jobs:
           name: integration-logs-${{ matrix.os.name }}-ziti-${{ inputs.label }}
           path: |
             ${{ runner.temp }}/zets/logs/*.log
+            ${{ runner.temp }}/zets/upgrade-*/zet/logs/*.log
             ${{ runner.temp }}/overlay/quickstart-logs/*.log
             ${{ runner.temp }}/idp/logs/*.log
           if-no-files-found: ignore

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -257,7 +257,7 @@ jobs:
           name: integration-logs-${{ matrix.os.name }}-ziti-${{ inputs.label }}
           path: |
             ${{ runner.temp }}/zets/logs/*.log
-            ${{ runner.temp }}/zets/upgrade-*/zet/logs/*.log
+            ${{ runner.temp }}/zets/upgrade*/zet/logs/*.log
             ${{ runner.temp }}/overlay/quickstart-logs/*.log
             ${{ runner.temp }}/idp/logs/*.log
           if-no-files-found: ignore

--- a/tests/integration/legacy_auth_mfa_test.go
+++ b/tests/integration/legacy_auth_mfa_test.go
@@ -65,6 +65,9 @@ func restartOffersCodePromptForEnrolledIdentity(t *testing.T) {
 		idName := "test_legacy_mfa_restart_prompt"
 		enrollment, secret := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
+		// every re-auth here can land on any cluster member, so the preceding MFA write must
+		// have been applied everywhere first; same guard as triggerReauthChallenge
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 
 		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
@@ -88,6 +91,7 @@ func disableEnableOffersCodePromptForEnrolledIdentity(t *testing.T) {
 		idName := "test_legacy_mfa_toggle_prompt"
 		enrollment, secret := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
+		state.overlay.WaitForDataModelConsensus()
 		state.zetClient.DisableEnableIdentity(t, enrollment.Identifier)
 
 		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
@@ -116,6 +120,7 @@ func restartKeepsPersistedMfaEnabled(t *testing.T) {
 		idName := "test_legacy_mfa_restart_state"
 		enrollment, _ := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 
 		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
@@ -148,6 +153,7 @@ func recoversWhenPersistedMfaEnabledIsWrong(t *testing.T) {
 
 		state.zetClient.Stop()
 		state.zetClient.SetPersistedMfaEnabled(t, enrollment.Identifier, false)
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Start(), "start %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 
 		state.zetClient.WaitForMfaEvent(t, "enrollment_required", idName)
@@ -181,6 +187,7 @@ func repeatedRestartsKeepOfferingCodePrompt(t *testing.T) {
 		answers := []string{testutil.GenerateTOTP(t, secret, time.Now()), enrollment.RecoveryCodes[0]}
 
 		for pass, answer := range answers {
+			state.overlay.WaitForDataModelConsensus()
 			require.NoError(t, state.zetClient.Restart(), "restart %d of %s\n%s", pass+1, state.zetClient.Discriminator, state.zetClient.LogPath())
 
 			state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
@@ -208,6 +215,7 @@ func restartAcceptsRecoveryCode(t *testing.T) {
 		idName := "test_legacy_mfa_restart_recovery"
 		enrollment, _ := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 
 		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
@@ -230,6 +238,7 @@ func acceptedCodeEndsThePrompting(t *testing.T) {
 		idName := "test_legacy_mfa_quiet_after_code"
 		enrollment, secret := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 
 		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
@@ -261,6 +270,7 @@ func twoIdentitiesKeepSeparateMfaState(t *testing.T) {
 		plain := testutil.FetchAndEnrollJwt(t, state.overlay, state.zetClient, plainName)
 		state.zetClient.WaitForControllerEvent(t, "connected", plainName)
 
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 
 		state.zetClient.WaitForMfaEvent(t, "auth_challenge", mfaName)
@@ -291,6 +301,7 @@ func removeMfaThenRestartStopsPrompting(t *testing.T) {
 		state.zetClient.RemoveMFA(t, enrollment.Identifier, code).AssertSuccess()
 		state.zetClient.WaitForMfaEvent(t, "enrollment_remove", idName).AssertSuccess()
 
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 		state.zetClient.WaitForControllerEvent(t, "connected", idName)
 
@@ -316,6 +327,7 @@ func adminRemovedMfaStopsPromptingAfterRestart(t *testing.T) {
 		state.overlay.RemoveIdentityMFA(t, idName)
 		require.False(t, state.overlay.IdentityMfaEnabled(t, idName), "controller still says %q is enrolled after an admin removed MFA", idName)
 
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 		state.zetClient.WaitForControllerEvent(t, "connected", idName)
 
@@ -341,12 +353,14 @@ func migratingToOidcKeepsTheIdentityEnrolled(t *testing.T) {
 		idName := "test_legacy_mfa_oidc_migration"
 		enrollment, secret := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
 
 		t.Cleanup(func() { state.overlay.RestoreLegacyAuth(t) })
 		state.overlay.EnableOidc(t)
 
+		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s after the OIDC migration\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 		state.zetClient.WaitForMfaEvent(t, "auth_challenge", idName)
 

--- a/tests/integration/legacy_auth_mfa_test.go
+++ b/tests/integration/legacy_auth_mfa_test.go
@@ -65,8 +65,6 @@ func restartOffersCodePromptForEnrolledIdentity(t *testing.T) {
 		idName := "test_legacy_mfa_restart_prompt"
 		enrollment, secret := testutil.EnrollAndVerifyMFA(t, state.overlay, state.zetClient, idName)
 
-		// every re-auth here can land on any cluster member, so the preceding MFA write must
-		// have been applied everywhere first; same guard as triggerReauthChallenge
 		state.overlay.WaitForDataModelConsensus()
 		require.NoError(t, state.zetClient.Restart(), "restart %s\n%s", state.zetClient.Discriminator, state.zetClient.LogPath())
 

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/openziti/ziti-tunnel-sdk-c/tests/integration/testutil"
 )
 
-const setupTimeout = 45 * time.Second
+const setupTimeout = 60 * time.Second
 
 const fixturePath = "testdata/fixture.json"
 

--- a/tests/integration/testutil/overlay_auth.go
+++ b/tests/integration/testutil/overlay_auth.go
@@ -210,7 +210,7 @@ func enableOidcInConfig(path string) error {
 // missing identity.
 func (o *Overlay) waitForRouterOnline() error {
 	log.Printf("overlay: waiting for the quickstart router to come online")
-	// under doSetup's own 45s guard, so keep this shorter than that: a longer deadline can
+	// under doSetup's own 60s guard, so keep this shorter than that: a longer deadline can
 	// never elapse and the caller reports "setup did not complete" instead of naming the router
 	deadline := time.Now().Add(30 * time.Second)
 


### PR DESCRIPTION
- Wait for data model consensus before every re-auth trigger in legacy MFA tests
- Raise setup timeout to 60s to avoid setup failures on slow machines/runners
- upload the Windows upgrade tests' ZET logs with the integration log artifact
- Admin remove MFA test flakes rely on https://github.com/openziti/ziti/pull/4284