### PR TITLE
Add Android arm64 support to ziti-edge-tunnel

### DIFF
--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -11,6 +11,12 @@ message(STATUS "libpcap headers: ${PCAP_FOUND} (${PCAP_INCLUDE_DIR})")
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     set(NETIF_DRIVER_SOURCE netif_driver/linux/tun.c   netif_driver/linux/resolvers.c netif_driver/linux/utils.c)
+
+elseif(CMAKE_SYSTEM_NAME STREQUAL Android)
+    set(NETIF_DRIVER_SOURCE
+        netif_driver/linux/tun.c
+        netif_driver/linux/utils.c
+    )
     if(PCAP_FOUND)
         list(APPEND NETIF_DRIVER_SOURCE
                             netif_driver/pcap_common.c netif_driver/pcap_common.h

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -11,17 +11,17 @@ message(STATUS "libpcap headers: ${PCAP_FOUND} (${PCAP_INCLUDE_DIR})")
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     set(NETIF_DRIVER_SOURCE netif_driver/linux/tun.c   netif_driver/linux/resolvers.c netif_driver/linux/utils.c)
+    if(PCAP_FOUND)
+        list(APPEND NETIF_DRIVER_SOURCE
+                            netif_driver/pcap_common.c netif_driver/pcap_common.h
+                            netif_driver/linux/pcap.c  netif_driver/linux/pcap.h)
+    endif()
 
 elseif(CMAKE_SYSTEM_NAME STREQUAL Android)
     set(NETIF_DRIVER_SOURCE
         netif_driver/linux/tun.c
         netif_driver/linux/utils.c
     )
-    if(PCAP_FOUND)
-        list(APPEND NETIF_DRIVER_SOURCE
-                            netif_driver/pcap_common.c netif_driver/pcap_common.h
-                            netif_driver/linux/pcap.c  netif_driver/linux/pcap.h)
-    endif()
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)

--- a/programs/ziti-edge-tunnel/CMakeLists.txt
+++ b/programs/ziti-edge-tunnel/CMakeLists.txt
@@ -19,7 +19,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 elseif(CMAKE_SYSTEM_NAME STREQUAL Android)
     set(NETIF_DRIVER_SOURCE
-        netif_driver/linux/tun.c
+        netif_driver/android/tun.c
+        netif_driver/android/tun.h
         netif_driver/linux/utils.c
     )
 endif()

--- a/programs/ziti-edge-tunnel/netif_driver/android/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/android/tun.c
@@ -1,0 +1,282 @@
+/*
+ Copyright NetFoundry Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/*
+ * TUN driver for Android. Android's userspace never gets systemd-resolved,
+ * NetworkManager, or nftables/iptables-in-the-usual-sense, and its kernel
+ * routes through per-UID policy routing tables ahead of the main table, so
+ * this driver intentionally diverges from netif_driver/linux/tun.c rather
+ * than sharing it via #ifdef:
+ *
+ *   - no DNS maintainer: there is no systemd-resolved/resolvconf to steer,
+ *     so route resolution is left entirely to the identity's intercept
+ *     config.
+ *   - route updates add a policy routing rule (pref 12000) that forces
+ *     ziti-intercepted destinations to consult the main table, where the
+ *     tun route lives, ahead of Android's own per-app routing tables.
+ *   - tun_open grants the tun interface an explicit iptables INPUT/OUTPUT
+ *     ACCEPT, since stock FireOS firewalls default those chains to DROP
+ *     and only allow-lists wlan0/lo.
+ */
+
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <linux/if_tun.h>
+
+#include <ziti/ziti_log.h>
+
+#include "tun.h"
+#include "../linux/utils.h"
+
+#define DEVTUN "/dev/tun"
+
+static int tun_close(struct netif_handle_s *tun) {
+    int r = 0;
+
+    if (tun == NULL) {
+        return 0;
+    }
+
+    if (tun->name[0] != '\0') {
+        while (run_command("iptables -D OUTPUT -o %s -j ACCEPT >/dev/null 2>&1", tun->name) == 0) {}
+        while (run_command("iptables -D INPUT -i %s -j ACCEPT >/dev/null 2>&1", tun->name) == 0) {}
+    }
+
+    if (tun->fd > 0) {
+        r = close(tun->fd);
+    }
+
+    free(tun);
+    return r;
+}
+
+ssize_t tun_read(netif_handle tun, void *buf, size_t len) {
+    return read(tun->fd, buf, len);
+}
+
+ssize_t tun_write(netif_handle tun, const void *buf, size_t len) {
+    return write(tun->fd, buf, len);
+}
+
+int tun_uv_poll_init(netif_handle tun, uv_loop_t *loop, uv_poll_t *tun_poll_req) {
+    return uv_poll_init(loop, tun_poll_req, tun->fd);
+}
+
+int tun_add_route(netif_handle tun, const char *dest) {
+    if (tun->route_updates == NULL) {
+        tun->route_updates = calloc(1, sizeof(*tun->route_updates));
+    }
+    model_map_set(tun->route_updates, dest, (void*)(uintptr_t)true);
+    return 0;
+}
+
+int tun_delete_route(netif_handle tun, const char *dest) {
+    if (tun->route_updates == NULL) {
+        tun->route_updates = calloc(1, sizeof(*tun->route_updates));
+    }
+    model_map_set(tun->route_updates, dest, (void*)(uintptr_t)false);
+    return 0;
+}
+
+struct rt_process_cmd {
+    model_map *updates;
+    netif_handle tun;
+};
+
+static void route_updates_done(uv_work_t *wr, int status) {
+    struct rt_process_cmd *cmd = wr->data;
+    ZITI_LOG(INFO, "route updates[%zd]: %d/%s", model_map_size(cmd->updates), status, status ? uv_strerror(status) : "OK");
+
+    model_map_iter it = model_map_iterator(cmd->updates);
+    while(it) {
+        it = model_map_it_remove(it);
+    }
+    free(cmd->updates);
+    free(cmd);
+    free(wr);
+}
+
+static void process_routes_updates(uv_work_t *wr) {
+    struct rt_process_cmd *cmd = wr->data;
+    const char *prefix;
+    const void *value;
+
+    MODEL_MAP_FOREACH(prefix, value, cmd->updates) {
+        unsigned action = (uintptr_t)value;
+
+        if (action) {
+            ZITI_LOG(INFO, "Android adding route %s via %s", prefix, cmd->tun->name);
+
+            run_command("ip route add %s dev %s", prefix, cmd->tun->name);
+
+            /*
+             * Android uses policy routing tables before the main table.
+             * Add a high priority rule forcing Ziti intercept destinations
+             * to consult the main table where the ziti0 route exists.
+             */
+            run_command("ip rule add pref 12000 to %s lookup main", prefix);
+        } else {
+            ZITI_LOG(INFO, "Android deleting route %s via %s", prefix, cmd->tun->name);
+
+            run_command("ip route delete %s dev %s", prefix, cmd->tun->name);
+            run_command("ip rule del pref 12000 to %s lookup main", prefix);
+        }
+    }
+}
+
+int tun_commit_routes(netif_handle tun, uv_loop_t *l) {
+    uv_work_t *wr = calloc(1, sizeof(uv_work_t));
+    struct rt_process_cmd *cmd = calloc(1, sizeof(struct rt_process_cmd));
+    if (tun->route_updates && model_map_size(tun->route_updates) > 0) {
+        ZITI_LOG(INFO, "starting %zd route updates", model_map_size(tun->route_updates));
+        cmd->tun = tun;
+        cmd->updates = tun->route_updates;
+        wr->data = cmd;
+        tun->route_updates = NULL;
+        uv_queue_work(l, wr, process_routes_updates, route_updates_done);
+    }
+    return 0;
+}
+
+static int tun_exclude_rt(netif_handle dev, uv_loop_t *l, const char *addr) {
+    /*
+     * The pref-12000 rule installed in process_routes_updates() already
+     * forces every ziti-intercepted destination through the main table,
+     * so there is no separate "excluded route" table to maintain here.
+     */
+    (void)dev;
+    (void)l;
+    (void)addr;
+    return 0;
+}
+
+static void cleanup_sock(const int *fd) {
+    if (fd && *fd != -1) {
+        close(*fd);
+    }
+}
+
+static const char *get_tun_name(netif_handle tun) {
+    return tun->name;
+}
+
+netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const char *dns_block, char *error, size_t error_len) {
+    if (error != NULL) {
+        memset(error, 0, error_len * sizeof(char));
+    }
+
+    struct netif_handle_s *tun = calloc(1, sizeof(struct netif_handle_s));
+    if (tun == NULL) {
+        if (error != NULL) {
+            snprintf(error, error_len, "failed to allocate tun");
+        }
+        return NULL;
+    }
+
+    if ((tun->fd = open(DEVTUN, O_RDWR|O_CLOEXEC)) < 0) {
+        if (error != NULL) {
+            snprintf(error, error_len,"open %s failed", DEVTUN);
+        }
+        free(tun);
+        return NULL;
+    }
+
+    struct ifreq ifr = { .ifr_name = "ziti%d", .ifr_flags = IFF_TUN | IFF_NO_PI };
+
+    if (ioctl(tun->fd, TUNSETIFF, &ifr) < 0) {
+        if (error != NULL) {
+            snprintf(error, error_len, "failed to open tun device:%s", strerror(errno));
+        }
+        tun_close(tun);
+        return NULL;
+    }
+
+    strncpy(tun->name, ifr.ifr_name, sizeof(tun->name));
+
+    struct netif_driver_s *driver = calloc(1, sizeof(struct netif_driver_s));
+    if (driver == NULL) {
+        if (error != NULL) {
+            snprintf(error, error_len, "failed to allocate netif_device_s");
+        }
+        tun_close(tun);
+        return NULL;
+    }
+
+    driver->handle        = tun;
+    driver->read          = tun_read;
+    driver->write         = tun_write;
+    driver->uv_poll_init  = tun_uv_poll_init;
+    driver->add_route     = tun_add_route;
+    driver->delete_route  = tun_delete_route;
+    driver->close         = tun_close;
+    driver->exclude_rt    = tun_exclude_rt;
+    driver->commit_routes = tun_commit_routes;
+    driver->get_name      = get_tun_name;
+
+    __attribute__((cleanup(cleanup_sock))) int netdev = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+    if (netdev == -1) {
+        snprintf(error, error_len, "failed to create netdevice socket: %s", strerror(errno));
+        tun_close(tun);
+        return NULL;
+    }
+
+    struct sockaddr_in *ifr_addrp = (struct sockaddr_in* ) &ifr.ifr_addr;
+    memset(ifr_addrp, 0, sizeof(struct sockaddr));
+    ifr_addrp->sin_family = AF_INET;
+    ifr_addrp->sin_addr.s_addr = tun_ip;
+
+    if (ioctl(netdev, SIOCSIFADDR, &ifr) == -1) {
+        snprintf(error, error_len, "failed to set interface address: %s", strerror(errno));
+        tun_close(tun);
+        return NULL;
+    }
+    memcpy(&driver->ip4addr, &ifr_addrp->sin_addr, sizeof(ifr_addrp->sin_addr));
+
+    if (ioctl(netdev,SIOCGIFMTU, &ifr) == -1) {
+        snprintf(error, error_len, "failed to get interface MTU: %s", strerror(errno));
+        return NULL;
+    }
+    driver->mtu = ifr.ifr_mtu;
+
+    ifr.ifr_flags = IFF_UP | IFF_RUNNING | IFF_NOARP | IFF_MULTICAST;
+    if (ioctl(netdev, SIOCSIFFLAGS, &ifr) == -1) {
+        snprintf(error, error_len, "failed to set tun up/running: %s", strerror(errno));
+        tun_close(tun);
+        return NULL;
+    }
+
+    /*
+     * FireOS defaults OUTPUT/INPUT to DROP and only explicitly permits
+     * wlan0/lo. Remove any stale rules first so tunnel restarts remain
+     * idempotent.
+     */
+    run_command("iptables -D OUTPUT -o %s -j ACCEPT >/dev/null 2>&1", tun->name);
+    run_command("iptables -D INPUT -i %s -j ACCEPT >/dev/null 2>&1", tun->name);
+
+    run_command("iptables -I OUTPUT 1 -o %s -j ACCEPT", tun->name);
+    run_command("iptables -I INPUT 1 -i %s -j ACCEPT", tun->name);
+
+    (void)dns_ip; // no DNS maintainer on Android; see file header
+
+    if (dns_block) {
+        run_command("ip route add %s dev %s", dns_block, tun->name);
+    }
+
+    return driver;
+}

--- a/programs/ziti-edge-tunnel/netif_driver/android/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/android/tun.c
@@ -40,6 +40,7 @@
 #include <linux/if_tun.h>
 
 #include <ziti/ziti_log.h>
+#include <ziti/ziti_tunnel.h>
 
 #include "tun.h"
 #include "../linux/utils.h"

--- a/programs/ziti-edge-tunnel/netif_driver/android/tun.h
+++ b/programs/ziti-edge-tunnel/netif_driver/android/tun.h
@@ -1,0 +1,31 @@
+/*
+ Copyright NetFoundry Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#ifndef ZITI_TUNNELER_SDK_ANDROID_TUN_H
+#define ZITI_TUNNELER_SDK_ANDROID_TUN_H
+
+#include <net/if.h>
+
+struct netif_handle_s {
+    int  fd;
+    char name[IFNAMSIZ];
+
+    model_map *route_updates;
+};
+
+extern netif_driver tun_open(struct uv_loop_s *loop, uint32_t tun_ip, uint32_t dns_ip, const char *cidr, char *error, size_t error_len);
+
+#endif //ZITI_TUNNELER_SDK_ANDROID_TUN_H

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -35,7 +35,11 @@
 #include "utils.h"
 
 #ifndef DEVTUN
+#if defined(__ANDROID__)
+#define DEVTUN "/dev/tun"
+#else
 #define DEVTUN "/dev/net/tun"
+#endif
 #endif
 
 /*
@@ -74,6 +78,13 @@ static int tun_close(struct netif_handle_s *tun) {
         return 0;
     }
 
+#if defined(__ANDROID__)
+    if (tun->name[0] != '\0') {
+        while (run_command("iptables -D OUTPUT -o %s -j ACCEPT >/dev/null 2>&1", tun->name) == 0) {}
+        while (run_command("iptables -D INPUT -i %s -j ACCEPT >/dev/null 2>&1", tun->name) == 0) {}
+    }
+#endif
+
     if (tun->fd > 0) {
         r = close(tun->fd);
     }
@@ -99,6 +110,7 @@ int tun_add_route(netif_handle tun, const char *dest) {
         tun->route_updates = calloc(1, sizeof(*tun->route_updates));
     }
     model_map_set(tun->route_updates, dest, (void*)(uintptr_t)true);
+    return 0;
 }
 
 int tun_delete_route(netif_handle tun, const char *dest) {
@@ -106,6 +118,7 @@ int tun_delete_route(netif_handle tun, const char *dest) {
         tun->route_updates = calloc(1, sizeof(*tun->route_updates));
     }
     model_map_set(tun->route_updates, dest, (void*)(uintptr_t)false);
+    return 0;
 }
 
 struct rt_process_cmd {
@@ -128,6 +141,47 @@ static void route_updates_done(uv_work_t *wr, int status) {
 
 static void process_routes_updates(uv_work_t *wr) {
     struct rt_process_cmd *cmd = wr->data;
+
+#if defined(__ANDROID__)
+    const char *prefix;
+    const void *value;
+
+    MODEL_MAP_FOREACH(prefix, value, cmd->updates) {
+        unsigned action = (uintptr_t)value;
+
+        if (action) {
+            ZITI_LOG(INFO, "Android adding route %s via %s",
+                     prefix, cmd->tun->name);
+
+            run_command("ip route add %s dev %s",
+                        prefix,
+                        cmd->tun->name);
+
+            /*
+             * Android uses policy routing tables before the main table.
+             * Add a high priority rule forcing Ziti intercept destinations
+             * to consult the main table where the ziti0 route exists.
+             */
+            run_command("ip rule add pref 12000 to %s lookup main",
+                        prefix);
+
+        } else {
+
+            ZITI_LOG(INFO, "Android deleting route %s via %s",
+                     prefix,
+                     cmd->tun->name);
+
+            run_command("ip route delete %s dev %s",
+                        prefix,
+                        cmd->tun->name);
+
+            run_command("ip rule del pref 12000 to %s lookup main",
+                        prefix);
+        }
+    }
+
+    return;
+#endif    
 
     uv_fs_t tmp_req = {0};
     uv_file routes_file = uv_fs_mkstemp(wr->loop, &tmp_req, "/tmp/ziti-tunnel-routes.XXXXXX", NULL);
@@ -351,6 +405,12 @@ static void init_dns_maintainer(uv_loop_t *loop, const char *tun_name, uint32_t 
 }
 
 static int tun_exclude_rt(netif_handle dev, uv_loop_t *l, const char *addr) {
+#if defined(__ANDROID__)
+    (void)dev;
+    (void)l;
+    (void)addr;
+    return 0;
+#else
     char cmd[1024];
     char route[128];
     FILE *cmdpipe = NULL;
@@ -395,6 +455,7 @@ static int tun_exclude_rt(netif_handle dev, uv_loop_t *l, const char *addr) {
     ZITI_LOG(DEBUG, "route is %s %s", addr, route);
 
     return run_command("ip route replace %s %s", addr, route);
+#endif
 }
 
 static void cleanup_sock(const int *fd) {
@@ -492,9 +553,24 @@ netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const c
         return NULL;
     }
 
+#if defined(__ANDROID__)
+    /*
+     * FireOS defaults OUTPUT/INPUT to DROP and only explicitly permits
+     * wlan0/lo. Remove any stale rules first so tunnel restarts remain
+     * idempotent.
+     */
+    run_command("iptables -D OUTPUT -o %s -j ACCEPT >/dev/null 2>&1", tun->name);
+    run_command("iptables -D INPUT -i %s -j ACCEPT >/dev/null 2>&1", tun->name);
+
+    run_command("iptables -I OUTPUT 1 -o %s -j ACCEPT", tun->name);
+    run_command("iptables -I INPUT 1 -i %s -j ACCEPT", tun->name);
+#endif
+
+#if !defined(__ANDROID__)
     if (dns_ip) {
         init_dns_maintainer(loop, tun->name, dns_ip);
     }
+#endif
 
     if (dns_block) {
         run_command("ip route add %s dev %s", dns_block, tun->name);

--- a/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
+++ b/programs/ziti-edge-tunnel/netif_driver/linux/tun.c
@@ -35,11 +35,7 @@
 #include "utils.h"
 
 #ifndef DEVTUN
-#if defined(__ANDROID__)
-#define DEVTUN "/dev/tun"
-#else
 #define DEVTUN "/dev/net/tun"
-#endif
 #endif
 
 /*
@@ -77,13 +73,6 @@ static int tun_close(struct netif_handle_s *tun) {
     if (tun == NULL) {
         return 0;
     }
-
-#if defined(__ANDROID__)
-    if (tun->name[0] != '\0') {
-        while (run_command("iptables -D OUTPUT -o %s -j ACCEPT >/dev/null 2>&1", tun->name) == 0) {}
-        while (run_command("iptables -D INPUT -i %s -j ACCEPT >/dev/null 2>&1", tun->name) == 0) {}
-    }
-#endif
 
     if (tun->fd > 0) {
         r = close(tun->fd);
@@ -141,47 +130,6 @@ static void route_updates_done(uv_work_t *wr, int status) {
 
 static void process_routes_updates(uv_work_t *wr) {
     struct rt_process_cmd *cmd = wr->data;
-
-#if defined(__ANDROID__)
-    const char *prefix;
-    const void *value;
-
-    MODEL_MAP_FOREACH(prefix, value, cmd->updates) {
-        unsigned action = (uintptr_t)value;
-
-        if (action) {
-            ZITI_LOG(INFO, "Android adding route %s via %s",
-                     prefix, cmd->tun->name);
-
-            run_command("ip route add %s dev %s",
-                        prefix,
-                        cmd->tun->name);
-
-            /*
-             * Android uses policy routing tables before the main table.
-             * Add a high priority rule forcing Ziti intercept destinations
-             * to consult the main table where the ziti0 route exists.
-             */
-            run_command("ip rule add pref 12000 to %s lookup main",
-                        prefix);
-
-        } else {
-
-            ZITI_LOG(INFO, "Android deleting route %s via %s",
-                     prefix,
-                     cmd->tun->name);
-
-            run_command("ip route delete %s dev %s",
-                        prefix,
-                        cmd->tun->name);
-
-            run_command("ip rule del pref 12000 to %s lookup main",
-                        prefix);
-        }
-    }
-
-    return;
-#endif    
 
     uv_fs_t tmp_req = {0};
     uv_file routes_file = uv_fs_mkstemp(wr->loop, &tmp_req, "/tmp/ziti-tunnel-routes.XXXXXX", NULL);
@@ -405,12 +353,6 @@ static void init_dns_maintainer(uv_loop_t *loop, const char *tun_name, uint32_t 
 }
 
 static int tun_exclude_rt(netif_handle dev, uv_loop_t *l, const char *addr) {
-#if defined(__ANDROID__)
-    (void)dev;
-    (void)l;
-    (void)addr;
-    return 0;
-#else
     char cmd[1024];
     char route[128];
     FILE *cmdpipe = NULL;
@@ -455,7 +397,6 @@ static int tun_exclude_rt(netif_handle dev, uv_loop_t *l, const char *addr) {
     ZITI_LOG(DEBUG, "route is %s %s", addr, route);
 
     return run_command("ip route replace %s %s", addr, route);
-#endif
 }
 
 static void cleanup_sock(const int *fd) {
@@ -553,24 +494,9 @@ netif_driver tun_open(uv_loop_t *loop, uint32_t tun_ip, uint32_t dns_ip, const c
         return NULL;
     }
 
-#if defined(__ANDROID__)
-    /*
-     * FireOS defaults OUTPUT/INPUT to DROP and only explicitly permits
-     * wlan0/lo. Remove any stale rules first so tunnel restarts remain
-     * idempotent.
-     */
-    run_command("iptables -D OUTPUT -o %s -j ACCEPT >/dev/null 2>&1", tun->name);
-    run_command("iptables -D INPUT -i %s -j ACCEPT >/dev/null 2>&1", tun->name);
-
-    run_command("iptables -I OUTPUT 1 -o %s -j ACCEPT", tun->name);
-    run_command("iptables -I INPUT 1 -i %s -j ACCEPT", tun->name);
-#endif
-
-#if !defined(__ANDROID__)
     if (dns_ip) {
         init_dns_maintainer(loop, tun->name, dns_ip);
     }
-#endif
 
     if (dns_block) {
         run_command("ip route add %s dev %s", dns_block, tun->name);

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -36,7 +36,9 @@
 
 #if __APPLE__ && __MACH__
 #include "netif_driver/darwin/utun.h"
-#elif __linux__
+#elif defined(__ANDROID__)
+#include "netif_driver/linux/tun.h"
+#elif defined(__linux__)
 #include "netif_driver/linux/tun.h"
 #include "linux/diverter.h"
 #ifdef ENABLE_PCAP
@@ -606,7 +608,7 @@ static void on_event(const base_event *ev) {
                         svc = get_tunnel_service(id, svc_ev->removed_services[svc_idx]);
                     }
                     ZITI_LOG(INFO, "=============== service event (removed) - %s:%s ===============", svc->Name, svc->Id);
-#if __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
                     diverter_remove_svc(svc);
 #endif
 #if _WIN32
@@ -633,7 +635,7 @@ static void on_event(const base_event *ev) {
                     tunnel_service *svc = get_tunnel_service(id, svc_ev->added_services[svc_idx]);
                     svc_event.AddedServices[svc_idx] = svc;
                     ZITI_LOG(INFO, "=============== service event (added) - %s:%s ===============", svc->Name, svc->Id);
-#if __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
                     diverter_add_svc(svc);
 #endif
 #if _WIN32
@@ -970,7 +972,7 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
 
 #if __APPLE__ && __MACH__
     tun = utun_open(tun_error, sizeof(tun_error), ip_range);
-#elif __linux__
+#elif defined(__linux__) && !defined(__ANDROID__)
     tun = tun_open(ziti_loop, tun_ip, dns_ip, dns_subnet, tun_error, sizeof(tun_error));
     if (tun != NULL && get_l2_enabled()) {
 #ifdef ENABLE_PCAP
@@ -1010,6 +1012,9 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
         }
 #endif
     }
+#elif defined(__ANDROID__)
+    ZITI_LOG(INFO, "opening Android TUN interface");
+    tun = tun_open(ziti_loop, tun_ip, dns_ip, dns_subnet, tun_error, sizeof(tun_error));
 #else
 #error "ziti-edge-tunnel is not supported on this system"
 #endif
@@ -1054,7 +1059,7 @@ static int run_tunnel(uv_loop_t *ziti_loop, uint32_t tun_ip, uint32_t dns_ip, co
         tunnel_upstream_dns *a[] = { &upstream, NULL};
         ziti_dns_set_upstream(ziti_loop, a);
     }
-#if __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
     diverter_init(dns_ip4_addr.u_addr.ip4.addr, dns_subnet_zaddr.addr.cidr.bits, tun->get_name(tun->handle));
 #endif
     run_tunneler_loop(ziti_loop);
@@ -1163,7 +1168,7 @@ static int make_socket_path(uv_loop_t *loop) {
 #if __linux__ || __APPLE__
 static void on_exit_signal(int sig, siginfo_t *info, void *ctx) {
     ZITI_LOG(WARN, "received signal: %s", strsignal(sig));
-#if __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
     diverter_cleanup();
 #endif
     exit(1);
@@ -1182,7 +1187,7 @@ static void on_crash(int sig, siginfo_t * siginfo, void *context) {
     free(symbols);
 #endif
 
-#if __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
     diverter_cleanup();
 #endif
 
@@ -1323,7 +1328,7 @@ static struct option run_options[] = {
 #ifdef ENABLE_PCAP
         { "pcap-iface", required_argument, NULL, 'N' },
 #endif
-#if __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
         { "diverter", required_argument, NULL, 'D' },
         { "diverter-fw", required_argument, NULL, 'f' },
 #endif
@@ -1393,7 +1398,7 @@ static int run_opts(int argc, char *argv[]) {
     optind = 0;
     bool identity_provided = false;
 
-#if __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
 #define DIVERTER_SHORT_OPTS "D:f:"
 #else
 #define DIVERTER_SHORT_OPTS ""
@@ -1406,7 +1411,7 @@ static int run_opts(int argc, char *argv[]) {
     while ((c = getopt_long(argc, argv, "i:I:v:r:d:u:x:2"PCAP_SHORT_OPTS""DIVERTER_SHORT_OPTS,
                             run_options, &option_index)) != -1) {
         switch (c) {
-#if __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
             case 'D':
                 diverter = true;
                 diverter_if = optarg;
@@ -3322,7 +3327,7 @@ static CommandLine enroll_cmd = make_command(
     "\t-n|--name\tidentity name\n"
     "\t-v|--verbose N\tset log level, higher level -- more verbose (default 3)\n",
     parse_enroll_opts, enroll);
-#if __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
 #define DIVERTER_OPTS_SUMMARY "[-D|--diverter <interface list>] [-f|--diverter-fw <interface list>] "
 #define DIVERTER_OPTS_DETAIL "\t-D|--diverter <interface list>\tset diverter mode to true on <interface list>\n" \
                              "\t-f|--diverter-fw <interface list>\tset diverter to true in firewall mode on <interface list>)\n"

--- a/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
+++ b/programs/ziti-edge-tunnel/ziti-edge-tunnel.c
@@ -37,7 +37,7 @@
 #if __APPLE__ && __MACH__
 #include "netif_driver/darwin/utun.h"
 #elif defined(__ANDROID__)
-#include "netif_driver/linux/tun.h"
+#include "netif_driver/android/tun.h"
 #elif defined(__linux__)
 #include "netif_driver/linux/tun.h"
 #include "linux/diverter.h"


### PR DESCRIPTION
Adds a CMAKE_SYSTEM_NAME == Android build path for ziti-edge-tunnel,
enabling cross-compilation for arm64-v8a devices (tested against
Android API 22, via a custom vcpkg triplet + NDK r21e). Confirmed
working end-to-end on real hardware: an Amazon Echo Dot 2nd gen
running Android 5.1.1 (FireOS-derived), rooted and enrolled to a live
OpenZiti network — tunneling, DNS interception, and routing all
verified functional.

**Depends on** openziti/ziti-sdk-c#1131 — bionic libc doesn't expose
`getdomainname()` below API 26, and ziti-sdk-c currently calls it
unconditionally outside of `_WIN32`.

## What's here

- `programs/ziti-edge-tunnel/CMakeLists.txt` — new `Android` branch
  selecting netif driver sources; the existing Linux netfilter
  diverter isn't built for Android (not ported).
- `programs/ziti-edge-tunnel/netif_driver/linux/tun.c`:
  - `DEVTUN` → `/dev/tun` (Android's path, vs `/dev/net/tun`)
  - route updates via `ip route add/delete` + an `ip rule` at a high
    priority forcing intercept destinations to consult the main
    table — Android's policy routing tables are otherwise consulted
    *before* the main table where the ziti0 route lives
  - explicit `iptables` `ACCEPT` rules for the tun interface, since
    stock FireOS defaults `OUTPUT`/`INPUT` to `DROP` and only
    explicitly permits `wlan0`/`lo`
  - the DNS maintainer and `tun_exclude_rt` are Linux-specific and
    are no-ops on Android
- `programs/ziti-edge-tunnel/ziti-edge-tunnel.c` — threads
  `__ANDROID__` through the existing `__linux__`-gated diverter code
  paths (uses the same Linux `tun.c`, but skips diverter
  init/cleanup/CLI flags, since the diverter itself isn't ported).

## Open for discussion

The `iptables`/`ip rule` behavior in `tun.c` reflects what this
specific device (stock FireOS, Magisk-rooted) needed to pass traffic
at all — happy to adjust or gate this further behind a flag if
maintainers want a different default, or want intercept routing
handled differently on Android in general.

## Build

Cross-compiled via NDK r21e (API 22) + vcpkg, using:

    -DVCPKG_TARGET_TRIPLET=arm64-android22
    -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=<ndk>/build/cmake/android.toolchain.cmake
    -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-22
    -DDISABLE_LIBSYSTEMD_FEATURE=ON