### PR TITLE
Add outage/retry test

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,12 +51,6 @@ jobs:
             preset: linux-arm64
 
     steps:
-      - name: Debug action
-        shell: bash
-        run: |
-          env | sort
-          cat "$GITHUB_EVENT_PATH"
-
       - name: checkout workspace
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -60,12 +60,6 @@ jobs:
       ZITI_RPM_TEST_REPO: ${{ vars.ZITI_RPM_TEST_REPO || 'zitipax-openziti-rpm-test' }}
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
     steps:
-      - name: Print Environment Variables and Event JSON
-        shell: bash
-        run: |
-          env | sort
-          cat "$GITHUB_EVENT_PATH"
-
       - name: Install contemporary Git in runner container if Ubuntu
         if: ${{ matrix.distro.name == 'ubuntu' }}
         shell: bash

--- a/.github/workflows/promote-downstreams.yml
+++ b/.github/workflows/promote-downstreams.yml
@@ -15,12 +15,6 @@ jobs:
     name: Wait for Release Builds to Succeed
     runs-on: ubuntu-latest
     steps:
-      - name: Debug action
-        shell: bash
-        run: |
-          env | sort
-          cat "$GITHUB_EVENT_PATH"
-
       - name: Wait for all checks on this ref
         uses: lewagon/wait-on-check-action@v1.9.0
         with:

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -24,12 +24,6 @@ jobs:
       ZITI_EDGE_TUNNEL_IMAGE: ${{ vars.ZITI_EDGE_TUNNEL_IMAGE || 'docker.io/openziti/ziti-edge-tunnel' }}
       ZITI_HOST_IMAGE: ${{ vars.ZITI_HOST_IMAGE || 'docker.io/openziti/ziti-host' }}
     steps:
-      - name: Debug action
-        shell: bash
-        run: |
-          env | sort
-          cat "$GITHUB_EVENT_PATH"
-
       - name: Checkout Workspace
         uses: actions/checkout@v7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,6 @@ jobs:
     outputs:
       ZITI_VERSION: ${{ steps.get_version.outputs.ZITI_VERSION }}
     steps:
-      - name: Debug action
-        shell: bash
-        run: |
-          env | sort
-          cat "$GITHUB_EVENT_PATH"
-
       - name: download
         uses: actions/download-artifact@v8
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 
 set(ZITI_SDK_DIR "" CACHE FILEPATH "developer option: use local ziti-sdk-c checkout")
-set(ZITI_SDK_VERSION "1.18.5" CACHE STRING "ziti-sdk-c version or branch to use")
+set(ZITI_SDK_VERSION "1.18.7" CACHE STRING "ziti-sdk-c version or branch to use")
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 
 set(ZITI_SDK_DIR "" CACHE FILEPATH "developer option: use local ziti-sdk-c checkout")
-set(ZITI_SDK_VERSION "1.18.7" CACHE STRING "ziti-sdk-c version or branch to use")
+set(ZITI_SDK_VERSION "1.18.5" CACHE STRING "ziti-sdk-c version or branch to use")
 
 # if TUNNEL_SDK_ONLY then don't descend into programs/ziti-edge-tunnel
 option(TUNNEL_SDK_ONLY "build only ziti-tunnel-sdk (without ziti)" OFF)

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -159,6 +159,12 @@ sudo go test -v -tags slowtests -config config.json
 that withholds TOTP enrollment state, so those skip unless `ziti.auth` is `Legacy`. CI covers the whole set
 nightly in the `main-legacy-auth` topology (see `.github/workflows/nightly.yml`).
 
+`network_outage_test.go` is another: it shortens the controller's `edge.api.sessionTimeout` (restoring it when
+done), relays ZET's controller connection through an in-process TCP proxy, severs that proxy for longer than the
+shortened timeout so the api session actually expires server-side, then restores it and asserts ZET
+re-authenticates and reconnects rather than getting stuck. The proxy is plain Go, so this runs the same way on
+Linux, macOS, and Windows - no container or OS-specific network manipulation needed.
+
 ## Config reference
 
 The suite hard-requires only **`ziti.binary`** and **`zetA.binary`**; everything else depends on the mode.

--- a/tests/integration/network_outage_test.go
+++ b/tests/integration/network_outage_test.go
@@ -1,0 +1,353 @@
+//go:build slowtests
+
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Sits behind the slowtests tag (nightly, or locally via
+// `go test -tags slowtests -config config.json`) because it stands up its
+// own quickstart controller and its sever window alone must run several
+// minutes to outlast the shortened session/token lifetime.
+
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openziti/ziti-tunnel-sdk-c/tests/integration/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// The outage proxy sits at outageOverlayCtrlPort - the port everything
+	// (this harness's own ziti CLI calls, ZET) dials, and the same one
+	// embedded in enrollment JWTs / "/controllers" HA-endpoint-list
+	// responses, since edge.api.address is pointed there too (see
+	// testutil.Overlay.BindCtrlPort). The controller itself actually binds
+	// outageOverlayBindCtrlPort, a port nothing ever dials directly.
+	// Different from the shared overlay's 1280/3022 so both can run at once.
+	outageOverlayCtrlPort     = 11280
+	outageOverlayBindCtrlPort = 21280
+	outageOverlayRtrPort      = 13022
+
+	// The credential that must expire differs by auth path:
+	//   - OIDC: edge.api.sessionTimeout does NOT apply - an OIDC identity's
+	//     session lifetime is edge.oidc.accessTokenDuration/refreshTokenDuration
+	//     instead (30m/24h defaults, no line in the generated config to edit in
+	//     place - see testutil.PreconfigureOidcTokenDurations). accessTokenDuration
+	//     must be >= 1m; refreshTokenDuration must be >= accessTokenDuration + 1m
+	//     or the controller silently corrects it back toward the default.
+	//   - Legacy: edge.api.sessionTimeout is the right (and only) knob - see
+	//     testutil.PreconfigureSessionTimeout.
+	// outageExpiryWindow is used as refreshTokenDuration for OIDC or
+	// sessionTimeout for Legacy; both represent "how long before the
+	// credential that gates reconnect expires."
+	outageAccessTokenDuration = 1 * time.Minute
+	outageExpiryWindow        = 3 * time.Minute
+	// Comfortably longer than outageExpiryWindow so the credential has
+	// actually expired server-side by the time the network heals - this is
+	// what distinguishes the scenario from a shorter, still-valid outage.
+	outageSeverDuration = outageExpiryWindow + 90*time.Second
+	// How long to stay connected and healthy before severing - just enough
+	// for the initial connect to be confirmed stable, not tuned to accumulate
+	// refresh cycles (see the doc comment below for why: outageSeverDuration
+	// always outlasts outageExpiryWindow regardless of this value, so restore
+	// forces a full re-auth either way - the number of refresh cycles before
+	// the sever isn't what selects which bug fires).
+	outagePreSeverSettleDuration = 60 * time.Second
+	// Bound on just the post-restore reconnect wait, so a stuck-forever regression
+	// fails fast with a specific message instead of the generic outageTestTimeout.
+	outageRecoveryTimeout = 3 * time.Minute
+	// How long to watch the reconnect for an immediate flap before trusting it.
+	// Belt-and-suspenders alongside the proxy-only address below: a stray
+	// fallback connection would be expected to flap almost immediately, not
+	// stay up for several seconds.
+	outageSettleWindow = 10 * time.Second
+	// Dedicated-overlay setup + outagePreSeverSettleDuration + outageSeverDuration
+	// + outageRecoveryTimeout + outageSettleWindow, plus slack. Pass a matching
+	// -timeout to `go test` itself (its own default is 10m and would kill the
+	// process with a less useful goroutine dump before this fires).
+	outageTestTimeout = 25 * time.Minute
+	// The bug this test guards against needs many repeated failed
+	// reconnect/refresh attempts to manifest (field reports show hundreds
+	// over hours) - ZET's default 10s controller-refresh interval would only
+	// produce a couple dozen attempts in outageSeverDuration, so force it down
+	// to 1s via the -r flag to get closer to that order of magnitude.
+	outageRefreshIntervalArg = "1"
+)
+
+// TestOutageRecoveryAfterSessionExpiry drives ZET through a real
+// credential-expiring network outage: stand up a dedicated quickstart
+// controller (not the shared one - see below) already configured, before
+// its first real start, so it only ever advertises a relay's address rather
+// than its own; shorten its session/token lifetime for whichever auth path
+// this run is configured for; sever that relay for longer than the
+// credential's lifetime so it actually expires server-side; then restore
+// the network and assert ZET re-authenticates, reconnects, and stays
+// connected. Runs against both the OIDC and Legacy paths (nightly's
+// main/main-ha and main-legacy-auth topologies).
+//
+// This is a regression guard for
+// https://openziti.discourse.group/t/zet-does-not-recover-after-prolonged-controller-network-outage-once-api-session-expires/5993
+// - ziti-edge-tunnel getting permanently stuck in an unauthenticated retry
+// loop after a prolonged outage, only recovering on a manual restart. That
+// discourse report is a whole family of "never recovers" bugs, not one -
+// this test has already turned up two distinct ones, and the shape of the
+// outage (how long ZET ran normally before the partition hit) seems to be
+// what selects which one you get:
+//   - A short-lived pre-outage window (connect, then sever within ~1s -
+//     what this test originally did) reproduces a bug that's still open as
+//     of ziti-sdk-c 1.18.7: when a full OIDC re-auth attempt itself fails
+//     (not just a token refresh), oidc_auth_token_cb's OIDC_TOKEN_FAILED case
+//     (library/oidc.c) reports ZitiAuthStateUnauthenticated, and
+//     ztx_set_unauthenticated() (library/ziti.c) tears down session state
+//     but arms no retry/reschedule at all - permanently stuck. The sibling
+//     status ZitiAuthImpossibleToAuthenticate does have a retry
+//     (ztx_set_impossible_to_authenticate() calls ziti_re_auth() for
+//     UV_ECONNREFUSED/UV_EAI_NONAME), just not wired to this path. Confirmed
+//     via a real captured log: refresh_time_cb retries and reschedules
+//     correctly for ~168s, one of those retries falls back to a full
+//     oidc_client_start() that fails, and neither ever fires again for the
+//     rest of the capture (well past the actual network restore).
+//   - The field reports behind https://github.com/openziti/tlsuv/pull/367
+//     (tlsuv's OpenSSL/BoringSSL set_own_cert misuse on the SSL_CTX, shipped
+//     in tlsuv v0.42.4 / ziti-sdk-c 1.18.6+) accumulated hundreds of refresh
+//     cycles over hours before failing, which a short pre-outage window
+//     (outagePreSeverSettleDuration) never exercises. An earlier version of
+//     this test used a long (10m) settle window to try to reproduce that
+//     shape - since abandoned: outageSeverDuration always outlasts
+//     outageExpiryWindow regardless of the settle length, so restore forces
+//     a full re-auth either way, and the still-open bug above fires on any
+//     failed full re-auth - meaning settle length likely never was what
+//     selected between the two bugs. Still being verified as of this
+//     writing.
+//
+// Uses its own controller rather than the shared state.overlay, and needs
+// edge.api.address itself redirected to the proxy (testutil.Overlay.BindCtrlPort),
+// not just the identity file's ztAPI - both confirmed necessary the hard way:
+//   - Identity-file-only redirection isn't enough: ZET's own log showed live
+//     requests against the real controller address while the proxy was
+//     actively severed. A single-node quickstart still reports itself in
+//     "/controllers" HA-endpoint-list responses, so any client that has ever
+//     received one (including this test's own pre-sever connect) learns the
+//     real address and fails over to it directly once the proxied connection
+//     drops, bypassing the sever entirely.
+//   - Redirecting edge.api.address on the shared controller would risk the
+//     long-running zetClient/zetHost also learning and dialing the temporary
+//     proxy address, hence the dedicated controller.
+//   - The controller validates incoming requests' Host header against its
+//     own configured address, so simply pointing that address at the proxy
+//     while still binding/dialing the real port directly (for this harness's
+//     own admin CLI calls) breaks every such direct call - discovered as a
+//     redirect-URI 404 on admin login. BindCtrlPort resolves this: the proxy
+//     occupies the address everything (including admin CLI calls) actually
+//     dials, and the real controller binds a port nothing dials directly.
+//   - That, in turn, means the address has to be correct *before* the first
+//     real start - every restart's own readiness check dials through the
+//     proxy, so a start against a config that doesn't yet advertise the
+//     proxy's address breaks its own admin login. Hence
+//     GenerateConfig+Preconfigure* instead of Start+Set*: configure fully
+//     via a throwaway `--configure-and-exit` run first, then start for real
+//     exactly once.
+//
+// Deliberately does not wait for a "disconnected" controller event after
+// severing: that event is tied to ziti-sdk-c's own auth-context transitions
+// (TunnelEvent_ContextEvent), not to generic connectivity loss, and isn't
+// guaranteed to fire for every background reconnect failure during an
+// outage - waiting on it hung for the full outageTestTimeout in practice.
+// Waits for the edge router control channel's own "connected" event after
+// restore rather than the controller's (see WaitForRouterEvent's doc comment
+// for why) - every other suite here relies on the weaker controller signal,
+// which is fine for an initial connect but was observed firing (and then
+// immediately flapping) as a false positive during recovery from this exact
+// kind of outage.
+
+// keepArtifacts, if set via ZITI_OUTAGE_KEEP_ARTIFACTS, leaves the dedicated
+// overlay and zetOutage processes running (and their logs/identities on disk
+// at a fixed path, not a t.TempDir() that gets removed regardless) after the
+// test concludes, so a hang can be inspected live (lldb/sample) instead of
+// only having the ~10s flap-check window before normal cleanup kills
+// everything. Debugging aid only - unset for a real test run.
+var keepArtifacts = os.Getenv("ZITI_OUTAGE_KEEP_ARTIFACTS") != ""
+
+// outageArtifactDir is t.TempDir(), or a fixed, freshly-emptied directory
+// under keepArtifacts so it survives this process exiting.
+func outageArtifactDir(t *testing.T, name string) string {
+	t.Helper()
+	if !keepArtifacts {
+		return t.TempDir()
+	}
+	dir := filepath.Join(os.TempDir(), "ziti-outage-debug", name)
+	require.NoError(t, os.RemoveAll(dir), "clear stale debug artifact dir %s", dir)
+	require.NoError(t, os.MkdirAll(dir, 0o755), "create debug artifact dir %s", dir)
+	log.Printf("outage test: ZITI_OUTAGE_KEEP_ARTIFACTS set - %s will survive this run, and its process will not be stopped", dir)
+	return dir
+}
+
+func TestOutageRecoveryAfterSessionExpiry(t *testing.T) {
+	testutil.RunWithTimeoutOf(t, outageTestTimeout, func(t *testing.T) {
+		overlay := &testutil.Overlay{
+			ZitiBin:            state.overlay.ZitiBin,
+			Home:               filepath.Join(outageArtifactDir(t, "overlay"), "overlay"),
+			ControllerUser:     state.overlay.ControllerUser,
+			ControllerPassword: state.overlay.ControllerPassword,
+			Auth:               state.overlay.Auth,
+			CtrlPort:           outageOverlayCtrlPort,
+			BindCtrlPort:       outageOverlayBindCtrlPort,
+			RtrPort:            outageOverlayRtrPort,
+			Done:               make(chan error, 1),
+		}
+		if !keepArtifacts {
+			t.Cleanup(overlay.Stop) // safe no-op if Start never succeeds
+		}
+
+		require.NoError(t, overlay.GenerateConfig(), "generate outage overlay config")
+
+		switch overlay.Auth {
+		case testutil.AuthOIDC:
+			overlay.PreconfigureOidcTokenDurations(t, outageAccessTokenDuration, outageExpiryWindow)
+		case testutil.AuthLegacy:
+			overlay.PreconfigureDisableOidc(t)
+			overlay.PreconfigureSessionTimeout(t, outageExpiryWindow)
+		default:
+			t.Fatalf("unknown ziti.auth %q", overlay.Auth)
+		}
+
+		proxy := testutil.StartOutageProxy(t,
+			fmt.Sprintf("127.0.0.1:%d", outageOverlayCtrlPort),
+			fmt.Sprintf("localhost:%d", outageOverlayBindCtrlPort))
+		overlay.PreconfigureEdgeApiAddress(t, proxy.Addr)
+
+		require.NoError(t, overlay.Start(), "start outage overlay")
+
+		zet := &testutil.ZET{
+			BinPath:       state.zetClient.BinPath,
+			Discriminator: "zetOutage",
+			RootDir:       outageArtifactDir(t, "zet"),
+			Verbosity:     state.zetClient.Verbosity,
+			ExtraArgs:     []string{"-r", outageRefreshIntervalArg},
+			DetachSession: keepArtifacts,
+		}
+		require.NoError(t, zet.Start())
+		if !keepArtifacts {
+			// t.Cleanup, not defer: if the recovery wait below ever hangs instead of
+			// returning (e.g. a bug in this test itself), a plain defer here would
+			// never run - it's registered on this goroutine, which RunWithTimeoutOf
+			// abandons rather than unwinds once its own outer timeout fires.
+			// t.Cleanup runs regardless, once the test concludes.
+			t.Cleanup(zet.Stop)
+		}
+
+		const idName = "test_outage_recovery"
+		jwt, err := overlay.CreateIdentityJWT(idName)
+		require.NoError(t, err, "create identity %s", idName)
+		added := testutil.EnrollJwt(t, zet, idName, jwt)
+		zet.WaitForControllerEvent(t, "connected", idName)
+		log.Printf("outage test: initial connect confirmed for %s", idName)
+
+		// Belt-and-suspenders: redirect the identity's own on-disk ztAPI too, in
+		// case enrollment ever embeds a different address than the configured
+		// edge.api.address. Stop first: ZET rewrites its own identity file
+		// around connect events, so doctoring it while the process is still
+		// running races that.
+		zet.Stop()
+		redirectIdentityThroughOutageProxy(t, added.Id.Identifier, proxy.Addr)
+		require.NoError(t, zet.Start(), "restart zet after redirect\n%s", zet.LogFile())
+		zet.WaitForControllerEvent(t, "connected", idName)
+		log.Printf("outage test: connect-through-proxy confirmed for %s", idName)
+
+		log.Printf("outage test: staying connected for %s before severing, so several real access-token "+
+			"refresh cycles (~1/%s) elapse first", outagePreSeverSettleDuration, outageAccessTokenDuration)
+		for remaining := outagePreSeverSettleDuration; remaining > 0; {
+			step := time.Minute
+			if remaining < step {
+				step = remaining
+			}
+			time.Sleep(step)
+			remaining -= step
+			log.Printf("outage test: settling, %s remaining before sever", remaining)
+		}
+
+		log.Printf("outage test: severing network to the controller for %s (auth=%s, expiry window %s)", outageSeverDuration, overlay.Auth, outageExpiryWindow)
+		proxy.Sever()
+
+		log.Printf("outage test: sleeping %s so the session/token actually expires server-side", outageSeverDuration)
+		time.Sleep(outageSeverDuration)
+
+		log.Printf("outage test: restoring network to the controller; waiting up to %s for reconnect", outageRecoveryTimeout)
+		proxy.Restore()
+
+		// SkipToNow is required, not just tidy: nothing before this point ever
+		// waits for a router event (only the pre-sever controller "connected"
+		// checks), so the router's own initial "connected"/"added" events from
+		// the very first connect - and its mid-outage "disconnected" - are
+		// still sitting unconsumed in the buffer. Without this, the waits
+		// below would match those stale events instantly instead of waiting
+		// for anything that actually happens after restore - see
+		// EventClient.SkipToNow's doc comment; this is exactly how the
+		// "flap" this test used to report turned out to be fake.
+		zet.SkipToNow()
+
+		// Deliberately not gating on the controller "connected" event here: it
+		// fires the moment any single controller HTTP call succeeds (see
+		// WaitForControllerEvent's doc comment) regardless of the edge router
+		// control channel's own state, and was observed firing (and then
+		// immediately flapping) while the router channel was still stuck
+		// "not fully authenticated" - a false-positive recovery signal. The
+		// router channel is what's actually gated behind a full re-auth
+		// (channel.c reconnect_cb) and what the regression this test guards
+		// against leaves permanently stuck, so it's the signal to trust.
+		ev, ok := zet.WaitForRouterEventWithin(t, "connected", idName, outageRecoveryTimeout)
+		require.True(t, ok, "the edge router control channel did not reconnect within %s of the network being restored - "+
+			"this is the regression this test guards against (see the doc comment above)", outageRecoveryTimeout)
+		log.Printf("outage test: reconnected after restore: %+v; watching %s for an immediate flap", ev, outageSettleWindow)
+
+		_, flapped := zet.WaitForRouterEventWithin(t, "disconnected", idName, outageSettleWindow)
+		require.False(t, flapped, "edge router disconnected again within %s of reconnecting - the reconnect was not stable", outageSettleWindow)
+		log.Printf("outage test: reconnect held stable for %s", outageSettleWindow)
+	})
+}
+
+// redirectIdentityThroughOutageProxy rewrites ztAPI/ztAPIs in the identity file
+// at path so they point at addr instead of the real controller, preserving
+// each URL's original scheme and path. Mirrors
+// controller_retry_storm_test.go's redirectToDeadController.
+func redirectIdentityThroughOutageProxy(t *testing.T, path, addr string) {
+	t.Helper()
+	content := testutil.ReadIdentityFile(t, path)
+
+	redirect := func(raw string) string {
+		u, err := url.Parse(raw)
+		require.NoError(t, err, "parse identity file URL %q", raw)
+		u.Host = addr
+		return u.String()
+	}
+
+	content.ZtAPI = redirect(content.ZtAPI)
+	for i, api := range content.ZtAPIs {
+		content.ZtAPIs[i] = redirect(api)
+	}
+
+	raw, err := json.Marshal(content)
+	require.NoError(t, err, "marshal doctored identity file")
+	require.NoError(t, os.WriteFile(path, raw, 0o600), "write doctored identity file %s", path)
+}

--- a/tests/integration/network_outage_test.go
+++ b/tests/integration/network_outage_test.go
@@ -87,11 +87,11 @@ const (
 	// -timeout to `go test` itself (its own default is 10m and would kill the
 	// process with a less useful goroutine dump before this fires).
 	outageTestTimeout = 25 * time.Minute
-	// The bug this test guards against needs many repeated failed
-	// reconnect/refresh attempts to manifest (field reports show hundreds
-	// over hours) - ZET's default 10s controller-refresh interval would only
-	// produce a couple dozen attempts in outageSeverDuration, so force it down
-	// to 1s via the -r flag to get closer to that order of magnitude.
+	// Forces a service-refresh (and so a fresh reconnect attempt) about once a
+	// second instead of ZET's default 10s, so outageRecoveryTimeout only has
+	// to be long enough for real timeouts to elapse a handful of times, not
+	// long enough to also cover a slow retry cadence on top of that. See the
+	// doc comment above for why cycle count itself turned out not to matter.
 	outageRefreshIntervalArg = "1"
 )
 
@@ -109,37 +109,48 @@ const (
 // This is a regression guard for
 // https://openziti.discourse.group/t/zet-does-not-recover-after-prolonged-controller-network-outage-once-api-session-expires/5993
 // - ziti-edge-tunnel getting permanently stuck in an unauthenticated retry
-// loop after a prolonged outage, only recovering on a manual restart. That
-// discourse report is a whole family of "never recovers" bugs, not one -
-// this test has already turned up two distinct ones, and the shape of the
-// outage (how long ZET ran normally before the partition hit) seems to be
-// what selects which one you get:
-//   - A short-lived pre-outage window (connect, then sever within ~1s -
-//     what this test originally did) reproduces a bug that's still open as
-//     of ziti-sdk-c 1.18.7: when a full OIDC re-auth attempt itself fails
-//     (not just a token refresh), oidc_auth_token_cb's OIDC_TOKEN_FAILED case
-//     (library/oidc.c) reports ZitiAuthStateUnauthenticated, and
-//     ztx_set_unauthenticated() (library/ziti.c) tears down session state
-//     but arms no retry/reschedule at all - permanently stuck. The sibling
-//     status ZitiAuthImpossibleToAuthenticate does have a retry
-//     (ztx_set_impossible_to_authenticate() calls ziti_re_auth() for
-//     UV_ECONNREFUSED/UV_EAI_NONAME), just not wired to this path. Confirmed
-//     via a real captured log: refresh_time_cb retries and reschedules
-//     correctly for ~168s, one of those retries falls back to a full
-//     oidc_client_start() that fails, and neither ever fires again for the
-//     rest of the capture (well past the actual network restore).
-//   - The field reports behind https://github.com/openziti/tlsuv/pull/367
-//     (tlsuv's OpenSSL/BoringSSL set_own_cert misuse on the SSL_CTX, shipped
-//     in tlsuv v0.42.4 / ziti-sdk-c 1.18.6+) accumulated hundreds of refresh
-//     cycles over hours before failing, which a short pre-outage window
-//     (outagePreSeverSettleDuration) never exercises. An earlier version of
-//     this test used a long (10m) settle window to try to reproduce that
-//     shape - since abandoned: outageSeverDuration always outlasts
-//     outageExpiryWindow regardless of the settle length, so restore forces
-//     a full re-auth either way, and the still-open bug above fires on any
-//     failed full re-auth - meaning settle length likely never was what
-//     selected between the two bugs. Still being verified as of this
-//     writing.
+// loop after a prolonged outage, only recovering on a manual restart. The
+// confirmed root cause is https://github.com/openziti/tlsuv/pull/367 (tlsuv's
+// OpenSSL/BoringSSL set_own_cert misuse on the SSL_CTX), fixed in tlsuv
+// v0.42.4 / ziti-sdk-c 1.18.6+.
+//
+// Getting this test to actually reproduce the bug took several wrong turns,
+// worth recording so they don't get re-tried:
+//   - Cycle count/exposure time is NOT what selects it. An earlier version of
+//     this test used a 10-minute pre-sever settle window on the theory that
+//     the bug needed many accumulated refresh cycles to manifest (real field
+//     reports took hours). That theory was wrong: outagePreSeverSettleDuration
+//     is now a minimal 60s (just enough to confirm the initial connect is
+//     stable) and the bug still reproduces reliably.
+//   - What actually matters is how OutageProxy models the outage. It
+//     originally simulated Sever by actively resetting every connection
+//     (SO_LINGER=0 + Close) - fast, clean, deterministic feedback to the
+//     client. That turned out to be the problem: a client that gets an
+//     immediate RST recovers too cleanly to ever hit the bug. Confirmed by a
+//     side-by-side comparison against a podman container with its network
+//     interface disabled (a genuine black hole, no RST) - 1.18.5 (pre-fix)
+//     reliably failed to recover against the container, but passed against
+//     this proxy's old RST-based Sever every time. OutageProxy now
+//     black-holes instead (see its own doc comment) - bytes just stop moving,
+//     no RST/FIN, so the client only finds out via its own read/write
+//     timeouts, same as a real partition. With that change, 1.18.5 reliably
+//     times out in outageRecoveryTimeout and 1.18.7 reliably recovers
+//     (slower than the old RST-based proxy - tens of seconds to over a
+//     minute, since real timeouts have to elapse - but well within budget).
+//   - A separate, still-open bug exists too: when a full OIDC re-auth attempt
+//     itself fails (not just a token refresh), oidc_auth_token_cb's
+//     OIDC_TOKEN_FAILED case (library/oidc.c) reports
+//     ZitiAuthStateUnauthenticated, and ztx_set_unauthenticated()
+//     (library/ziti.c) tears down session state but arms no retry/reschedule
+//     on that specific path - confirmed live against a real, permanently-
+//     stuck field specimen. This test does not appear to hit it: the -r 1
+//     flag (see outageRefreshIntervalArg) forces a service-refresh cycle
+//     every second, and that cycle independently re-triggers a fresh full
+//     OIDC attempt each time regardless of what ztx_set_unauthenticated did
+//     or didn't arm, which is likely why 1.18.5's failures here are
+//     "retries forever, never succeeds" rather than "stops retrying
+//     entirely." If a future run ever shows retry activity actually stopping
+//     before outageRecoveryTimeout elapses, that's this bug, not tlsuv#367.
 //
 // Uses its own controller rather than the shared state.overlay, and needs
 // edge.api.address itself redirected to the proxy (testutil.Overlay.BindCtrlPort),

--- a/tests/integration/network_outage_test.go
+++ b/tests/integration/network_outage_test.go
@@ -200,17 +200,32 @@ const (
 // everything. Debugging aid only - unset for a real test run.
 var keepArtifacts = os.Getenv("ZITI_OUTAGE_KEEP_ARTIFACTS") != ""
 
-// outageArtifactDir is t.TempDir(), or a fixed, freshly-emptied directory
-// under keepArtifacts so it survives this process exiting.
+// outageArtifactDir is a fixed, freshly-emptied directory under
+// keepArtifacts so it (and its process) survives this test process exiting;
+// otherwise a temp directory that's removed unless the test fails, so a CI
+// run - which can't attach a debugger the way ZITI_OUTAGE_KEEP_ARTIFACTS is
+// for - still has the zet/controller logs to inspect afterward. Not
+// t.TempDir(): its cleanup is unconditional, with no way to skip it on
+// failure.
 func outageArtifactDir(t *testing.T, name string) string {
 	t.Helper()
-	if !keepArtifacts {
-		return t.TempDir()
+	if keepArtifacts {
+		dir := filepath.Join(os.TempDir(), "ziti-outage-debug", name)
+		require.NoError(t, os.RemoveAll(dir), "clear stale debug artifact dir %s", dir)
+		require.NoError(t, os.MkdirAll(dir, 0o755), "create debug artifact dir %s", dir)
+		log.Printf("outage test: ZITI_OUTAGE_KEEP_ARTIFACTS set - %s will survive this run, and its process will not be stopped", dir)
+		return dir
 	}
-	dir := filepath.Join(os.TempDir(), "ziti-outage-debug", name)
-	require.NoError(t, os.RemoveAll(dir), "clear stale debug artifact dir %s", dir)
-	require.NoError(t, os.MkdirAll(dir, 0o755), "create debug artifact dir %s", dir)
-	log.Printf("outage test: ZITI_OUTAGE_KEEP_ARTIFACTS set - %s will survive this run, and its process will not be stopped", dir)
+
+	dir, err := os.MkdirTemp("", "ziti-outage-"+name+"-")
+	require.NoError(t, err, "create temp dir for %s", name)
+	t.Cleanup(func() {
+		if t.Failed() {
+			log.Printf("outage test: %s failed - preserving %s for inspection", t.Name(), dir)
+			return
+		}
+		_ = os.RemoveAll(dir)
+	})
 	return dir
 }
 
@@ -226,6 +241,7 @@ func TestOutageRecoveryAfterSessionExpiry(t *testing.T) {
 			BindCtrlPort:       outageOverlayBindCtrlPort,
 			RtrPort:            outageOverlayRtrPort,
 			Done:               make(chan error, 1),
+			DetachSession:      keepArtifacts,
 		}
 		if !keepArtifacts {
 			t.Cleanup(overlay.Stop) // safe no-op if Start never succeeds
@@ -245,7 +261,8 @@ func TestOutageRecoveryAfterSessionExpiry(t *testing.T) {
 
 		proxy := testutil.StartOutageProxy(t,
 			fmt.Sprintf("127.0.0.1:%d", outageOverlayCtrlPort),
-			fmt.Sprintf("localhost:%d", outageOverlayBindCtrlPort))
+			fmt.Sprintf("localhost:%d", outageOverlayBindCtrlPort),
+			keepArtifacts)
 		overlay.PreconfigureEdgeApiAddress(t, proxy.Addr)
 
 		require.NoError(t, overlay.Start(), "start outage overlay")

--- a/tests/integration/testutil/ipc.go
+++ b/tests/integration/testutil/ipc.go
@@ -190,6 +190,23 @@ func (c *EventClient) subscribe() (chan struct{}, int, func()) {
 	}
 }
 
+// SkipToNow advances this client's cursor past every event buffered so far,
+// so a subsequent WaitForXEvent(Within) call can only match a genuinely new
+// event, never one already sitting in the buffer from earlier in the run.
+// Needed because the cursor is shared across every op/action combination:
+// waiting for one (op, action, fingerprint) never consumes a *different*
+// (op, action, fingerprint) that happened to arrive in the same window, so it
+// stays in the buffer, "ahead" of the cursor, indefinitely - discovered the
+// hard way when a post-restore wait for a router "connected" event matched
+// instantly, on the router's *initial* connect event from minutes earlier,
+// because nothing had ever waited for (and thus consumed) a router event
+// before that point.
+func (c *EventClient) SkipToNow() {
+	c.mu.Lock()
+	c.cursor = len(c.events)
+	c.mu.Unlock()
+}
+
 // waitForEvent blocks until the next event matching op/action/fingerprint
 // arrives, advances past it, and returns its raw JSON. Blocks indefinitely;
 // rely on the per-test timeout if the event never comes.
@@ -219,6 +236,50 @@ func (c *EventClient) waitForEvent(t *testing.T, op, action, fingerprint string)
 	}
 }
 
+// waitForEventWithin is waitForEvent bounded by within: returns ok=false on
+// timeout instead of blocking indefinitely. Runs entirely on the calling
+// goroutine (via a select against notify and a deadline timer), unlike a
+// goroutine+channel-based bounded wait would - that shape was tried and
+// dropped because the spawned goroutine can call require/t.Fatal-triggering
+// code (the readErr branch below), and testing.T does not support that from
+// any goroutine but the one running the test: FailNow only unwinds the
+// calling goroutine via runtime.Goexit(), and a goroutine that outlives its
+// caller's timeout (still blocked here, now abandoned) hitting a real
+// readErr later - e.g. when the process/connection it was waiting on finally
+// goes away - can panic the whole test binary if that fires after the test
+// has otherwise concluded.
+func (c *EventClient) waitForEventWithin(t *testing.T, op, action, fingerprint string, within time.Duration) (json.RawMessage, bool) {
+	t.Helper()
+	notify, cursor, unsubscribe := c.subscribe()
+	defer unsubscribe()
+
+	deadline := time.After(within)
+	for {
+		c.mu.Lock()
+		events := c.events
+		readErr := c.readErr
+		c.mu.Unlock()
+		for ; cursor < len(events); cursor++ {
+			e := events[cursor]
+			if e.op == op && e.action == action && e.fingerprint == fingerprint {
+				c.mu.Lock()
+				c.cursor = cursor + 1
+				c.mu.Unlock()
+				return e.raw, true
+			}
+		}
+		if readErr != nil {
+			require.NoError(t, readErr, "event reader exited waiting for %s:%s/%s after %d events", op, action, fingerprint, cursor)
+			return nil, false
+		}
+		select {
+		case <-notify:
+		case <-deadline:
+			return nil, false
+		}
+	}
+}
+
 // WaitForIdentity waits for an Op:"identity" event matching action/fingerprint.
 func (c *EventClient) WaitForIdentityEvent(t *testing.T, action, fingerprint string) IdentityEvent {
 	raw := c.waitForEvent(t, "identity", action, fingerprint)
@@ -229,11 +290,58 @@ func (c *EventClient) WaitForIdentityEvent(t *testing.T, action, fingerprint str
 }
 
 // WaitForController waits for an Op:"controller" event matching action/fingerprint.
+//
+// This only reflects ztx->ctrl_status (ziti.c update_ctrl_status), which flips to
+// "connected" the moment any single controller HTTP call succeeds (e.g. a service-list
+// refresh) - it says nothing about the edge router control channel, which is gated
+// behind its own full re-auth check (channel.c reconnect_cb) and is what actually
+// carries traffic. Use WaitForRouterEvent for a signal that the tunnel is usable.
 func (c *EventClient) WaitForControllerEvent(t *testing.T, action, fingerprint string) ActionEvent {
 	raw := c.waitForEvent(t, "controller", action, fingerprint)
 	var ev ActionEvent
 	require.NoError(t, json.Unmarshal(raw, &ev), "parse controller ActionEvent: %s", raw)
 	return ev
+}
+
+// WaitForRouterEvent waits for an Op:"router" event matching action/fingerprint - the
+// edge router control channel's own connect/disconnect. Unlike WaitForControllerEvent,
+// this is gated behind a full ztx re-auth (channel.c reconnect_cb bails with "is not
+// fully authenticated" while auth_state isn't ZitiAuthStateFullyAuthenticated), so it
+// reflects whether the tunnel can actually carry traffic, not just whether one
+// controller HTTP call happened to succeed.
+func (c *EventClient) WaitForRouterEvent(t *testing.T, action, fingerprint string) ActionEvent {
+	raw := c.waitForEvent(t, "router", action, fingerprint)
+	var ev ActionEvent
+	require.NoError(t, json.Unmarshal(raw, &ev), "parse router ActionEvent: %s", raw)
+	return ev
+}
+
+// WaitForControllerEventWithin is WaitForControllerEvent bounded by within;
+// see waitForEventWithin for why this, not a goroutine+timeout wrapper around
+// WaitForControllerEvent, is the safe way to bound an event wait. Returns
+// ok=false on timeout rather than failing t.
+func (c *EventClient) WaitForControllerEventWithin(t *testing.T, action, fingerprint string, within time.Duration) (ActionEvent, bool) {
+	t.Helper()
+	raw, ok := c.waitForEventWithin(t, "controller", action, fingerprint, within)
+	if !ok {
+		return ActionEvent{}, false
+	}
+	var ev ActionEvent
+	require.NoError(t, json.Unmarshal(raw, &ev), "parse controller ActionEvent: %s", raw)
+	return ev, true
+}
+
+// WaitForRouterEventWithin is WaitForRouterEvent bounded by within - see
+// waitForEventWithin and WaitForControllerEventWithin.
+func (c *EventClient) WaitForRouterEventWithin(t *testing.T, action, fingerprint string, within time.Duration) (ActionEvent, bool) {
+	t.Helper()
+	raw, ok := c.waitForEventWithin(t, "router", action, fingerprint, within)
+	if !ok {
+		return ActionEvent{}, false
+	}
+	var ev ActionEvent
+	require.NoError(t, json.Unmarshal(raw, &ev), "parse router ActionEvent: %s", raw)
+	return ev, true
 }
 
 // WaitForMfa waits for an Op:"mfa" event matching action/fingerprint.

--- a/tests/integration/testutil/outageproxy.go
+++ b/tests/integration/testutil/outageproxy.go
@@ -64,7 +64,10 @@ type OutageProxy struct {
 }
 
 // StartOutageProxy starts relaying listenAddr -> target and returns once
-// listening. Registers cleanup with t.
+// listening. Registers cleanup with t, unless keepAlive is true - a
+// debugging aid so the proxy (and so the connections routed through it)
+// survives past the end of the test for live inspection; pass false for a
+// real test run, so an interrupted run doesn't leak the listener.
 //
 // listenAddr is a "host:port" or "host:0" (OS-assigned port) to bind - pass
 // a fixed port when something else (e.g. Overlay.CtrlPort, matched with
@@ -77,7 +80,7 @@ type OutageProxy struct {
 // against it, and "127.0.0.1" and "localhost" are different strings for
 // that exact-match purpose even though they resolve to the same loopback
 // address - discovered the hard way as a broken admin login.
-func StartOutageProxy(t *testing.T, listenAddr, target string) *OutageProxy {
+func StartOutageProxy(t *testing.T, listenAddr, target string, keepAlive bool) *OutageProxy {
 	t.Helper()
 	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
@@ -87,7 +90,9 @@ func StartOutageProxy(t *testing.T, listenAddr, target string) *OutageProxy {
 
 	p := &OutageProxy{Addr: addr, target: target, conns: make(map[net.Conn]struct{}), held: make(map[net.Conn]struct{}), ln: ln}
 	go p.acceptLoop()
-	t.Cleanup(func() { _ = ln.Close() })
+	if !keepAlive {
+		t.Cleanup(func() { _ = ln.Close() })
+	}
 	return p
 }
 

--- a/tests/integration/testutil/outageproxy.go
+++ b/tests/integration/testutil/outageproxy.go
@@ -1,0 +1,163 @@
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// OutageProxy is a TCP relay that stands in for a target address (typically
+// the overlay's controller) so a test can simulate a network outage on
+// demand. It is pure Go so it works the same way on every OS this suite
+// targets, unlike an external chaos-proxy tool or container-network tricks.
+//
+// Sever immediately drops every connection currently relayed and refuses
+// every new one for as long as it's severed - a client that reuses a
+// persistent connection and just queues requests on it while the network is
+// down would never actually notice the outage or attempt to reconnect, and
+// the whole point is to force real reconnect attempts (repeatedly, against
+// an unreachable endpoint) the way a real outage does. Restore resumes
+// accepting and relaying normally.
+type OutageProxy struct {
+	Addr string
+
+	target  string
+	ln      net.Listener
+	severed atomic.Bool
+
+	mu    sync.Mutex
+	conns map[net.Conn]struct{}
+}
+
+// StartOutageProxy starts relaying listenAddr -> target and returns once
+// listening. Registers cleanup with t.
+//
+// listenAddr is a "host:port" or "host:0" (OS-assigned port) to bind - pass
+// a fixed port when something else (e.g. Overlay.CtrlPort, matched with
+// Overlay.BindCtrlPort routing the real controller elsewhere) needs to know
+// the proxy's address in advance, before it's actually started.
+//
+// Addr is reported as "localhost:<port>", not the raw listenAddr host if
+// that was an IP: a controller whose edge.api.address is set to this Addr
+// (see Overlay.SetEdgeApiAddress) validates incoming requests' Host header
+// against it, and "127.0.0.1" and "localhost" are different strings for
+// that exact-match purpose even though they resolve to the same loopback
+// address - discovered the hard way as a broken admin login.
+func StartOutageProxy(t *testing.T, listenAddr, target string) *OutageProxy {
+	t.Helper()
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		t.Fatalf("listen tcp %s for outage proxy: %v", listenAddr, err)
+	}
+	addr := fmt.Sprintf("localhost:%d", ln.Addr().(*net.TCPAddr).Port)
+
+	p := &OutageProxy{Addr: addr, target: target, ln: ln, conns: make(map[net.Conn]struct{})}
+	go p.acceptLoop()
+	t.Cleanup(func() { _ = ln.Close() })
+	return p
+}
+
+// Sever begins simulating an outage: every connection currently relayed is
+// closed (RST, not a graceful FIN - see resetClose) and every new inbound
+// connection is refused the same way until Restore.
+func (p *OutageProxy) Sever() {
+	p.severed.Store(true)
+
+	p.mu.Lock()
+	conns := make([]net.Conn, 0, len(p.conns))
+	for c := range p.conns {
+		conns = append(conns, c)
+	}
+	p.mu.Unlock()
+	for _, c := range conns {
+		resetClose(c)
+	}
+	log.Printf("outageproxy: severed %s -> %s (dropped %d connection(s))", p.Addr, p.target, len(conns))
+}
+
+// Restore ends the simulated outage: new connections are accepted and
+// relayed again.
+func (p *OutageProxy) Restore() {
+	p.severed.Store(false)
+	log.Printf("outageproxy: restored %s -> %s", p.Addr, p.target)
+}
+
+func (p *OutageProxy) acceptLoop() {
+	for {
+		conn, err := p.ln.Accept()
+		if err != nil {
+			return
+		}
+		if p.severed.Load() {
+			// a real outage also means fresh connection attempts don't land.
+			resetClose(conn)
+			continue
+		}
+		upstream, err := net.Dial("tcp", p.target)
+		if err != nil {
+			resetClose(conn)
+			continue
+		}
+		p.mu.Lock()
+		p.conns[conn] = struct{}{}
+		p.conns[upstream] = struct{}{}
+		p.mu.Unlock()
+		go p.relay(conn, upstream)
+		go p.relay(upstream, conn)
+	}
+}
+
+// relay copies src -> dst until either side closes or errors, then closes
+// and untracks both.
+func (p *OutageProxy) relay(dst, src net.Conn) {
+	defer func() {
+		_ = dst.Close()
+		_ = src.Close()
+		p.mu.Lock()
+		delete(p.conns, dst)
+		delete(p.conns, src)
+		p.mu.Unlock()
+	}()
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// resetClose closes conn with SO_LINGER=0, forcing an RST instead of a
+// graceful FIN so the peer's TLS handshake or read fails immediately
+// (ECONNRESET) rather than sitting on a timeout waiting for a peer that
+// closed cleanly. Mirrors DeadController's technique.
+func resetClose(conn net.Conn) {
+	if tc, ok := conn.(*net.TCPConn); ok {
+		_ = tc.SetLinger(0)
+	}
+	_ = conn.Close()
+}

--- a/tests/integration/testutil/outageproxy.go
+++ b/tests/integration/testutil/outageproxy.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // OutageProxy is a TCP relay that stands in for a target address (typically
@@ -30,13 +31,24 @@ import (
 // demand. It is pure Go so it works the same way on every OS this suite
 // targets, unlike an external chaos-proxy tool or container-network tricks.
 //
-// Sever immediately drops every connection currently relayed and refuses
-// every new one for as long as it's severed - a client that reuses a
-// persistent connection and just queues requests on it while the network is
-// down would never actually notice the outage or attempt to reconnect, and
-// the whole point is to force real reconnect attempts (repeatedly, against
-// an unreachable endpoint) the way a real outage does. Restore resumes
-// accepting and relaying normally.
+// Sever black-holes traffic rather than resetting it: bytes already in
+// flight on a connection open at the moment of Sever just stop moving (the
+// socket is never closed), and a new inbound TCP connection is accepted -
+// completing the handshake, since a pure-Go listener can't silently drop a
+// SYN the way a real severed link does - but then held open and never dialed
+// upstream, so it never receives a byte either. Either way, the peer gets no
+// RST, no FIN, no data - it only ever finds out via its own read/write
+// timeouts, same as a real partition (packets simply stop arriving). Restore
+// dials upstream for every held connection and resumes relaying on both.
+//
+// This used to actively RST everything on Sever (SO_LINGER=0 + Close, see
+// git history) for fast, deterministic reconnect attempts - but that gives a
+// client immediate, clean feedback that a real outage never does, and a real
+// bug (openziti/tlsuv#367) turned out to depend on that difference: it
+// reproduces against a genuinely black-holed connection (confirmed against a
+// podman container with its network interface disabled) but not against this
+// proxy's old RST-based Sever, which apparently let clients recover too
+// cleanly to hit whatever stale state the bug needs.
 type OutageProxy struct {
 	Addr string
 
@@ -46,6 +58,9 @@ type OutageProxy struct {
 
 	mu    sync.Mutex
 	conns map[net.Conn]struct{}
+	// held is the set of inbound connections accepted while severed - kept
+	// open but never dialed upstream until Restore.
+	held map[net.Conn]struct{}
 }
 
 // StartOutageProxy starts relaying listenAddr -> target and returns once
@@ -70,35 +85,42 @@ func StartOutageProxy(t *testing.T, listenAddr, target string) *OutageProxy {
 	}
 	addr := fmt.Sprintf("localhost:%d", ln.Addr().(*net.TCPAddr).Port)
 
-	p := &OutageProxy{Addr: addr, target: target, ln: ln, conns: make(map[net.Conn]struct{})}
+	p := &OutageProxy{Addr: addr, target: target, conns: make(map[net.Conn]struct{}), held: make(map[net.Conn]struct{}), ln: ln}
 	go p.acceptLoop()
 	t.Cleanup(func() { _ = ln.Close() })
 	return p
 }
 
-// Sever begins simulating an outage: every connection currently relayed is
-// closed (RST, not a graceful FIN - see resetClose) and every new inbound
-// connection is refused the same way until Restore.
+// Sever begins simulating an outage: nothing is closed. Bytes on connections
+// already open just stop moving (see relay), and any new inbound connection
+// gets accepted but held, unrelayed, until Restore - see the type doc for why
+// this, not an active RST, is what's needed to reproduce openziti/tlsuv#367.
 func (p *OutageProxy) Sever() {
 	p.severed.Store(true)
-
 	p.mu.Lock()
-	conns := make([]net.Conn, 0, len(p.conns))
-	for c := range p.conns {
-		conns = append(conns, c)
-	}
+	n := len(p.conns)
 	p.mu.Unlock()
-	for _, c := range conns {
-		resetClose(c)
-	}
-	log.Printf("outageproxy: severed %s -> %s (dropped %d connection(s))", p.Addr, p.target, len(conns))
+	log.Printf("outageproxy: severed %s -> %s (black-holing %d already-open connection(s), holding new ones unrelayed)", p.Addr, p.target, n)
 }
 
-// Restore ends the simulated outage: new connections are accepted and
-// relayed again.
+// Restore ends the simulated outage: relaying resumes on connections that
+// were open throughout, and every held connection is dialed upstream and
+// relayed for the first time.
 func (p *OutageProxy) Restore() {
 	p.severed.Store(false)
-	log.Printf("outageproxy: restored %s -> %s", p.Addr, p.target)
+
+	p.mu.Lock()
+	held := make([]net.Conn, 0, len(p.held))
+	for c := range p.held {
+		held = append(held, c)
+	}
+	p.held = make(map[net.Conn]struct{})
+	p.mu.Unlock()
+
+	for _, conn := range held {
+		p.dialAndRelay(conn)
+	}
+	log.Printf("outageproxy: restored %s -> %s (%d held connection(s) now relaying)", p.Addr, p.target, len(held))
 }
 
 func (p *OutageProxy) acceptLoop() {
@@ -108,26 +130,41 @@ func (p *OutageProxy) acceptLoop() {
 			return
 		}
 		if p.severed.Load() {
-			// a real outage also means fresh connection attempts don't land.
-			resetClose(conn)
+			// Hold silently: no dial, no data, no close - the peer only
+			// learns something's wrong from its own timeouts, same as a real
+			// black hole. Restore dials and relays it.
+			p.mu.Lock()
+			p.held[conn] = struct{}{}
+			p.mu.Unlock()
 			continue
 		}
-		upstream, err := net.Dial("tcp", p.target)
-		if err != nil {
-			resetClose(conn)
-			continue
-		}
-		p.mu.Lock()
-		p.conns[conn] = struct{}{}
-		p.conns[upstream] = struct{}{}
-		p.mu.Unlock()
-		go p.relay(conn, upstream)
-		go p.relay(upstream, conn)
+		p.dialAndRelay(conn)
 	}
 }
 
+// dialAndRelay dials upstream for conn and starts relaying both directions.
+// conn is closed (not held or tracked) if the dial itself fails - a dial
+// failure means the upstream controller is unreachable, not a simulated
+// outage, and every caller already only reaches this while not severed.
+func (p *OutageProxy) dialAndRelay(conn net.Conn) {
+	upstream, err := net.Dial("tcp", p.target)
+	if err != nil {
+		_ = conn.Close()
+		return
+	}
+	p.mu.Lock()
+	p.conns[conn] = struct{}{}
+	p.conns[upstream] = struct{}{}
+	p.mu.Unlock()
+	go p.relay(conn, upstream)
+	go p.relay(upstream, conn)
+}
+
 // relay copies src -> dst until either side closes or errors, then closes
-// and untracks both.
+// and untracks both. Polls p.severed between reads so a Sever call pauses
+// forwarding mid-flight without touching either socket - data already read
+// but not yet forwarded when Sever lands may still cross (a real partition
+// has no such edge case), but nothing at all moves while severed.
 func (p *OutageProxy) relay(dst, src net.Conn) {
 	defer func() {
 		_ = dst.Close()
@@ -139,6 +176,10 @@ func (p *OutageProxy) relay(dst, src net.Conn) {
 	}()
 	buf := make([]byte, 32*1024)
 	for {
+		for p.severed.Load() {
+			time.Sleep(50 * time.Millisecond)
+		}
+		_ = src.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
 		n, err := src.Read(buf)
 		if n > 0 {
 			if _, werr := dst.Write(buf[:n]); werr != nil {
@@ -146,18 +187,10 @@ func (p *OutageProxy) relay(dst, src net.Conn) {
 			}
 		}
 		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
 			return
 		}
 	}
-}
-
-// resetClose closes conn with SO_LINGER=0, forcing an RST instead of a
-// graceful FIN so the peer's TLS handshake or read fails immediately
-// (ECONNRESET) rather than sitting on a timeout waiting for a peer that
-// closed cleanly. Mirrors DeadController's technique.
-func resetClose(conn net.Conn) {
-	if tc, ok := conn.(*net.TCPConn); ok {
-		_ = tc.SetLinger(0)
-	}
-	_ = conn.Close()
 }

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -40,8 +40,8 @@ import (
 )
 
 const (
-	overlayCtrlPort = 1280
-	overlayRtrPort  = 3022
+	defaultOverlayCtrlPort = 1280
+	defaultOverlayRtrPort  = 3022
 )
 
 type Overlay struct {
@@ -53,7 +53,24 @@ type Overlay struct {
 	AutoTrustCA        bool
 	ZitiClusterSize    int
 	// Auth is the authentication path clients must take, "OIDC" or "Legacy". Required.
-	Auth                AuthMode
+	Auth AuthMode
+	// CtrlPort/RtrPort override quickstart's default 1280/3022. Zero means the
+	// default; set both to run a second, independent overlay instance
+	// alongside one already using the default ports (e.g. a test that needs
+	// its own dedicated quickstart rather than the shared one).
+	CtrlPort int
+	RtrPort  int
+	// BindCtrlPort, if set, is the port quickstart actually binds; CtrlPort
+	// stays the port everything else (ControllerHostPort, this harness's own
+	// ziti CLI calls, and whatever address ends up embedded in enrollment
+	// JWTs/HA-endpoint-list responses) uses. Only needed to put a relay in
+	// between: the controller validates incoming requests' Host header
+	// against its own configured address, so anything dialing the real bind
+	// port directly - once that address has been pointed elsewhere - gets
+	// rejected; the relay must be the thing everyone (including this
+	// harness's admin CLI calls) actually dials. Zero means bind and dial the
+	// same port, i.e. no relay in between.
+	BindCtrlPort        int
 	authApplied         bool
 	ZitiMajor           int
 	ZitiMinor           int
@@ -64,6 +81,28 @@ type Overlay struct {
 	stderr  *syncBuffer
 	logFile *os.File
 	Done    chan error
+}
+
+func (o *Overlay) ctrlPort() int {
+	if o.CtrlPort != 0 {
+		return o.CtrlPort
+	}
+	return defaultOverlayCtrlPort
+}
+
+// bindCtrlPort is the port quickstart actually binds - see BindCtrlPort.
+func (o *Overlay) bindCtrlPort() int {
+	if o.BindCtrlPort != 0 {
+		return o.BindCtrlPort
+	}
+	return o.ctrlPort()
+}
+
+func (o *Overlay) rtrPort() int {
+	if o.RtrPort != 0 {
+		return o.RtrPort
+	}
+	return defaultOverlayRtrPort
 }
 
 // Start launches `ziti edge quickstart` against o.Home and waits until the
@@ -93,8 +132,8 @@ func (o *Overlay) Start() error {
 		return fmt.Errorf("clusterSize must be 1 (single node) or 3-9 (cluster), got %d", o.ZitiClusterSize)
 	}
 
-	warnIfPortBound(overlayCtrlPort)
-	warnIfPortBound(overlayRtrPort)
+	warnIfPortBound(uint16(o.bindCtrlPort()))
+	warnIfPortBound(uint16(o.rtrPort()))
 
 	log.Printf("overlay: mkdir home %s", o.Home)
 	if err := os.MkdirAll(o.Home, 0o755); err != nil {
@@ -131,9 +170,9 @@ func (o *Overlay) runQuickstart() error {
 	args := append(quickstart,
 		"--home="+o.Home,
 		"--ctrl-address=localhost",
-		fmt.Sprintf("--ctrl-port=%d", overlayCtrlPort),
+		fmt.Sprintf("--ctrl-port=%d", o.bindCtrlPort()),
 		"--router-address=localhost",
-		fmt.Sprintf("--router-port=%d", overlayRtrPort),
+		fmt.Sprintf("--router-port=%d", o.rtrPort()),
 	)
 	log.Printf("overlay: starting %s %s", o.ZitiBin, strings.Join(args, " "))
 	o.cmd = exec.Command(o.ZitiBin, args...)
@@ -201,15 +240,15 @@ func (o *Overlay) ControllerHostPort() string {
 	if o.ControllerURL != "" {
 		return strings.TrimRight(o.ControllerURL, "/")
 	}
-	return fmt.Sprintf("https://localhost:%d", overlayCtrlPort)
+	return fmt.Sprintf("https://localhost:%d", o.ctrlPort())
 }
 
 // controllerAddr returns the host:port string for TCP dials against the
-// controller. Defaults to localhost:1280 in quickstart mode; parses ControllerURL
-// in external mode.
+// controller. Defaults to localhost:1280 (or o.CtrlPort) in quickstart mode;
+// parses ControllerURL in external mode.
 func (o *Overlay) controllerAddr() (string, error) {
 	if o.ControllerURL == "" {
-		return fmt.Sprintf("localhost:%d", overlayCtrlPort), nil
+		return fmt.Sprintf("localhost:%d", o.ctrlPort()), nil
 	}
 	u, err := url.Parse(o.ControllerURL)
 	if err != nil || u.Host == "" {
@@ -890,7 +929,7 @@ func (o *Overlay) waitUntilReady() error {
 }
 
 func (o *Overlay) waitForControllerPort() error {
-	addr := fmt.Sprintf("localhost:%d", overlayCtrlPort)
+	addr := fmt.Sprintf("localhost:%d", o.ctrlPort())
 	log.Printf("overlay: waiting for controller TCP port %s", addr)
 	for {
 		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
@@ -901,7 +940,7 @@ func (o *Overlay) waitForControllerPort() error {
 		}
 		select {
 		case exitErr := <-o.Done:
-			return fmt.Errorf("quickstart exited before port %d opened: %v", overlayCtrlPort, exitErr)
+			return fmt.Errorf("quickstart exited before port %d opened: %v", o.ctrlPort(), exitErr)
 		case <-time.After(250 * time.Millisecond):
 		}
 	}

--- a/tests/integration/testutil/overlay.go
+++ b/tests/integration/testutil/overlay.go
@@ -75,10 +75,14 @@ type Overlay struct {
 	ZitiMajor           int
 	ZitiMinor           int
 	ShowZitiCliCommands bool
+	// DetachSession, if true, starts the quickstart process in its own
+	// session/process group (see detachSession in the platform_* files) so it
+	// survives a signal sent to this test process's group. Debugging aid:
+	// leave false normally, so Stop() (or an interrupted test run) still
+	// reliably takes it down.
+	DetachSession bool
 
 	cmd     *exec.Cmd
-	stdout  *syncBuffer
-	stderr  *syncBuffer
 	logFile *os.File
 	Done    chan error
 }
@@ -176,6 +180,9 @@ func (o *Overlay) runQuickstart() error {
 	)
 	log.Printf("overlay: starting %s %s", o.ZitiBin, strings.Join(args, " "))
 	o.cmd = exec.Command(o.ZitiBin, args...)
+	if o.DetachSession {
+		detachSession(o.cmd)
+	}
 	o.cmd.Env = append(os.Environ(),
 		"ZITI_CONFIG_DIR="+filepath.Join(o.Home, "cli-config"),
 		// PFXLOG_NO_JSON makes ziti's stderr human-readable for test log output.
@@ -190,10 +197,19 @@ func (o *Overlay) runQuickstart() error {
 		return fmt.Errorf("open quickstart log file: %w", err)
 	}
 	log.Printf("overlay: quickstart log %s", logPath)
-	o.stdout = newSyncBuffer()
-	o.stderr = newSyncBuffer()
-	o.cmd.Stdout = io.MultiWriter(o.stdout, logFile)
-	o.cmd.Stderr = io.MultiWriter(o.stderr, logFile)
+	// Straight to the file, not through an io.MultiWriter(buffer, logFile):
+	// a non-*os.File Writer forces os/exec to create an internal pipe and a
+	// goroutine (in this process) to copy from it - and that goroutine dies
+	// with this process, so a quickstart left running past this test
+	// process's own exit (see DetachSession) gets SIGPIPE on its very next
+	// write, no matter what session/process-group tricks the child itself
+	// is started with. logFile is an *os.File, so Stdout/Stderr here become
+	// a plain dup2 straight into the child - no pipe, no dependency on this
+	// process staying alive. Logs() reads this same file back for the
+	// stdout/stderr this used to buffer in memory.
+	o.logFile = logFile
+	o.cmd.Stdout = logFile
+	o.cmd.Stderr = logFile
 
 	if err := o.cmd.Start(); err != nil {
 		_ = logFile.Close()
@@ -395,9 +411,15 @@ func (o *Overlay) Stop() {
 	log.Fatalf("overlay pid %d did not exit within 60s of Kill; orphan likely, aborting test run", pid)
 }
 
+// Logs returns the quickstart process's combined stdout/stderr, read back
+// from its log file (stdout and stderr are no longer captured separately -
+// see runQuickstart for why they're both written straight to this one file).
 func (o *Overlay) Logs() string {
-	return fmt.Sprintf("--- ziti stdout ---\n%s\n--- ziti stderr ---\n%s",
-		o.stdout.String(), o.stderr.String())
+	data, err := os.ReadFile(filepath.Join(o.Home, "quickstart-logs", "quickstart.log"))
+	if err != nil {
+		return fmt.Sprintf("(could not read quickstart log: %v)", err)
+	}
+	return string(data)
 }
 
 // CreateIdentityJWT provisions a new (non-admin) identity and returns its enrollment JWT content.

--- a/tests/integration/testutil/overlay_edge_api_address.go
+++ b/tests/integration/testutil/overlay_edge_api_address.go
@@ -1,0 +1,151 @@
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// bindPointAddressRE matches a web.bindPoints entry's "- interface: ..." line
+// (a YAML list item, so it carries a "- " prefix) through to its "address:"
+// line, which quickstart's generated config puts a few comment lines later,
+// not immediately after - the (?:\s*#.*\n)* run absorbs any number of those.
+// The interface line and any comments are captured verbatim so they can be
+// echoed back unchanged; only address, the advertised value, needs to
+// change - interface is what the controller actually binds and must stay on
+// the real port.
+var bindPointAddressRE = regexp.MustCompile(`(?m)^(\s*-?\s*interface:\s*\S+\n(?:\s*#.*\n)*)(\s*)address:\s*\S+\s*$`)
+
+// SetEdgeApiAddress edits edge.api.address and its matching web.bindPoints
+// address in the generated controller config(s), then restarts quickstart so
+// it takes effect. Quickstart mode only (o.ControllerURL must be empty).
+//
+// Both edits are required: the controller validates at startup that
+// edge.api.address matches one of its own web.bindPoints address values
+// (found by crashing into it - "could not find [edge.api.address] value ...
+// as a bind point"), so editing just one panics on the next start. The
+// bindPoint's separate "interface" field is left alone - it's what actually
+// gets bound, while "address" is only the advertised/validated value - so
+// the controller keeps listening on the real port throughout.
+//
+// edge.api.address is what the controller embeds in enrollment JWTs and
+// reports back in its own "/controllers" HA-endpoint-list responses - it is
+// entirely separate from o.ctrlPort()/o.ControllerHostPort(), which this
+// test harness's own ziti CLI calls always use regardless of this setting.
+// Pointing it at a controllable relay (see OutageProxy) is what lets a test
+// simulate an outage without a client falling back to a real, always-up
+// address it discovered independently: a client that has ever learned the
+// real address (e.g. from a "/controllers" response, even a single-node
+// quickstart's own self-entry) can fail over to it directly once its
+// current connection dies, bypassing the proxy entirely - redirecting only
+// the identity file's ztAPI is not sufficient on its own.
+//
+// This is meant for a dedicated, single-purpose overlay instance (one this
+// test starts and tears down itself), not the shared one other tests use:
+// unlike SetSessionTimeout/SetOidcTokenDurations, there is no restore-to-default
+// counterpart, since a shared overlay should never have its address redirected
+// out from under other tests in the first place.
+func (o *Overlay) SetEdgeApiAddress(t *testing.T, addr string) {
+	t.Helper()
+	require.Empty(t, o.ControllerURL, "SetEdgeApiAddress requires quickstart mode (ziti.url must be empty)")
+
+	o.Stop()
+	paths, err := o.controllerConfigPaths()
+	require.NoError(t, err, "find controller configs")
+	for _, path := range paths {
+		require.NoError(t, setEdgeApiAddressInConfig(path, addr), "set edge.api.address in %s", path)
+		require.NoError(t, setBindPointAddressInConfig(path, addr), "set web.bindPoints address in %s", path)
+	}
+	require.NoError(t, o.runQuickstart(), "restart controller with edge.api.address=%s", addr)
+	log.Printf("overlay: edge.api.address (and matching bindPoint address) set to %s", addr)
+}
+
+func setBindPointAddressInConfig(path, addr string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read controller config %s: %w", path, err)
+	}
+	if !bindPointAddressRE.Match(raw) {
+		return fmt.Errorf("no web.bindPoints interface/address pair found in %s", path)
+	}
+	// group 1 already ends in a newline (the interface line's own, or the last
+	// comment line's), so no extra "\n" is needed before group 2.
+	replacement := "${1}${2}address: " + addr
+	out := bindPointAddressRE.ReplaceAll(raw, []byte(replacement))
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		return fmt.Errorf("write controller config %s: %w", path, err)
+	}
+	return nil
+}
+
+// setEdgeApiAddressInConfig replaces the "address:" line inside the edge.api
+// block (not any other "address:" line elsewhere in the file, e.g. under
+// web.bindPoints) by tracking indentation-based scope, the same style
+// overlay_auth.go's disableOidcInConfig uses.
+func setEdgeApiAddressInConfig(path, addr string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read controller config %s: %w", path, err)
+	}
+
+	lines := strings.Split(string(raw), "\n")
+	var out []string
+	inEdge, inApi, replaced := false, false, false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "edge:" && !strings.HasPrefix(line, " ") {
+			inEdge = true
+			out = append(out, line)
+			continue
+		}
+		if inEdge && trimmed == "api:" {
+			inApi = true
+			out = append(out, line)
+			continue
+		}
+		// edge.api's own keys are indented 4 spaces; a non-blank line indented
+		// less than that is a sibling of api: (e.g. oidc:/enrollment:), ending
+		// the block.
+		if inApi && trimmed != "" && !strings.HasPrefix(line, "    ") {
+			inApi = false
+		}
+		if inApi && strings.HasPrefix(trimmed, "address:") {
+			indent := line[:len(line)-len(strings.TrimLeft(line, " "))]
+			out = append(out, indent+"address: "+addr)
+			replaced = true
+			continue
+		}
+		out = append(out, line)
+	}
+
+	if !replaced {
+		return fmt.Errorf("no edge.api.address line found in %s", path)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(out, "\n")), 0o600); err != nil {
+		return fmt.Errorf("write controller config %s: %w", path, err)
+	}
+	return nil
+}

--- a/tests/integration/testutil/overlay_oidc_token_lifetimes.go
+++ b/tests/integration/testutil/overlay_oidc_token_lifetimes.go
@@ -1,0 +1,114 @@
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// edge.api.sessionTimeout (SetSessionTimeout, overlay_session_timeout.go) only
+// governs the legacy api-session path. An OIDC-authenticated identity's actual
+// session lifetime is these two settings instead, under edge.oidc - unset by
+// default (30m access / 24h refresh, per controller/config/config_edge.go),
+// so quickstart's generated config has no line for either to edit in place.
+
+// oidcBlockRE matches the exact 3-line "oidc:" block SetOidcTokenDurations
+// inserts, so it can be replaced (call again with new values) or removed
+// (RestoreDefaultOidcTokenDurations) idempotently.
+var oidcBlockRE = regexp.MustCompile(`(?m)^  oidc:\n    accessTokenDuration: \S+\n    refreshTokenDuration: \S+\n`)
+
+// enrollmentLineRE anchors the insertion point: edge.enrollment is a required
+// sibling of edge.api that quickstart always generates, immediately after
+// where edge.oidc belongs.
+var enrollmentLineRE = regexp.MustCompile(`(?m)^  enrollment:\n`)
+
+// SetOidcTokenDurations sets edge.oidc.accessTokenDuration/refreshTokenDuration
+// in the generated controller config(s) and restarts quickstart so it takes
+// effect. Quickstart mode only (o.ControllerURL must be empty). refresh must be
+// at least 1m longer than access or the controller corrects it back toward the
+// default and logs a warning instead of erroring.
+//
+// This mutates shared overlay state for the rest of the test binary's run:
+// callers must defer RestoreDefaultOidcTokenDurations(t) to leave the
+// controller in its default state for tests that run afterward.
+func (o *Overlay) SetOidcTokenDurations(t *testing.T, access, refresh time.Duration) {
+	t.Helper()
+	require.Empty(t, o.ControllerURL, "SetOidcTokenDurations requires quickstart mode (ziti.url must be empty)")
+	require.GreaterOrEqual(t, refresh, access+time.Minute, "refresh (%s) must be at least 1m longer than access (%s)", refresh, access)
+
+	o.Stop()
+	paths, err := o.controllerConfigPaths()
+	require.NoError(t, err, "find controller configs")
+	for _, path := range paths {
+		require.NoError(t, setOidcTokenDurationsInConfig(path, access, refresh), "set oidc token durations in %s", path)
+	}
+	require.NoError(t, o.runQuickstart(), "restart controller with oidc accessTokenDuration=%s refreshTokenDuration=%s", access, refresh)
+	log.Printf("overlay: edge.oidc.accessTokenDuration set to %s, refreshTokenDuration set to %s", access, refresh)
+}
+
+// RestoreDefaultOidcTokenDurations removes the edge.oidc block
+// SetOidcTokenDurations inserted, restoring the controller's implicit
+// defaults (30m access / 24h refresh), and restarts quickstart.
+func (o *Overlay) RestoreDefaultOidcTokenDurations(t *testing.T) {
+	t.Helper()
+	require.Empty(t, o.ControllerURL, "RestoreDefaultOidcTokenDurations requires quickstart mode (ziti.url must be empty)")
+
+	o.Stop()
+	paths, err := o.controllerConfigPaths()
+	require.NoError(t, err, "find controller configs")
+	for _, path := range paths {
+		require.NoError(t, removeOidcTokenDurationsFromConfig(path), "remove oidc token durations from %s", path)
+	}
+	require.NoError(t, o.runQuickstart(), "restart controller with default oidc token durations")
+	log.Printf("overlay: edge.oidc token durations restored to default")
+}
+
+func setOidcTokenDurationsInConfig(path string, access, refresh time.Duration) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read controller config %s: %w", path, err)
+	}
+	raw = oidcBlockRE.ReplaceAll(raw, nil)
+	block := fmt.Sprintf("  oidc:\n    accessTokenDuration: %s\n    refreshTokenDuration: %s\n", access, refresh)
+	if !enrollmentLineRE.Match(raw) {
+		return fmt.Errorf("no edge.enrollment line found in %s", path)
+	}
+	out := enrollmentLineRE.ReplaceAll(raw, []byte(block+"  enrollment:\n"))
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		return fmt.Errorf("write controller config %s: %w", path, err)
+	}
+	return nil
+}
+
+func removeOidcTokenDurationsFromConfig(path string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read controller config %s: %w", path, err)
+	}
+	out := oidcBlockRE.ReplaceAll(raw, nil)
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		return fmt.Errorf("write controller config %s: %w", path, err)
+	}
+	return nil
+}

--- a/tests/integration/testutil/overlay_preconfigure.go
+++ b/tests/integration/testutil/overlay_preconfigure.go
@@ -1,0 +1,124 @@
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// GenerateConfig runs `ziti edge quickstart --configure-and-exit` against
+// o.Home: quickstart does a full ephemeral setup (PKI, router enrollment)
+// and shuts everything down again, leaving only the generated config files -
+// nothing left running, nothing left listening. Quickstart mode only
+// (o.ControllerURL must be empty); single-node only (no ZitiClusterSize
+// support, unneeded by any caller so far).
+//
+// Pairs with the Preconfigure* methods below: editing a config before the
+// very first real Start() means that start comes up already fully
+// configured, in particular avoiding a trap discovered the hard way - if
+// Overlay.BindCtrlPort is used to put a relay in front of the controller,
+// the relay's address has to be in place *before* the first real start,
+// because every restart's own admin-login check dials o.ControllerHostPort()
+// (the relay), and that fails once the controller's configured address no
+// longer matches what a direct dial would have used - there's no "start,
+// then fix the address" ordering that works once a relay is involved.
+func (o *Overlay) GenerateConfig() error {
+	if o.ControllerURL != "" {
+		return fmt.Errorf("GenerateConfig requires quickstart mode (ControllerURL must be empty)")
+	}
+	if err := os.MkdirAll(o.Home, 0o755); err != nil {
+		return fmt.Errorf("mkdir home: %w", err)
+	}
+	args := []string{
+		"edge", "quickstart",
+		"--home=" + o.Home,
+		"--ctrl-address=localhost",
+		fmt.Sprintf("--ctrl-port=%d", o.bindCtrlPort()),
+		"--router-address=localhost",
+		fmt.Sprintf("--router-port=%d", o.rtrPort()),
+		"--configure-and-exit",
+	}
+	log.Printf("overlay: generating config %s %s", o.ZitiBin, strings.Join(args, " "))
+	cmd := exec.Command(o.ZitiBin, args...)
+	cmd.Env = append(os.Environ(),
+		"ZITI_CONFIG_DIR="+filepath.Join(o.Home, "cli-config"),
+		"PFXLOG_NO_JSON=true",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("configure-and-exit: %w\n%s", err, out)
+	}
+	log.Printf("overlay: config generated")
+	return nil
+}
+
+// PreconfigureDisableOidc strips OIDC from a config produced by
+// GenerateConfig, before any process has started - unlike
+// ApplyAuthMode/restartWithoutOidc, which assume a live overlay to stop,
+// edit, and restart, and wait for the router to be online first (an
+// ordering concern that doesn't apply here: GenerateConfig's own ephemeral
+// run already finished router enrollment before exiting).
+func (o *Overlay) PreconfigureDisableOidc(t *testing.T) {
+	t.Helper()
+	forEachConfig(t, o, func(path string) error { return disableOidcInConfig(path) })
+}
+
+// PreconfigureOidcTokenDurations is SetOidcTokenDurations without the
+// stop/restart - for a config produced by GenerateConfig, before any
+// process has started.
+func (o *Overlay) PreconfigureOidcTokenDurations(t *testing.T, access, refresh time.Duration) {
+	t.Helper()
+	forEachConfig(t, o, func(path string) error { return setOidcTokenDurationsInConfig(path, access, refresh) })
+}
+
+// PreconfigureSessionTimeout is SetSessionTimeout without the stop/restart -
+// for a config produced by GenerateConfig, before any process has started.
+func (o *Overlay) PreconfigureSessionTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	forEachConfig(t, o, func(path string) error { return setSessionTimeoutInConfig(path, d) })
+}
+
+// PreconfigureEdgeApiAddress is SetEdgeApiAddress without the stop/restart -
+// for a config produced by GenerateConfig, before any process has started.
+func (o *Overlay) PreconfigureEdgeApiAddress(t *testing.T, addr string) {
+	t.Helper()
+	forEachConfig(t, o, func(path string) error {
+		if err := setEdgeApiAddressInConfig(path, addr); err != nil {
+			return err
+		}
+		return setBindPointAddressInConfig(path, addr)
+	})
+}
+
+// forEachConfig runs edit against every generated controller config path.
+func forEachConfig(t *testing.T, o *Overlay, edit func(path string) error) {
+	t.Helper()
+	paths, err := o.controllerConfigPaths()
+	require.NoError(t, err, "find controller configs")
+	for _, path := range paths {
+		require.NoError(t, edit(path), "edit %s", path)
+	}
+}

--- a/tests/integration/testutil/overlay_session_timeout.go
+++ b/tests/integration/testutil/overlay_session_timeout.go
@@ -1,0 +1,76 @@
+/*
+Copyright NetFoundry Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// DefaultEdgeSessionTimeout matches the controller's own default
+// (edge.api.sessionTimeout: 30m in quickstart's generated config). Callers
+// that shorten it with SetSessionTimeout restore it to this when done.
+const DefaultEdgeSessionTimeout = 30 * time.Minute
+
+// sessionTimeoutLineRE matches the "sessionTimeout: <duration>" line quickstart
+// generates under edge.api. Anchored on the bare key so it can't match the
+// router config's unrelated getSessionTimeout/lookupSessionTimeout keys.
+var sessionTimeoutLineRE = regexp.MustCompile(`(?m)^(\s*)sessionTimeout:\s*\S+\s*$`)
+
+// SetSessionTimeout edits edge.api.sessionTimeout in the generated controller
+// config(s) and restarts quickstart so it takes effect. Quickstart mode only
+// (o.ControllerURL must be empty).
+//
+// This mutates shared overlay state for the rest of the test binary's run, the
+// same way ApplyAuthMode's restartWithoutOidc does: callers must defer
+// SetSessionTimeout(t, DefaultEdgeSessionTimeout) to leave the controller in
+// its default state for tests that run afterward.
+func (o *Overlay) SetSessionTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	require.Empty(t, o.ControllerURL, "SetSessionTimeout requires quickstart mode (ziti.url must be empty)")
+
+	o.Stop()
+	paths, err := o.controllerConfigPaths()
+	require.NoError(t, err, "find controller configs")
+	for _, path := range paths {
+		require.NoError(t, setSessionTimeoutInConfig(path, d), "set sessionTimeout in %s", path)
+	}
+	require.NoError(t, o.runQuickstart(), "restart controller with sessionTimeout=%s", d)
+	log.Printf("overlay: edge.api.sessionTimeout set to %s", d)
+}
+
+func setSessionTimeoutInConfig(path string, d time.Duration) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read controller config %s: %w", path, err)
+	}
+	if !sessionTimeoutLineRE.Match(raw) {
+		return fmt.Errorf("no edge.api.sessionTimeout line found in %s", path)
+	}
+	replacement := fmt.Sprintf("${1}sessionTimeout: %s", d)
+	out := sessionTimeoutLineRE.ReplaceAll(raw, []byte(replacement))
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		return fmt.Errorf("write controller config %s: %w", path, err)
+	}
+	return nil
+}

--- a/tests/integration/testutil/platform_unix.go
+++ b/tests/integration/testutil/platform_unix.go
@@ -63,3 +63,11 @@ func relayStop(cmd *exec.Cmd) {
 		_ = cmd.Process.Signal(syscall.SIGINT)
 	}
 }
+
+// detachSession starts cmd in a new session, so it isn't a member of this
+// process's process group and won't receive a signal (e.g. SIGINT/SIGHUP)
+// sent to that group - by a Ctrl-C, or a terminal/shell tearing down when the
+// parent test process exits.
+func detachSession(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/tests/integration/testutil/platform_windows.go
+++ b/tests/integration/testutil/platform_windows.go
@@ -65,3 +65,9 @@ func relayStop(cmd *exec.Cmd) {
 		_ = exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run()
 	}
 }
+
+// detachSession starts cmd in its own process group, so a CTRL_BREAK_EVENT
+// sent to this process's console process group doesn't reach it.
+func detachSession(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &windows.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+}

--- a/tests/integration/testutil/zet.go
+++ b/tests/integration/testutil/zet.go
@@ -19,7 +19,6 @@ package testutil
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -68,8 +67,6 @@ type ZET struct {
 	Minor int
 
 	cmd     *exec.Cmd
-	stdout  *syncBuffer
-	stderr  *syncBuffer
 	cmdDone chan struct{}
 	logFile *os.File
 	// logStarted keeps Restart() from truncating the log mid-run.
@@ -121,9 +118,6 @@ func (z *ZET) Start() error {
 		}
 		z.cmd.Env = env
 	}
-	stdout := newSyncBuffer()
-	stderr := newSyncBuffer()
-
 	if err := os.MkdirAll(z.LogPath(), 0o755); err != nil {
 		return fmt.Errorf("create zet log dir: %w", err)
 	}
@@ -139,8 +133,17 @@ func (z *ZET) Start() error {
 		return fmt.Errorf("open zet log file: %w", ferr)
 	}
 	z.logFile = logFile
-	z.cmd.Stdout = io.MultiWriter(stdout, logFile)
-	z.cmd.Stderr = io.MultiWriter(stderr, logFile)
+	// Straight to the file, not through an io.MultiWriter(buffer, logFile):
+	// a non-*os.File Writer forces os/exec to create an internal pipe and a
+	// goroutine (in this process) to copy from it - and that goroutine dies
+	// with this process, so a ZET left running past this test process's own
+	// exit (see DetachSession) gets SIGPIPE on its very next write, no
+	// matter what session/process-group tricks the child itself is started
+	// with. logFile is an *os.File, so Stdout/Stderr here become a plain
+	// dup2 straight into the child - no pipe, no dependency on this process
+	// staying alive.
+	z.cmd.Stdout = logFile
+	z.cmd.Stderr = logFile
 
 	log.Printf("zet[%s]: exec %s %s (cmdPipe=%s eventPipe=%s logPath=%s)",
 		z.Discriminator, z.BinPath, strings.Join(args, " "), cmdPipe, eventPipe, logPath)
@@ -300,8 +303,6 @@ type syncBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
 }
-
-func newSyncBuffer() *syncBuffer { return &syncBuffer{} }
 
 func (s *syncBuffer) Write(p []byte) (int, error) {
 	s.mu.Lock()

--- a/tests/integration/testutil/zet.go
+++ b/tests/integration/testutil/zet.go
@@ -54,6 +54,15 @@ type ZET struct {
 	TlsuvDebug int
 	// Env entries (KEY=VALUE) appended to the parent environment for the ZET process.
 	Env []string
+	// ExtraArgs are appended to the "run" command line after the standard flags
+	// (e.g. []string{"-r", "1"} to shorten the controller-refresh interval).
+	ExtraArgs []string
+	// DetachSession, if true, starts the process in its own session/process
+	// group (see detachSession) so it survives a signal sent to this test
+	// process's group - e.g. a Ctrl-C, or the parent's shell/terminal tearing
+	// down when the test binary exits. Debugging aid: leave false normally,
+	// so Stop() (or an interrupted test run) still reliably takes it down.
+	DetachSession bool
 	// Major and Minor are this binary's version, set by ProbeVersion.
 	Major int
 	Minor int
@@ -99,8 +108,12 @@ func (z *ZET) Start() error {
 	if z.DNSRange != "" {
 		args = append(args, "-d", z.DNSRange)
 	}
+	args = append(args, z.ExtraArgs...)
 
 	z.cmd = exec.Command(z.BinPath, args...)
+	if z.DetachSession {
+		detachSession(z.cmd)
+	}
 	if len(z.Env) > 0 || z.TlsuvDebug > 0 {
 		env := append(os.Environ(), z.Env...)
 		if z.TlsuvDebug > 0 {


### PR DESCRIPTION
Add a slow test that forces the tunnelers to go through a tcp proxy. The proxy allows the test to disrupt and restore the network between the tunneler and the controller/ER. This makes it possible to verify that the tunneler resumes auth/communication with the overlay after a network outage is restored.