### PR TITLE
Fix test setup on ZET older than 1.18.7

### DIFF
--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -252,6 +252,10 @@ func doSetup(state TestState) error {
 	}
 
 	log.Printf("setup: wiping identity dirs before starting ZET(s)")
+	// ZET < 1.18.7 exits when the -I dir is missing, so the suite's shared dir is created here
+	if err := os.MkdirAll(state.zetClient.IdentityDir(), 0o755); err != nil {
+		return fmt.Errorf("create shared identity dir: %w", err)
+	}
 	if err := state.zetClient.RemoveJSONIdentities(); err != nil {
 		return fmt.Errorf("wipe shared identity dir: %w", err)
 	}

--- a/tests/integration/testutil/ipc.go
+++ b/tests/integration/testutil/ipc.go
@@ -98,7 +98,7 @@ func openCommandPipe(path string, done <-chan struct{}) (*CommandsClient, error)
 		}
 		select {
 		case <-done:
-			log.Printf("ipc: dial connected %s", path)
+			log.Printf("ipc: process exited before command pipe %s became dialable", path)
 			return nil, fmt.Errorf("process exited before %s became dialable: %v", path, err)
 		case <-time.After(dialRetryInterval):
 		}
@@ -120,7 +120,7 @@ func subscribeToEventPipe(path string, done <-chan struct{}) (*EventClient, erro
 		}
 		select {
 		case <-done:
-			log.Printf("ipc: dial event pipe connected %s", path)
+			log.Printf("ipc: process exited before event pipe %s became dialable", path)
 			return nil, fmt.Errorf("process exited before event pipe %s became dialable: %v", path, err)
 		case <-time.After(dialRetryInterval):
 		}

--- a/tests/integration/testutil/ipc.go
+++ b/tests/integration/testutil/ipc.go
@@ -98,7 +98,6 @@ func openCommandPipe(path string, done <-chan struct{}) (*CommandsClient, error)
 		}
 		select {
 		case <-done:
-			log.Printf("ipc: process exited before command pipe %s became dialable", path)
 			return nil, fmt.Errorf("process exited before %s became dialable: %v", path, err)
 		case <-time.After(dialRetryInterval):
 		}
@@ -120,7 +119,6 @@ func subscribeToEventPipe(path string, done <-chan struct{}) (*EventClient, erro
 		}
 		select {
 		case <-done:
-			log.Printf("ipc: process exited before event pipe %s became dialable", path)
 			return nil, fmt.Errorf("process exited before event pipe %s became dialable: %v", path, err)
 		case <-time.After(dialRetryInterval):
 		}

--- a/tests/integration/testutil/zet.go
+++ b/tests/integration/testutil/zet.go
@@ -166,16 +166,36 @@ func (z *ZET) Start() error {
 
 	cmds, err := z.DialIPC()
 	if err != nil {
-		return fmt.Errorf("zet[%s] command pipe: %w", z.Discriminator, err)
+		return fmt.Errorf("zet[%s] command pipe: %w%s", z.Discriminator, err, z.exitDetail())
 	}
 	z.CommandsClient = cmds
 
 	events, err := subscribeToEventPipe(EventPipePathFor(z.Discriminator), z.cmdDone)
 	if err != nil {
-		return fmt.Errorf("zet[%s] event pipe: %w", z.Discriminator, err)
+		return fmt.Errorf("zet[%s] event pipe: %w%s", z.Discriminator, err, z.exitDetail())
 	}
 	z.EventClient = events
 	return nil
+}
+
+// exitDetail is the process exit status and the tail of its log, for a Start that lost the process.
+// ZET's stdout and stderr go straight to the log file (see Start), so the tail is read back from disk.
+func (z *ZET) exitDetail() string {
+	select {
+	case <-z.cmdDone:
+	default:
+		return ""
+	}
+	const tailBytes = 2000
+	raw, err := os.ReadFile(z.LogFile())
+	if err != nil {
+		return fmt.Sprintf(" (%s)\n--- zet[%s] log unreadable: %v", z.cmd.ProcessState, z.Discriminator, err)
+	}
+	output := string(raw)
+	if len(output) > tailBytes {
+		output = "..." + output[len(output)-tailBytes:]
+	}
+	return fmt.Sprintf(" (%s)\n--- zet[%s] log tail ---\n%s", z.cmd.ProcessState, z.Discriminator, output)
 }
 
 // A surviving ZET orphans wintun state and breaks subsequent tests, so abort rather than let an orphan hide.


### PR DESCRIPTION
- Test setup creates the shared identity dir (again), ZET creates a missing -I dir itself since 1.18.7 and older versions exit
- When ZET exits before its IPC pipes come up, Start now reports the exit status and the tail of ZET's log instead of only "process exited before <pipe> became dialable".